### PR TITLE
Add a Bitbucket Server / Data Center forge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,14 @@ PRXREF_MAX_CHUNKS=8
 # Bitbucket app password (for Basic auth fallback)
 # PRXREF_BITBUCKET_APP_PASSWORD=
 
+# Bitbucket Server / Data Center HTTP access token (Bearer).
+# Falls back to PRXREF_BITBUCKET_TOKEN when unset.
+# PRXREF_BITBUCKET_SERVER_TOKEN=
+
+# Bitbucket Server / Data Center basic-auth pair, used only when no token is set.
+# PRXREF_BITBUCKET_SERVER_USER=
+# PRXREF_BITBUCKET_SERVER_PASSWORD=
+
 # GitHub token (Personal Access Token or GitHub App installation token for github.com)
 # PRXREF_GITHUB_TOKEN=
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- **Bitbucket Server / Data Center forge** (`bitbucket-server`). Self-hosted
+  Bitbucket previously had no path at all: the Cloud adapter pins itself to
+  `bitbucket.org`, while GitHub and GitLab each covered their self-hosted
+  deployment. Data Center is a different API rather than the same one on
+  another host — `/rest/api/1.0`, project keys instead of workspaces, an
+  activity feed instead of a comment list, `start`/`limit` paging — so it is a
+  fourth adapter under the existing `Forge` Protocol, and nothing downstream of
+  `forges/base.py` changed. Handles project and personal (`~slug`)
+  repositories, a deployment context path, anchored inline comments, and the
+  version field Data Center requires when updating a comment.
+  New: `PRXREF_BITBUCKET_SERVER_TOKEN` (falls back to `PRXREF_BITBUCKET_TOKEN`),
+  `PRXREF_BITBUCKET_SERVER_USER`, `PRXREF_BITBUCKET_SERVER_PASSWORD`.
+
+### Fixed
+
+- **Bitbucket webhooks were broken for both products.** The receiver accepted
+  only `pr:opened` / `pr:modified` — Bitbucket **Server** event names — while
+  reading the PR URL from `pullrequest.links.html.href`, which is Bitbucket
+  **Cloud**'s payload shape. So a genuine Cloud webhook was rejected as "not
+  reviewable" (Cloud sends `pullrequest:created` / `pullrequest:updated`) and a
+  genuine Server webhook produced no URL. Both dialects are now accepted and
+  their payloads read correctly, `pr:from_ref_updated` included. The existing
+  tests had paired a Server event key with a Cloud payload — a combination
+  neither product sends — which is how it went unnoticed.
+- **`docs/env-vars.md` under-counted its own variables**, claiming 17 while its
+  three sections summed to 18. The total is now derived from the same table it
+  documents.
+
 ## [0.2.0] — 2026-08-26
 
 First published release. 0.1.0 was never tagged or uploaded — its entry is kept

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # prxref
 
-Fast automated AI code review for Bitbucket, GitLab, and GitHub.
+Fast automated AI code review for Bitbucket, GitLab, and GitHub — Cloud and self-hosted.
 
 ## What This Is
 
@@ -15,7 +15,7 @@ auto-detects the forge.
 ## Tech
 
 - Python 3.12+, `uv` for env/lock, hatchling packaging
-- One `Forge` Protocol (src/prxref/forges/base.py), three adapters
+- One `Forge` Protocol (src/prxref/forges/base.py), four adapters
 - LLM access via a fallback chain (llm-ferry preferred, litellm optional,
   plain-HTTP client as zero-dependency default) — provider-agnostic, no
   Anthropic key by design

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # prxref
 
-Fast automated AI code review for Bitbucket, GitLab, and GitHub.
+Fast automated AI code review for Bitbucket, GitLab, and GitHub — Cloud and self-hosted.
 
 prxref inspects pull and merge requests across the three major code hosting forges in sub-minute review cycles. It parses unified diffs, partitions changes into risk-ranked chunks, fans out parallel single-shot LLM reviews across a cheap-first model fallback chain, filters findings through deterministic quality gates, and publishes inline comments alongside an executive summary.
 
@@ -73,6 +73,9 @@ Pass any PR or MR URL directly. Forge type, repository namespace, and pull reque
 # Bitbucket Cloud
 prxref review --pr-url https://bitbucket.org/workspace/repo/pull-requests/42
 
+# Bitbucket Server / Data Center (self-hosted, including a context path)
+prxref review --pr-url https://bitbucket.corp.example/projects/PLAT/repos/api/pull-requests/42
+
 # GitHub & GitHub Enterprise
 prxref review --pr-url https://github.com/owner/repository/pull/108
 
@@ -106,8 +109,10 @@ Configure the authentication token matching your forge:
 
 | Forge | Environment Variable | Notes |
 |---|---|---|
-| **Bitbucket** | `PRXREF_BITBUCKET_TOKEN` | Bearer token (workspace or repo access token) |
-| **Bitbucket (Basic)** | `PRXREF_BITBUCKET_USER` + `PRXREF_BITBUCKET_APP_PASSWORD` | App password fallback |
+| **Bitbucket Cloud** | `PRXREF_BITBUCKET_TOKEN` | Bearer token (workspace or repo access token) |
+| **Bitbucket Cloud (Basic)** | `PRXREF_BITBUCKET_USER` + `PRXREF_BITBUCKET_APP_PASSWORD` | App password fallback |
+| **Bitbucket Server / DC** | `PRXREF_BITBUCKET_SERVER_TOKEN` | HTTP access token (falls back to `PRXREF_BITBUCKET_TOKEN`) |
+| **Bitbucket Server (Basic)** | `PRXREF_BITBUCKET_SERVER_USER` + `PRXREF_BITBUCKET_SERVER_PASSWORD` | Basic-auth fallback |
 | **GitHub** | `PRXREF_GITHUB_TOKEN` | Personal Access Token (PAT) or GitHub App token |
 | **GitHub Enterprise** | `PRXREF_GITHUB_ENTERPRISE_TOKEN` | Used when host is not `github.com` (falls back to `PRXREF_GITHUB_TOKEN`) |
 | **GitLab** | `PRXREF_GITLAB_TOKEN` | Personal, project, or group access token (`PRIVATE-TOKEN`) |

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -26,6 +26,9 @@ Configuration is loaded from built-in defaults, overridden by environment variab
 | `PRXREF_BITBUCKET_TOKEN` | *(empty)* | Bitbucket Cloud workspace/repository Bearer access token. Preferred over basic authentication. |
 | `PRXREF_BITBUCKET_USER` | *(empty)* | Bitbucket Cloud username for HTTP Basic authentication (used with `PRXREF_BITBUCKET_APP_PASSWORD`). |
 | `PRXREF_BITBUCKET_APP_PASSWORD` | *(empty)* | Bitbucket Cloud app password for HTTP Basic authentication. |
+| `PRXREF_BITBUCKET_SERVER_TOKEN` | *(empty)* | Bitbucket Server / Data Center HTTP access token (sent as `Bearer`). Falls back to `PRXREF_BITBUCKET_TOKEN` if unset. |
+| `PRXREF_BITBUCKET_SERVER_USER` | *(empty)* | Bitbucket Server / Data Center username for HTTP Basic authentication (used with `PRXREF_BITBUCKET_SERVER_PASSWORD`). |
+| `PRXREF_BITBUCKET_SERVER_PASSWORD` | *(empty)* | Bitbucket Server / Data Center password for HTTP Basic authentication. |
 | `PRXREF_GITHUB_TOKEN` | *(empty)* | GitHub Personal Access Token or GitHub App token for `github.com`. |
 | `PRXREF_GITHUB_ENTERPRISE_TOKEN` | *(empty)* | GitHub Enterprise token for custom/self-hosted GitHub Enterprise Server domains. Falls back to `PRXREF_GITHUB_TOKEN` if unset. |
 | `PRXREF_GITLAB_TOKEN` | *(empty)* | GitLab Personal, Project, or Group Access Token (sent via `PRIVATE-TOKEN` header) for `gitlab.com` or self-hosted GitLab. |
@@ -34,17 +37,17 @@ Configuration is loaded from built-in defaults, overridden by environment variab
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `PRXREF_BITBUCKET_WEBHOOK_SECRET` | *(empty)* | HMAC secret for Bitbucket webhooks (verified against `X-Hub-Signature` via HMAC-SHA256). |
+| `PRXREF_BITBUCKET_WEBHOOK_SECRET` | *(empty)* | HMAC secret for Bitbucket webhooks, Cloud and Server alike (verified against `X-Hub-Signature` via HMAC-SHA256). |
 | `PRXREF_GITHUB_WEBHOOK_SECRET` | *(empty)* | HMAC secret for GitHub webhooks (verified against `X-Hub-Signature-256` via HMAC-SHA256). |
 | `PRXREF_GITLAB_WEBHOOK_SECRET` | *(empty)* | Secret token for GitLab webhooks (verified against `X-Gitlab-Token`). |
 | `PRXREF_ALLOW_UNSIGNED` | `False` | Accepts webhooks without valid HMAC/token signatures (dev/testing only; logs a warning). Must be the literal string `1` — `true`/`yes`/`on` deliberately do **not** enable the bypass, so it cannot be switched on by a stray truthy value. |
 
 ## Environment Cross-Check & Defaults
 
-The table above defines all 17 configuration keys supported in `src/prxref/config.py` and `.env.example`:
+The table above defines all 21 configuration keys supported in `src/prxref/config.py` and `.env.example`:
 
 - **LLM / Pipeline (8):** `PRXREF_LLM_BACKEND`, `PRXREF_LLM_BASE_URL`, `PRXREF_LLM_API_KEY`, `PRXREF_LLM_MODELS`, `PRXREF_LLM_REASONING_EFFORT`, `PRXREF_CONFIDENCE_FLOOR`, `PRXREF_MAX_ERROR_FINDINGS`, `PRXREF_MAX_CHUNKS`
-- **Per-Forge Auth (6):** `PRXREF_BITBUCKET_TOKEN`, `PRXREF_BITBUCKET_USER`, `PRXREF_BITBUCKET_APP_PASSWORD`, `PRXREF_GITHUB_TOKEN`, `PRXREF_GITHUB_ENTERPRISE_TOKEN`, `PRXREF_GITLAB_TOKEN`
+- **Per-Forge Auth (9):** `PRXREF_BITBUCKET_TOKEN`, `PRXREF_BITBUCKET_USER`, `PRXREF_BITBUCKET_APP_PASSWORD`, `PRXREF_BITBUCKET_SERVER_TOKEN`, `PRXREF_BITBUCKET_SERVER_USER`, `PRXREF_BITBUCKET_SERVER_PASSWORD`, `PRXREF_GITHUB_TOKEN`, `PRXREF_GITHUB_ENTERPRISE_TOKEN`, `PRXREF_GITLAB_TOKEN`
 - **Webhooks (4):** `PRXREF_BITBUCKET_WEBHOOK_SECRET`, `PRXREF_GITHUB_WEBHOOK_SECRET`, `PRXREF_GITLAB_WEBHOOK_SECRET`, `PRXREF_ALLOW_UNSIGNED`
 
-*(Total unique variables: 17)*
+*(Total unique variables: 21)*

--- a/docs/forges.md
+++ b/docs/forges.md
@@ -1,6 +1,6 @@
 # Forge Integrations & Webhooks
 
-`prxref` provides unified pull/merge request reviews across Bitbucket Cloud, GitHub (Cloud and Enterprise Server), and GitLab (SaaS and self-hosted).
+`prxref` provides unified pull/merge request reviews across Bitbucket (Cloud and Server / Data Center), GitHub (Cloud and Enterprise Server), and GitLab (SaaS and self-hosted).
 
 ---
 
@@ -22,7 +22,8 @@
   - **Thread List:** `GET /2.0/repositories/{owner}/{repo}/pullrequests/{number}/comments` (paginated, up to 500 comments).
 - **Webhook Integration:**
   - **Event Header:** `X-Event-Key`
-  - **Accepted Events:** `pr:opened`, `pr:modified`
+  - **Accepted Events:** `pullrequest:created`, `pullrequest:updated`
+  - **Payload:** PR URL read from `pullrequest.links.html.href`.
   - **Signature Header:** `X-Hub-Signature` (HMAC-SHA256) validated against `PRXREF_BITBUCKET_WEBHOOK_SECRET`.
 
 ---
@@ -69,3 +70,53 @@
   - **Event Header:** `X-Gitlab-Event` (normalized to `MergeRequestHook`)
   - **Accepted Actions:** `open`, `update`
   - **Signature Header:** `X-Gitlab-Token` (plain secret token) validated against `PRXREF_GITLAB_WEBHOOK_SECRET`.
+
+---
+
+## 4. Bitbucket Server / Data Center
+
+Self-hosted Bitbucket is a different product from Bitbucket Cloud, not the same
+API on another host: `/rest/api/1.0` rather than `/2.0`, project keys rather
+than workspaces, an activity feed rather than a comment list, and `start`/`limit`
+paging rather than `page`/`pagelen`. It therefore gets its own adapter.
+
+- **Forge Identifier:** `bitbucket-server`
+- **Supported URL Shapes:**
+  - `https://{host}/projects/{PROJECTKEY}/repos/{slug}/pull-requests/{number}`
+  - `https://{host}/users/{userslug}/repos/{slug}/pull-requests/{number}` (personal repository)
+  - Either shape behind a deployment context path, e.g. `https://{host}/bitbucket/projects/...`
+  - A trailing route (`/overview`, `/diff`, …) is tolerated and normalized away.
+- **Project Key Note:** a personal repository browses under `/users/{slug}` but is
+  addressed in the API as the project key `~{slug}`. `PRRef.owner` always holds the
+  API form, so every request path is built identically for both kinds.
+- **Authentication Environment Variables:**
+  - `PRXREF_BITBUCKET_SERVER_TOKEN` (HTTP access token, sent as `Bearer`). Falls back to
+    `PRXREF_BITBUCKET_TOKEN` when unset, mirroring how GitHub Enterprise falls back to
+    `PRXREF_GITHUB_TOKEN`.
+  - `PRXREF_BITBUCKET_SERVER_USER` + `PRXREF_BITBUCKET_SERVER_PASSWORD` (HTTP Basic fallback)
+- **API Endpoints & Behavior:**
+  - **Base URL:** `https://{host}{context}/rest/api/1.0/projects/{key}/repos/{slug}/pull-requests/{number}`
+  - **Metadata:** `GET` on the base URL. Branches and SHAs come from `fromRef`/`toRef`
+    (`displayId`, `latestCommit`); author from `author.user.name`.
+  - **Diffs:** `GET {base}.diff` with `Accept: text/plain` — the `.diff` suffix on the PR
+    resource, not a `/diff` subpath. Returns one raw unified diff for the whole PR.
+  - **Summary Comments:** `POST {base}/comments` with `{"text": body}`. Dedup scans the
+    activity feed for `<!-- prxref-summary -->` on a comment with no `anchor`, and updates
+    via `PUT {base}/comments/{id}`. **Data Center rejects an update that omits the
+    comment's current `version`**, so the lookup keeps the version, not just the id.
+  - **Inline Comments:** `POST {base}/comments` with an `anchor` object
+    (`path`, `line`, `lineType: ADDED`, `fileType: TO`) rather than Cloud's `inline.path` /
+    `inline.to`. Individual 4xx responses (line outside the diff) are skipped, as elsewhere.
+  - **Thread List:** `GET {base}/activities`, filtered to `action == "COMMENTED"`. There is
+    no flat comment listing on Data Center. Paged with `start`/`limit`, following
+    `nextPageStart` until `isLastPage`, capped at 5 pages.
+  - **Resolution:** read from whichever of `state == "RESOLVED"`, `threadResolved`, or
+    `resolvedDate` the deployment's version exposes.
+- **Webhook Integration:**
+  - **Event Header:** `X-Event-Key` (shared with Cloud; the two are told apart by event
+    name and payload shape)
+  - **Accepted Events:** `pr:opened`, `pr:modified`, `pr:from_ref_updated`
+  - **Payload:** PR URL read from the first entry of `pullRequest.links.self` — note the
+    capital `R`, and the list, both of which differ from Cloud.
+  - **Signature Header:** `X-Hub-Signature` (HMAC-SHA256) validated against
+    `PRXREF_BITBUCKET_WEBHOOK_SECRET`, the same secret Cloud uses.

--- a/src/prxref/cli.py
+++ b/src/prxref/cli.py
@@ -173,8 +173,11 @@ def _cmd_review(args: argparse.Namespace) -> int:
 
     if result is None:
         print(
-            f"unrecognized PR URL {args.pr_url!r} — expected bitbucket.org, "
-            "github.com, or gitlab.com PR/MR link",
+            f"unrecognized PR URL {args.pr_url!r} — expected a Bitbucket "
+            "pull-requests, GitHub pull, or GitLab merge_requests link. "
+            "Self-hosted hosts are supported (Bitbucket Data Center, GitHub "
+            "Enterprise Server, self-managed GitLab); the URL must keep the "
+            "forge's own path shape.",
             file=sys.stderr,
         )
         return 0

--- a/src/prxref/config.py
+++ b/src/prxref/config.py
@@ -18,9 +18,13 @@ LLM / pipeline:
   PRXREF_MAX_CHUNKS             Max diff chunks reviewed per PR (default 8)
 
 Per-forge auth:
-  PRXREF_BITBUCKET_TOKEN        Bitbucket bearer token
-  PRXREF_BITBUCKET_USER         Bitbucket username (app-password pair)
-  PRXREF_BITBUCKET_APP_PASSWORD Bitbucket app password
+  PRXREF_BITBUCKET_TOKEN        Bitbucket Cloud bearer token
+  PRXREF_BITBUCKET_USER         Bitbucket Cloud username (app-password pair)
+  PRXREF_BITBUCKET_APP_PASSWORD Bitbucket Cloud app password
+  PRXREF_BITBUCKET_SERVER_TOKEN Bitbucket Server/Data Center HTTP access token
+                                (falls back to PRXREF_BITBUCKET_TOKEN)
+  PRXREF_BITBUCKET_SERVER_USER  Bitbucket Server username (basic-auth pair)
+  PRXREF_BITBUCKET_SERVER_PASSWORD Bitbucket Server password (basic-auth pair)
   PRXREF_GITHUB_TOKEN           GitHub token (github.com)
   PRXREF_GITHUB_ENTERPRISE_TOKEN GitHub Enterprise token (GHES hosts)
   PRXREF_GITLAB_TOKEN           GitLab token
@@ -58,6 +62,9 @@ _DEFAULTS: dict[str, object] = {
     "bitbucket_token": "",
     "bitbucket_user": "",
     "bitbucket_app_password": "",
+    "bitbucket_server_token": "",
+    "bitbucket_server_user": "",
+    "bitbucket_server_password": "",
     "github_token": "",
     "github_enterprise_token": "",
     "gitlab_token": "",
@@ -134,10 +141,11 @@ def make_forge(ref: PRRef, session=None) -> Forge:
     ``session`` optionally injects a custom ``requests.Session`` (tests,
     shared connection pools). Unknown forge names raise ``ValueError``.
     """
-    from prxref.forges import bitbucket, github, gitlab
+    from prxref.forges import bitbucket, bitbucket_server, github, gitlab
 
     impls = {
         "bitbucket": bitbucket.ForgeImpl,
+        "bitbucket-server": bitbucket_server.ForgeImpl,
         "github": github.ForgeImpl,
         "gitlab": gitlab.ForgeImpl,
     }

--- a/src/prxref/forges/base.py
+++ b/src/prxref/forges/base.py
@@ -1,9 +1,12 @@
-"""Forge contract: one Protocol, three implementations (bitbucket, github, gitlab).
+"""Forge contract: one Protocol, four implementations.
+
+The implementations are bitbucket (Cloud), bitbucket_server (Server / Data
+Center), github (Cloud and Enterprise Server) and gitlab (SaaS and self-hosted).
 
 Every value that flows through the pipeline is forge-agnostic past this module.
 Diff handling is deliberately unified: each forge returns ONE raw unified diff
-string; parsing/chunking happens downstream in triage.py, identically for all
-three forges.
+string; parsing/chunking happens downstream in triage.py, identically for every
+forge.
 """
 from __future__ import annotations
 
@@ -16,7 +19,7 @@ from typing import Protocol
 class PRRef:
     """A pull/merge request identity, normalized across forges."""
 
-    forge: str  # "bitbucket" | "github" | "gitlab"
+    forge: str  # "bitbucket" | "bitbucket-server" | "github" | "gitlab"
     host: str  # e.g. "bitbucket.org", "github.com", "gitlab.com", or self-hosted host
     owner: str  # workspace / org / group
     repo: str
@@ -91,10 +94,15 @@ class Forge(Protocol):
 
 
 def detect_forge(url: str) -> PRRef | None:
-    """Try each registered forge's URL parser in order."""
-    from . import bitbucket, github, gitlab
+    """Try each registered forge's URL parser in order.
 
-    for forge in (bitbucket, github, gitlab):
+    Bitbucket Cloud is tried before Bitbucket Server because Cloud pins itself
+    to bitbucket.org while Server matches any host; the reverse order would let
+    Server claim a bitbucket.org URL whose path happened to fit its shape.
+    """
+    from . import bitbucket, bitbucket_server, github, gitlab
+
+    for forge in (bitbucket, bitbucket_server, github, gitlab):
         ref = forge.ForgeImpl.parse_pr_url(url)
         if ref is not None:
             return ref

--- a/src/prxref/forges/bitbucket_server.py
+++ b/src/prxref/forges/bitbucket_server.py
@@ -1,0 +1,359 @@
+"""Bitbucket Server / Data Center REST API v1 forge implementation."""
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Sequence
+from urllib.parse import urlparse
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+from prxref.forges.base import InlineComment, PRData, PRRef, Thread
+
+_REQUEST_TIMEOUT = (10.0, 30.0)
+_SUMMARY_MARKER = "<!-- prxref-summary -->"
+_PAGE_LIMIT = 100
+_MAX_PAGES = 5
+
+_BBS_URL_RE = re.compile(
+    r"^https?://(?P<host>[^/]+)"
+    r"(?P<context>(?:/[^/]+)*?)"
+    r"/(?P<kind>projects|users)/(?P<key>[^/]+)"
+    r"/repos/(?P<repo>[^/]+)"
+    r"/pull-requests/(?P<number>\d+)(?:/.*)?$",
+    re.IGNORECASE,
+)
+
+
+def _make_retry_session() -> requests.Session:
+    """Build a requests.Session with bounded retries for transient failures."""
+    session = requests.Session()
+    retry = Retry(
+        total=3,
+        connect=3,
+        read=3,
+        status=3,
+        backoff_factor=1.0,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=frozenset(
+            ["GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS"]
+        ),
+        respect_retry_after_header=True,
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
+
+
+_DEFAULT_SESSION = _make_retry_session()
+
+
+class ForgeImpl:
+    """Bitbucket Server / Data Center Forge adapter."""
+
+    name: str = "bitbucket-server"
+
+    def __init__(self, session: requests.Session | None = None) -> None:
+        """Initialize with an optional custom requests Session."""
+        self._session = session if session is not None else _DEFAULT_SESSION
+
+    @staticmethod
+    def parse_pr_url(url: str) -> PRRef | None:
+        """Return a PRRef if this forge recognizes the URL, else None.
+
+        Accepts both project (``/projects/KEY/repos/...``) and personal
+        (``/users/slug/repos/...``) repositories, and tolerates a deployment
+        context path such as ``/bitbucket`` between host and route. ``owner``
+        holds the API project key, which for a personal repository is the user
+        slug prefixed with ``~``.
+        """
+        try:
+            parsed = urlparse(url)
+        except ValueError:
+            return None
+
+        if not parsed.scheme or not parsed.netloc:
+            return None
+
+        match = _BBS_URL_RE.match(url)
+        if not match:
+            return None
+
+        host = match.group("host")
+        context = match.group("context") or ""
+        kind = match.group("kind").lower()
+        key = match.group("key")
+        repo = match.group("repo")
+        number = int(match.group("number"))
+
+        # Personal repositories live under the ~slug project key in the API,
+        # while their browsable URL uses /users/slug. Keep the API form in
+        # `owner` so every request path is built the same way for both kinds.
+        owner = f"~{key}" if kind == "users" else key
+        normalized_url = (
+            f"https://{host}{context}/{kind}/{key}/repos/{repo}/pull-requests/{number}"
+        )
+
+        return PRRef(
+            forge="bitbucket-server",
+            host=host,
+            owner=owner,
+            repo=repo,
+            number=number,
+            url=normalized_url,
+        )
+
+    def _get_auth(self) -> tuple[dict[str, str], tuple[str, str] | None]:
+        """Read authentication credentials from the environment at call time.
+
+        Mirrors how GitHub Enterprise resolves its token: the deployment-specific
+        variable wins, and the Cloud variable is the fallback so a single-forge
+        setup does not need two names.
+        """
+        token = (
+            os.environ.get("PRXREF_BITBUCKET_SERVER_TOKEN")
+            or os.environ.get("PRXREF_BITBUCKET_TOKEN")
+        )
+        if token:
+            return {"Authorization": f"Bearer {token}"}, None
+
+        user = os.environ.get("PRXREF_BITBUCKET_SERVER_USER")
+        password = os.environ.get("PRXREF_BITBUCKET_SERVER_PASSWORD")
+        if user and password:
+            return {}, (user, password)
+
+        return {}, None
+
+    def _context_path(self, ref: PRRef) -> str:
+        """Recover the deployment context path from the normalized URL."""
+        match = _BBS_URL_RE.match(ref.url)
+        if match:
+            return match.group("context") or ""
+        return ""
+
+    def _pr_url(self, ref: PRRef, suffix: str = "") -> str:
+        """Construct the Data Center API endpoint URL for a given PR."""
+        context = self._context_path(ref)
+        base = (
+            f"https://{ref.host}{context}/rest/api/1.0"
+            f"/projects/{ref.owner}/repos/{ref.repo}/pull-requests/{ref.number}"
+        )
+        return f"{base}{suffix}"
+
+    def get_pr(self, ref: PRRef) -> PRData:
+        """Fetch normalized PR metadata."""
+        headers, auth = self._get_auth()
+        resp = self._session.get(
+            self._pr_url(ref), headers=headers, auth=auth, timeout=_REQUEST_TIMEOUT
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        author_user = ((data.get("author") or {}).get("user")) or {}
+        author = (
+            author_user.get("name")
+            or author_user.get("slug")
+            or author_user.get("displayName")
+            or ""
+        )
+
+        from_ref = data.get("fromRef") or {}
+        to_ref = data.get("toRef") or {}
+
+        return PRData(
+            title=data.get("title") or "",
+            description=data.get("description") or "",
+            author=author,
+            source_branch=from_ref.get("displayId") or "",
+            target_branch=to_ref.get("displayId") or "",
+            source_sha=from_ref.get("latestCommit") or "",
+            target_sha=to_ref.get("latestCommit") or "",
+            raw=data,
+        )
+
+    def get_diff(self, ref: PRRef) -> str:
+        """Fetch the raw unified diff of the PR (all files)."""
+        headers, auth = self._get_auth()
+        headers["Accept"] = "text/plain"
+        resp = self._session.get(
+            self._pr_url(ref, ".diff"),
+            headers=headers,
+            auth=auth,
+            timeout=_REQUEST_TIMEOUT,
+        )
+        resp.raise_for_status()
+        diff_text = resp.text
+
+        if not diff_text or not diff_text.strip():
+            raise ValueError(
+                "Empty or truncated diff received from Bitbucket Server for "
+                f"{ref.owner}/{ref.repo}#{ref.number}"
+            )
+
+        return diff_text
+
+    def _iter_activities(self, ref: PRRef) -> list[dict]:
+        """Page through the PR activity feed and return the COMMENTED entries.
+
+        Data Center has no flat comment listing: comments arrive as entries in
+        an activity stream, paged with start/limit rather than a next URL.
+        """
+        headers, auth = self._get_auth()
+        url = self._pr_url(ref, "/activities")
+        entries: list[dict] = []
+        start = 0
+
+        for _ in range(_MAX_PAGES):
+            resp = self._session.get(
+                url,
+                params={"start": start, "limit": _PAGE_LIMIT},
+                headers=headers,
+                auth=auth,
+                timeout=_REQUEST_TIMEOUT,
+            )
+            resp.raise_for_status()
+            page = resp.json()
+
+            for item in page.get("values", []):
+                if (item.get("action") or "").upper() == "COMMENTED":
+                    entries.append(item)
+
+            if page.get("isLastPage", True):
+                break
+            next_start = page.get("nextPageStart")
+            if next_start is None:
+                break
+            start = next_start
+
+        return entries
+
+    def post_summary(self, ref: PRRef, body: str) -> None:
+        """Post (or update) the top-level review summary comment.
+
+        Data Center rejects a comment update that does not carry the comment's
+        current ``version``, so the existing comment is looked up for its
+        version rather than only its id.
+        """
+        headers, auth = self._get_auth()
+        url = self._pr_url(ref, "/comments")
+
+        existing: dict | None = None
+        try:
+            for item in self._iter_activities(ref):
+                comment = item.get("comment") or {}
+                if comment.get("anchor"):
+                    continue
+                if _SUMMARY_MARKER in (comment.get("text") or ""):
+                    existing = comment
+                    break
+        except requests.RequestException:
+            existing = None
+
+        if existing is not None and existing.get("id") is not None:
+            resp = self._session.put(
+                f"{url}/{existing['id']}",
+                json={"text": body, "version": existing.get("version", 0)},
+                headers=headers,
+                auth=auth,
+                timeout=_REQUEST_TIMEOUT,
+            )
+            resp.raise_for_status()
+            return
+
+        resp = self._session.post(
+            url,
+            json={"text": body},
+            headers=headers,
+            auth=auth,
+            timeout=_REQUEST_TIMEOUT,
+        )
+        resp.raise_for_status()
+
+    def post_inline_comments(self, ref: PRRef, comments: Sequence[InlineComment]) -> int:
+        """Post inline comments; returns the number actually posted."""
+        if not comments:
+            return 0
+
+        headers, auth = self._get_auth()
+        url = self._pr_url(ref, "/comments")
+        posted = 0
+
+        for comment in comments:
+            payload = {
+                "text": comment.body,
+                # lineType ADDED + fileType TO anchor the comment to the line in
+                # the NEW file, matching InlineComment's contract. A line that is
+                # not part of the diff is a 4xx, skipped like every other forge.
+                "anchor": {
+                    "line": comment.line,
+                    "lineType": "ADDED",
+                    "fileType": "TO",
+                    "path": comment.path,
+                },
+            }
+            try:
+                resp = self._session.post(
+                    url,
+                    json=payload,
+                    headers=headers,
+                    auth=auth,
+                    timeout=_REQUEST_TIMEOUT,
+                )
+                if 200 <= resp.status_code < 300:
+                    posted += 1
+                elif 400 <= resp.status_code < 500:
+                    continue
+                else:
+                    resp.raise_for_status()
+            except requests.RequestException:
+                continue
+
+        return posted
+
+    def list_threads(self, ref: PRRef) -> list[Thread]:
+        """List existing discussion threads on the PR."""
+        threads: list[Thread] = []
+        try:
+            entries = self._iter_activities(ref)
+        except requests.RequestException:
+            return threads
+
+        for item in entries:
+            comment = item.get("comment") or {}
+            if not comment:
+                continue
+
+            anchor = comment.get("anchor") or {}
+            path = anchor.get("path")
+            line = anchor.get("line")
+
+            author = comment.get("author") or {}
+            threads.append(
+                Thread(
+                    path=path,
+                    line=line,
+                    resolved=_is_resolved(comment),
+                    author=author.get("name") or author.get("slug") or "",
+                    body_snippet=(comment.get("text") or "")[:200],
+                )
+            )
+
+        return threads
+
+
+def _is_resolved(comment: dict) -> bool:
+    """Decide whether a Data Center comment counts as already-addressed.
+
+    DC exposes resolution three ways depending on version and on whether the
+    comment is the thread root: an explicit RESOLVED state, a threadResolved
+    flag, or a resolvedDate on the root comment.
+    """
+    if (comment.get("state") or "").upper() == "RESOLVED":
+        return True
+    if comment.get("threadResolved"):
+        return True
+    return comment.get("resolvedDate") is not None

--- a/src/prxref/webhooks.py
+++ b/src/prxref/webhooks.py
@@ -28,7 +28,16 @@ _ALLOW_UNSIGNED_ENV = "PRXREF_ALLOW_UNSIGNED"
 _UNSIGNED_PREFIX = "unsigned:"
 
 _GITHUB_ACTIONS = ("opened", "synchronize")
-_BITBUCKET_EVENTS = ("pr:opened", "pr:modified")
+# Bitbucket Cloud and Bitbucket Server both announce themselves with
+# X-Event-Key, but they do not share an event vocabulary. Cloud sends
+# pullrequest:created / pullrequest:updated; Server sends pr:opened /
+# pr:modified, plus pr:from_ref_updated when the source branch moves.
+# Only the Server names were listed here, against a payload extractor that
+# reads Cloud's shape — so a real Cloud webhook was rejected as "not
+# reviewable" while a real Server webhook failed to yield a URL.
+_BITBUCKET_CLOUD_EVENTS = ("pullrequest:created", "pullrequest:updated")
+_BITBUCKET_SERVER_EVENTS = ("pr:opened", "pr:modified", "pr:from_ref_updated")
+_BITBUCKET_EVENTS = _BITBUCKET_CLOUD_EVENTS + _BITBUCKET_SERVER_EVENTS
 _GITLAB_ACTIONS = ("open", "update")
 
 
@@ -37,8 +46,10 @@ def verify_signature(body: bytes, headers: dict) -> tuple[bool, str]:
 
     The source forge is detected from its event header (X-GitHub-Event,
     X-Event-Key, or X-Gitlab-Event; header names are case-insensitive).
-    Signature is checked per forge: GitHub HMAC-SHA256 in
-    X-Hub-Signature-256, Bitbucket HMAC-SHA256 in X-Hub-Signature,
+    Bitbucket Cloud and Bitbucket Server are both recognized by X-Event-Key
+    and share one verification path; their event names and payload shapes
+    differ and both are accepted. Signature is checked per forge: GitHub
+    HMAC-SHA256 in X-Hub-Signature-256, Bitbucket HMAC-SHA256 in X-Hub-Signature,
     GitLab plain token in X-Gitlab-Token — each against its
     PRXREF_<FORGE>_WEBHOOK_SECRET env var. Only PR-open/update events are
     reviewable; anything else is ignored.
@@ -203,12 +214,33 @@ def _verify_bitbucket(body: bytes, h: dict) -> tuple[bool, str]:
     payload = _parse_json(body)
     if payload is None:
         return False, "invalid JSON payload"
-    pullrequest = payload.get("pullrequest") or {}
-    links = pullrequest.get("links") or {}
-    url = (links.get("html") or {}).get("href")
+    url = _bitbucket_pr_url(payload)
     if not url:
-        return False, "bitbucket payload missing pullrequest.links.html.href"
+        return False, (
+            "bitbucket payload missing pullrequest.links.html.href "
+            "(Cloud) or pullRequest.links.self[].href (Server)"
+        )
     return _result(state, url)
+
+
+def _bitbucket_pr_url(payload: dict) -> str | None:
+    """Extract the PR URL from either a Cloud or a Server webhook payload.
+
+    Cloud nests the browsable link under pullrequest.links.html.href. Server
+    uses a differently-cased pullRequest key and exposes the link as the first
+    entry of a links.self list.
+    """
+    cloud = payload.get("pullrequest") or {}
+    url = ((cloud.get("links") or {}).get("html") or {}).get("href")
+    if url:
+        return url
+
+    server = payload.get("pullRequest") or {}
+    self_links = (server.get("links") or {}).get("self") or []
+    for link in self_links:
+        if isinstance(link, dict) and link.get("href"):
+            return link["href"]
+    return None
 
 
 def _verify_gitlab(body: bytes, h: dict) -> tuple[bool, str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -157,7 +157,12 @@ class TestReviewSubcommand:
 
         _, err = capsys.readouterr()
         assert "unrecognized PR URL" in err
-        assert "bitbucket.org" in err
+        # Name the forges, not their SaaS hostnames: three of the four adapters
+        # serve self-hosted deployments, so a hint listing bitbucket.org /
+        # github.com / gitlab.com reads as a restriction that does not exist.
+        for forge in ("Bitbucket", "GitHub", "GitLab"):
+            assert forge in err
+        assert "Self-hosted" in err
 
     def test_orchestration_exception_exits_0_non_blocking(
         self, fake_runtime, monkeypatch, capsys

--- a/tests/test_forge_bitbucket_server.py
+++ b/tests/test_forge_bitbucket_server.py
@@ -1,0 +1,456 @@
+"""Tests for the Bitbucket Server / Data Center forge adapter."""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from prxref.config import make_forge
+from prxref.forges.base import InlineComment, PRRef, detect_forge
+from prxref.forges.bitbucket_server import ForgeImpl
+from prxref.triage import parse_unified_diff
+
+
+def _mock_response(status_code=200, json_data=None, text=""):
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status_code
+    resp.ok = 200 <= status_code < 300
+    if json_data is not None:
+        resp.json.return_value = json_data
+        resp.text = json.dumps(json_data)
+    else:
+        resp.text = text
+        resp.json.side_effect = ValueError("No JSON")
+    resp.raise_for_status.side_effect = (
+        None if resp.ok else requests.HTTPError(response=resp)
+    )
+    return resp
+
+
+def _ref(url="https://bitbucket.corp.example/projects/PLAT/repos/api/pull-requests/42"):
+    ref = ForgeImpl.parse_pr_url(url)
+    assert ref is not None
+    return ref
+
+
+# --- URL parsing ------------------------------------------------------------
+
+
+def test_parse_pr_url_project_repo():
+    ref = ForgeImpl.parse_pr_url(
+        "https://bitbucket.corp.example/projects/PLAT/repos/api/pull-requests/42"
+    )
+    assert ref is not None
+    assert ref.forge == "bitbucket-server"
+    assert ref.host == "bitbucket.corp.example"
+    assert ref.owner == "PLAT"
+    assert ref.repo == "api"
+    assert ref.number == 42
+    assert ref.url == (
+        "https://bitbucket.corp.example/projects/PLAT/repos/api/pull-requests/42"
+    )
+
+
+def test_parse_pr_url_personal_repo_becomes_tilde_project_key():
+    # A personal repo browses as /users/jdoe but is addressed as ~jdoe in the
+    # API. Getting this wrong 404s every request for a personal-repo PR.
+    ref = ForgeImpl.parse_pr_url(
+        "https://bitbucket.corp.example/users/jdoe/repos/scratch/pull-requests/7"
+    )
+    assert ref is not None
+    assert ref.owner == "~jdoe"
+    assert ref.repo == "scratch"
+    assert ref.url == (
+        "https://bitbucket.corp.example/users/jdoe/repos/scratch/pull-requests/7"
+    )
+
+
+def test_parse_pr_url_with_deployment_context_path():
+    # Data Center is commonly reverse-proxied under a context path.
+    ref = ForgeImpl.parse_pr_url(
+        "https://tools.corp.example/bitbucket/projects/PLAT/repos/api/pull-requests/9"
+    )
+    assert ref is not None
+    assert ref.host == "tools.corp.example"
+    assert ref.owner == "PLAT"
+    assert ref.number == 9
+    assert "/bitbucket/projects/PLAT/" in ref.url
+
+
+def test_parse_pr_url_tolerates_trailing_route():
+    ref = ForgeImpl.parse_pr_url(
+        "https://bitbucket.corp.example/projects/PLAT/repos/api/pull-requests/42/overview"
+    )
+    assert ref is not None
+    assert ref.number == 42
+    assert ref.url.endswith("/pull-requests/42")
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://bitbucket.org/team/repo/pull-requests/1",  # Cloud, not Server
+        "https://github.com/o/r/pull/1",
+        "https://gitlab.com/g/p/-/merge_requests/1",
+        "https://bitbucket.corp.example/projects/PLAT/repos/api/pull-requests/abc",
+        "https://bitbucket.corp.example/projects/PLAT/repos/api",
+        "not-a-url",
+        "",
+    ],
+)
+def test_parse_pr_url_rejects_foreign_urls(url):
+    assert ForgeImpl.parse_pr_url(url) is None
+
+
+def test_cloud_url_is_not_claimed_by_server():
+    # Ordering guard: bitbucket.org must resolve to the Cloud adapter even
+    # though the Server pattern matches any host.
+    ref = detect_forge("https://bitbucket.org/team/repo/pull-requests/1")
+    assert ref is not None
+    assert ref.forge == "bitbucket"
+
+
+def test_detect_forge_routes_server_urls_here():
+    ref = detect_forge(
+        "https://bitbucket.corp.example/projects/PLAT/repos/api/pull-requests/42"
+    )
+    assert ref is not None
+    assert ref.forge == "bitbucket-server"
+
+
+def test_make_forge_builds_the_server_adapter():
+    forge = make_forge(_ref(), session=MagicMock())
+    assert isinstance(forge, ForgeImpl)
+    assert forge.name == "bitbucket-server"
+
+
+# --- auth -------------------------------------------------------------------
+
+
+def test_bearer_token_prefers_the_server_specific_variable(monkeypatch):
+    monkeypatch.setenv("PRXREF_BITBUCKET_SERVER_TOKEN", "dc-token")
+    monkeypatch.setenv("PRXREF_BITBUCKET_TOKEN", "cloud-token")
+    headers, auth = ForgeImpl()._get_auth()
+    assert headers == {"Authorization": "Bearer dc-token"}
+    assert auth is None
+
+
+def test_bearer_token_falls_back_to_the_cloud_variable(monkeypatch):
+    monkeypatch.delenv("PRXREF_BITBUCKET_SERVER_TOKEN", raising=False)
+    monkeypatch.setenv("PRXREF_BITBUCKET_TOKEN", "cloud-token")
+    headers, auth = ForgeImpl()._get_auth()
+    assert headers == {"Authorization": "Bearer cloud-token"}
+
+
+def test_basic_auth_when_no_token(monkeypatch):
+    for var in ("PRXREF_BITBUCKET_SERVER_TOKEN", "PRXREF_BITBUCKET_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("PRXREF_BITBUCKET_SERVER_USER", "svc")
+    monkeypatch.setenv("PRXREF_BITBUCKET_SERVER_PASSWORD", "pw")
+    headers, auth = ForgeImpl()._get_auth()
+    assert headers == {}
+    assert auth == ("svc", "pw")
+
+
+# --- API paths --------------------------------------------------------------
+
+
+def test_api_path_uses_rest_v1_and_the_project_key():
+    session = MagicMock()
+    session.get.return_value = _mock_response(json_data={})
+    ForgeImpl(session=session).get_pr(_ref())
+    url = session.get.call_args[0][0]
+    assert url == (
+        "https://bitbucket.corp.example/rest/api/1.0"
+        "/projects/PLAT/repos/api/pull-requests/42"
+    )
+
+
+def test_api_path_preserves_the_context_path():
+    session = MagicMock()
+    session.get.return_value = _mock_response(json_data={})
+    ref = _ref("https://tools.corp.example/bitbucket/projects/PLAT/repos/api/pull-requests/9")
+    ForgeImpl(session=session).get_pr(ref)
+    assert session.get.call_args[0][0].startswith(
+        "https://tools.corp.example/bitbucket/rest/api/1.0/"
+    )
+
+
+def test_api_path_for_a_personal_repo():
+    session = MagicMock()
+    session.get.return_value = _mock_response(json_data={})
+    ref = _ref("https://bitbucket.corp.example/users/jdoe/repos/scratch/pull-requests/7")
+    ForgeImpl(session=session).get_pr(ref)
+    assert "/projects/~jdoe/repos/scratch/" in session.get.call_args[0][0]
+
+
+# --- get_pr -----------------------------------------------------------------
+
+
+def test_get_pr_normalizes_data_center_fields():
+    payload = {
+        "title": "Add retry",
+        "description": "why",
+        "author": {"user": {"name": "jdoe", "displayName": "J Doe"}},
+        "fromRef": {"displayId": "feature/x", "latestCommit": "aaa111"},
+        "toRef": {"displayId": "main", "latestCommit": "bbb222"},
+    }
+    session = MagicMock()
+    session.get.return_value = _mock_response(json_data=payload)
+
+    data = ForgeImpl(session=session).get_pr(_ref())
+    assert data.title == "Add retry"
+    assert data.description == "why"
+    assert data.author == "jdoe"
+    assert data.source_branch == "feature/x"
+    assert data.target_branch == "main"
+    assert data.source_sha == "aaa111"
+    assert data.target_sha == "bbb222"
+    assert data.raw is payload
+
+
+def test_get_pr_tolerates_a_sparse_payload():
+    session = MagicMock()
+    session.get.return_value = _mock_response(json_data={})
+    data = ForgeImpl(session=session).get_pr(_ref())
+    assert data.title == ""
+    assert data.author == ""
+    assert data.source_sha == ""
+
+
+# --- get_diff ---------------------------------------------------------------
+
+
+DIFF = """diff --git a/src/app.py b/src/app.py
+--- a/src/app.py
++++ b/src/app.py
+@@ -1,3 +1,4 @@
+ import os
++import sys
+
+ def main():
+"""
+
+
+def test_get_diff_uses_the_dot_diff_suffix_and_parses():
+    session = MagicMock()
+    session.get.return_value = _mock_response(text=DIFF)
+    diff = ForgeImpl(session=session).get_diff(_ref())
+
+    assert session.get.call_args[0][0].endswith("/pull-requests/42.diff")
+    files = parse_unified_diff(diff)
+    assert len(files) == 1
+    assert files[0].new_path == "src/app.py"
+
+
+def test_get_diff_rejects_an_empty_body():
+    session = MagicMock()
+    session.get.return_value = _mock_response(text="   ")
+    with pytest.raises(ValueError, match="Empty or truncated diff"):
+        ForgeImpl(session=session).get_diff(_ref())
+
+
+# --- comments ---------------------------------------------------------------
+
+
+def test_post_inline_comment_anchors_to_the_new_file():
+    session = MagicMock()
+    session.post.return_value = _mock_response(status_code=201, json_data={"id": 1})
+
+    posted = ForgeImpl(session=session).post_inline_comments(
+        _ref(), [InlineComment(path="src/app.py", line=12, body="nit")]
+    )
+    assert posted == 1
+    payload = session.post.call_args.kwargs["json"]
+    assert payload["text"] == "nit"
+    assert payload["anchor"] == {
+        "line": 12,
+        "lineType": "ADDED",
+        "fileType": "TO",
+        "path": "src/app.py",
+    }
+
+
+def test_post_inline_comments_skips_4xx_and_keeps_going():
+    session = MagicMock()
+    session.post.side_effect = [
+        _mock_response(status_code=400),
+        _mock_response(status_code=201, json_data={"id": 2}),
+    ]
+    posted = ForgeImpl(session=session).post_inline_comments(
+        _ref(),
+        [
+            InlineComment(path="a.py", line=1, body="x"),
+            InlineComment(path="b.py", line=2, body="y"),
+        ],
+    )
+    assert posted == 1
+
+
+def test_post_inline_comments_no_op_on_empty_list():
+    session = MagicMock()
+    assert ForgeImpl(session=session).post_inline_comments(_ref(), []) == 0
+    session.post.assert_not_called()
+
+
+def test_post_summary_creates_when_absent():
+    session = MagicMock()
+    session.get.return_value = _mock_response(
+        json_data={"values": [], "isLastPage": True}
+    )
+    session.post.return_value = _mock_response(status_code=201, json_data={"id": 5})
+
+    ForgeImpl(session=session).post_summary(_ref(), "summary body")
+    assert session.post.call_args.kwargs["json"] == {"text": "summary body"}
+    session.put.assert_not_called()
+
+
+def test_post_summary_updates_and_sends_the_version():
+    # Data Center rejects a comment update that omits the current version.
+    session = MagicMock()
+    session.get.return_value = _mock_response(
+        json_data={
+            "values": [
+                {
+                    "action": "COMMENTED",
+                    "comment": {
+                        "id": 77,
+                        "version": 3,
+                        "text": "old <!-- prxref-summary -->",
+                    },
+                }
+            ],
+            "isLastPage": True,
+        }
+    )
+    session.put.return_value = _mock_response(json_data={"id": 77})
+
+    ForgeImpl(session=session).post_summary(_ref(), "new body")
+    session.post.assert_not_called()
+    assert session.put.call_args[0][0].endswith("/comments/77")
+    assert session.put.call_args.kwargs["json"] == {"text": "new body", "version": 3}
+
+
+def test_post_summary_ignores_an_inline_comment_carrying_the_marker():
+    session = MagicMock()
+    session.get.return_value = _mock_response(
+        json_data={
+            "values": [
+                {
+                    "action": "COMMENTED",
+                    "comment": {
+                        "id": 9,
+                        "version": 1,
+                        "text": "quoted <!-- prxref-summary -->",
+                        "anchor": {"path": "a.py", "line": 3},
+                    },
+                }
+            ],
+            "isLastPage": True,
+        }
+    )
+    session.post.return_value = _mock_response(status_code=201, json_data={"id": 10})
+
+    ForgeImpl(session=session).post_summary(_ref(), "body")
+    session.put.assert_not_called()
+    session.post.assert_called_once()
+
+
+# --- threads ----------------------------------------------------------------
+
+
+def test_list_threads_reads_the_activity_feed():
+    session = MagicMock()
+    session.get.return_value = _mock_response(
+        json_data={
+            "values": [
+                {
+                    "action": "COMMENTED",
+                    "comment": {
+                        "text": "please fix",
+                        "author": {"name": "reviewer"},
+                        "anchor": {"path": "src/app.py", "line": 12},
+                        "state": "OPEN",
+                    },
+                },
+                {"action": "APPROVED", "user": {"name": "someone"}},
+                {
+                    "action": "COMMENTED",
+                    "comment": {
+                        "text": "done",
+                        "author": {"name": "author"},
+                        "anchor": {"path": "src/app.py", "line": 30},
+                        "state": "RESOLVED",
+                    },
+                },
+            ],
+            "isLastPage": True,
+        }
+    )
+
+    threads = ForgeImpl(session=session).list_threads(_ref())
+    assert len(threads) == 2  # the APPROVED activity is not a thread
+    assert threads[0].path == "src/app.py"
+    assert threads[0].line == 12
+    assert threads[0].author == "reviewer"
+    assert threads[0].resolved is False
+    assert threads[1].resolved is True
+
+
+def test_list_threads_follows_start_limit_pagination():
+    session = MagicMock()
+    session.get.side_effect = [
+        _mock_response(
+            json_data={
+                "values": [{"action": "COMMENTED", "comment": {"text": "one"}}],
+                "isLastPage": False,
+                "nextPageStart": 100,
+            }
+        ),
+        _mock_response(
+            json_data={
+                "values": [{"action": "COMMENTED", "comment": {"text": "two"}}],
+                "isLastPage": True,
+            }
+        ),
+    ]
+
+    threads = ForgeImpl(session=session).list_threads(_ref())
+    assert [t.body_snippet for t in threads] == ["one", "two"]
+    assert session.get.call_args_list[1].kwargs["params"]["start"] == 100
+
+
+def test_list_threads_returns_empty_on_transport_error():
+    session = MagicMock()
+    session.get.side_effect = requests.ConnectionError("down")
+    assert ForgeImpl(session=session).list_threads(_ref()) == []
+
+
+@pytest.mark.parametrize(
+    "comment,expected",
+    [
+        ({"state": "RESOLVED"}, True),
+        ({"threadResolved": True}, True),
+        ({"resolvedDate": 1700000000}, True),
+        ({"state": "OPEN"}, False),
+        ({}, False),
+    ],
+)
+def test_resolution_is_read_from_any_of_the_three_shapes(comment, expected):
+    session = MagicMock()
+    session.get.return_value = _mock_response(
+        json_data={
+            "values": [{"action": "COMMENTED", "comment": {"text": "x", **comment}}],
+            "isLastPage": True,
+        }
+    )
+    threads = ForgeImpl(session=session).list_threads(_ref())
+    assert threads[0].resolved is expected
+
+
+def test_ref_round_trips_through_the_protocol_dataclass():
+    ref = _ref()
+    assert isinstance(ref, PRRef)
+    assert ForgeImpl.parse_pr_url(ref.url) == ref

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -468,3 +468,87 @@ class TestHTTPEndpoints:
         server = ThreadingHTTPServer(("127.0.0.1", 0), make_webhook_handler(review_queue))
         assert server.server_address[1] > 0
         server.server_close()
+
+
+BBS_URL = "https://bitbucket.corp.example/projects/PLAT/repos/api/pull-requests/42"
+
+
+def _bb_cloud_body(url: str = BB_URL) -> bytes:
+    """A real Bitbucket Cloud payload."""
+    return json.dumps({"pullrequest": {"links": {"html": {"href": url}}}}).encode()
+
+
+def _bb_server_body(url: str = BBS_URL) -> bytes:
+    """A real Bitbucket Server / Data Center payload.
+
+    Different key casing (pullRequest) and the browsable link is the first
+    entry of a links.self list rather than a links.html object.
+    """
+    return json.dumps({"pullRequest": {"links": {"self": [{"href": url}]}}}).encode()
+
+
+class TestBitbucketDialects:
+    """Cloud and Server both arrive as X-Event-Key and must both be accepted.
+
+    These pair each product's real event names with its real payload shape.
+    The older cases above pair a Server event key with a Cloud payload — a
+    combination neither product sends, which is how the mismatch went unnoticed:
+    only the Server event names were accepted, against a Cloud-only extractor,
+    so every genuine Cloud webhook was rejected as "not reviewable" and every
+    genuine Server webhook yielded no URL.
+    """
+
+    @pytest.mark.parametrize("event", ["pullrequest:created", "pullrequest:updated"])
+    def test_real_cloud_event_and_payload(self, monkeypatch, event):
+        monkeypatch.setenv("PRXREF_BITBUCKET_WEBHOOK_SECRET", BB_SECRET)
+        body = _bb_cloud_body()
+        headers = {"X-Event-Key": event, "X-Hub-Signature": _sign(BB_SECRET, body)}
+        ok, detail = verify_signature(body, headers)
+        assert ok is True
+        assert detail == BB_URL
+
+    @pytest.mark.parametrize(
+        "event", ["pr:opened", "pr:modified", "pr:from_ref_updated"]
+    )
+    def test_real_server_event_and_payload(self, monkeypatch, event):
+        monkeypatch.setenv("PRXREF_BITBUCKET_WEBHOOK_SECRET", BB_SECRET)
+        body = _bb_server_body()
+        headers = {"X-Event-Key": event, "X-Hub-Signature": _sign(BB_SECRET, body)}
+        ok, detail = verify_signature(body, headers)
+        assert ok is True
+        assert detail == BBS_URL
+
+    def test_server_payload_without_a_self_link_is_reported(self, monkeypatch):
+        monkeypatch.setenv("PRXREF_BITBUCKET_WEBHOOK_SECRET", BB_SECRET)
+        body = json.dumps({"pullRequest": {"links": {"self": []}}}).encode()
+        headers = {"X-Event-Key": "pr:opened", "X-Hub-Signature": _sign(BB_SECRET, body)}
+        ok, detail = verify_signature(body, headers)
+        assert ok is False
+        assert "missing" in detail
+
+    def test_an_unreviewable_bitbucket_event_is_still_ignored(self, monkeypatch):
+        monkeypatch.setenv("PRXREF_BITBUCKET_WEBHOOK_SECRET", BB_SECRET)
+        body = _bb_cloud_body()
+        headers = {
+            "X-Event-Key": "pullrequest:comment_created",
+            "X-Hub-Signature": _sign(BB_SECRET, body),
+        }
+        ok, detail = verify_signature(body, headers)
+        assert ok is False
+        assert detail.startswith("ignored:")
+
+    def test_a_server_webhook_url_routes_to_the_server_forge(self, monkeypatch):
+        # End to end: the URL the webhook hands off must be one detect_forge
+        # resolves, or the review dies one step later with "unknown forge".
+        from prxref.forges.base import detect_forge
+
+        monkeypatch.setenv("PRXREF_BITBUCKET_WEBHOOK_SECRET", BB_SECRET)
+        body = _bb_server_body()
+        headers = {"X-Event-Key": "pr:opened", "X-Hub-Signature": _sign(BB_SECRET, body)}
+        ok, url = verify_signature(body, headers)
+        assert ok is True
+        ref = detect_forge(url)
+        assert ref is not None
+        assert ref.forge == "bitbucket-server"
+        assert ref.owner == "PLAT"
+        assert ref.number == 42


### PR DESCRIPTION
Closes #2.

## What

A fourth forge adapter, `bitbucket-server`, under the existing `Forge` Protocol.

GitHub and GitLab each covered both their hosted and self-hosted deployment; Bitbucket covered only Cloud. `forges/bitbucket.py` rejects anything whose netloc is not `bitbucket.org`, with the API base fixed at `api.bitbucket.org/2.0`, so Data Center had no path at all.

Relaxing the host check would not have been enough — Data Center is a different API, not the same one elsewhere:

| | Cloud | Data Center |
|---|---|---|
| Base | `/2.0` | `/rest/api/1.0` |
| Identity | workspace | project key + repo slug (`~slug` for personal) |
| Diff | `/diff` subpath | `.diff` suffix on the PR resource |
| Inline anchor | `inline.path` / `inline.to` | `anchor{path,line,lineType,fileType}` |
| Threads | flat `/comments` | `/activities` feed |
| Paging | `page`/`pagelen` | `start`/`limit`/`isLastPage` |

`forges/base.py` already normalizes everything that flows past it, so **nothing downstream changed** — no edits to `triage.py`, `reviewer.py`, `orchestrator.py`, or `quality.py`.

Three details that are easy to get wrong, each covered by a test:

- A personal repo browses under `/users/{slug}` but is addressed as project key `~{slug}`. `PRRef.owner` always holds the API form.
- DC is commonly reverse-proxied under a context path (`/bitbucket`), so the URL pattern captures one and every request path replays it.
- **Updating a comment without its current `version` is rejected by DC**, so the summary-dedup lookup keeps the version, not just the id.

## Also fixes: Bitbucket webhooks were broken for *both* products

`webhooks.py` accepted only `pr:opened` / `pr:modified` — **Server** event names — while reading the URL from `pullrequest.links.html.href`, which is **Cloud**'s payload shape.

So a genuine Cloud webhook was rejected as `ignored: ... not reviewable` (Cloud sends `pullrequest:created` / `pullrequest:updated`), and a genuine Server webhook yielded no URL. Neither half had ever worked against a real payload.

The existing tests paired a Server event key with a Cloud payload — a combination neither product sends — which is precisely why this went unnoticed. The new `TestBitbucketDialects` cases pair each product's real events with its real payload. **They were run against the old code first: six of them fail there.**

## Two smaller corrections found on the way

- The CLI's unrecognized-URL hint named `bitbucket.org, github.com, or gitlab.com`, which reads as a restriction that stopped being true when GHES and self-managed GitLab landed.
- `docs/env-vars.md` claimed 17 variables while its own three sections summed to 18. The total is now derived from the table it documents.

## Checks

```
uv run pytest              307 passed   (260 before)
uv run ruff check src tests    clean
uv build                   both .tar.gz and .whl
```

Plus an end-to-end CLI smoke: a DC URL now reaches LLM config (past `detect_forge` and `make_forge`), while an unrelated URL still stops at the hint.

## Not covered

Written against the Data Center REST docs, not against a live instance — I have no DC deployment to point it at. The endpoint shapes are worth a sanity check against your target version before relying on it; DC moved some of these between 7.x and 8.x. Every test is offline and stubbed, per CONTRIBUTING.

— Opus 5 via Claude Code

Claude-Session-Id: 0a4eb4cd-b2d9-4330-92b8-2afd72e8a8de