### PR TITLE
release: 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,52 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.2.0] — 2026-08-26
+
+First published release. 0.1.0 was never tagged or uploaded — its entry is kept
+below as the development baseline for the work it describes.
+
+### Changed
+
+- **Shipped defaults no longer point at anything.** `PRXREF_LLM_BASE_URL`,
+  `PRXREF_LLM_API_KEY` and `PRXREF_LLM_MODELS` now default to empty. They
+  previously defaulted to a private LAN endpoint (`http://127.0.0.1:8090/v1`,
+  model chain `flash,orch`), so a fresh install with no configuration issued a
+  request that could only fail, against infrastructure that was never yours.
+- **`prxref review` exits 2 when required configuration is missing**, raising
+  the new `prxref.llm.ConfigError` naming the exact variable to set. This is
+  narrow and deliberate: a missing endpoint is a usage error, not a review
+  outcome. Genuine review failures still exit 0 — non-blocking is a product
+  tenet and is unchanged. An empty `PRXREF_LLM_API_KEY` remains valid, since a
+  local no-auth server (Ollama, vLLM) needs none.
+
+### Fixed
+
+- **`PRXREF_ALLOW_UNSIGNED` was parsed two different ways.** `config.py`
+  accepted `1`, `true`, `yes` and `on`, while `webhooks._allow_unsigned` — the
+  only gate that runs — accepted the literal `1` alone, and nothing in the
+  package read the config value at all. Setting it to `true` made the config
+  dict report the bypass as enabled while signature verification stayed on.
+  This failed safe, so it was a correctness and documentation defect rather
+  than a hole. Both now parse identically, pinned by a test asserting they
+  agree across 15 inputs.
+- **The bundled `pull_request_target` review workflow could never install
+  prxref.** It used `uv pip install --system`, which fails on GitHub's Ubuntu
+  runners because their system interpreter is PEP 668 externally-managed, and
+  which additionally suppressed the virtualenv the setup action provisions.
+  The failure was invisible: `continue-on-error` masked it and the review step
+  was skipped rather than failed, so the run reported success without a review
+  having happened.
+
+### Added
+
+- A test pinning the packaging metadata version to `prxref.__version__`, so the
+  two version declarations cannot drift apart across a release.
+
 ## [0.1.0] — 2026-08-26
 
-First public release.
+Development baseline. Never published to PyPI and never tagged; superseded by
+0.2.0 before release.
 
 ### Added
 
@@ -59,5 +102,5 @@ First public release.
 - Diff content is sent to whichever OpenAI-compatible endpoint you configure.
 - Requires Python 3.12+. Tested on 3.12 and 3.13.
 
-[Unreleased]: https://github.com/sblattj/prxref/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/sblattj/prxref/releases/tag/v0.1.0
+[Unreleased]: https://github.com/sblattj/prxref/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/sblattj/prxref/releases/tag/v0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prxref"
-version = "0.1.0"
+version = "0.2.0"
 description = "Fast automated AI code review for Bitbucket, GitLab, and GitHub"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/prxref/__init__.py
+++ b/src/prxref/__init__.py
@@ -1,3 +1,3 @@
 """prxref — fast automated AI code review for Bitbucket, GitLab, and GitHub."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,7 +69,20 @@ def test_version_flag(capsys):
     assert rc == 0
     out, _ = capsys.readouterr()
     assert out.strip() == __version__
-    assert out.strip() == "0.1.0"
+
+
+def test_version_matches_packaging_metadata():
+    """pyproject.toml and prxref.__version__ declare the version separately, and
+    a release is precisely when they drift.
+
+    Pinned to the installed metadata rather than to a literal: a literal has to
+    be hand-edited on every bump, and the one that used to live in
+    test_version_flag would have passed a release with a stale __version__ as
+    long as someone remembered to edit the test too.
+    """
+    from importlib.metadata import version as installed_version
+
+    assert installed_version("prxref") == __version__
 
 
 def test_no_subcommand_prints_help_and_exits_2(capsys):

--- a/uv.lock
+++ b/uv.lock
@@ -1153,7 +1153,7 @@ wheels = [
 
 [[package]]
 name = "prxref"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
## Release 0.2.0

Bumps the version and records the four changes that landed after the 0.1.0 changelog entry was written.

### Why 0.2.0 and not 0.1.0

`v0.1.0` was never tagged and never uploaded to PyPI. Its entry claimed a *"First public release"* that did not happen, and both of its link references — `releases/tag/v0.1.0` and `compare/v0.1.0...HEAD` — resolved to nothing.

It is kept as the development baseline for the work it describes, relabelled honestly, with links repointed at `v0.2.0`. **0.2.0 is the first published release.**

### Changelog contents

Every entry traces to a commit on `main`:

| commit | change |
|---|---|
| `fcc9c5a` | shipped defaults no longer name a private LAN endpoint; missing config raises `ConfigError` and `prxref review` exits 2 |
| `cf6f5da` | `PRXREF_ALLOW_UNSIGNED` was parsed two different ways |
| `c704f27` | dogfood workflow could never install prxref |
| `e567d79` | …and its first fix collided with `setup-uv`'s own venv |

### Release footgun removed

`tests/test_cli.py` carried a hardcoded literal next to the real assertion:

```python
assert out.strip() == __version__
assert out.strip() == "0.1.0"
```

That literal has to be hand-edited on every bump, and it does not test what it appears to — it would have passed a release with a stale `__version__` as long as whoever bumped remembered to edit the test to match.

Replaced with `test_version_matches_packaging_metadata`, asserting `importlib.metadata.version("prxref") == __version__`. That is the actual invariant: `pyproject.toml` and `src/prxref/__init__.py` declare the version separately, and a release is exactly the moment they drift.

### Verification

- 260 tests pass, `ruff check src tests` clean
- `uv build` produces `prxref-0.2.0-py3-none-any.whl` and `prxref-0.2.0.tar.gz`
- `prxref --version` reports `0.2.0`
- every `docs/` link in `CHANGELOG.md` resolves to a file that exists

— Claude Opus 5 via Claude Code (session `faf3381b`)
