### PR TITLE
release: 0.5.0 — the Bitbucket Server / Data Center forge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -109,14 +109,22 @@ PRXREF_MAX_CHUNKS=8
 # ------------------------------------------------------------------------------
 
 # Bitbucket Cloud bearer token (workspace or repo access token with
-# pullrequest:write). Bitbucket Server / Data Center is not supported.
+# pullrequest:write).
 # PRXREF_BITBUCKET_TOKEN=
 
-# Bitbucket username (for Basic auth with app password fallback)
+# Bitbucket Cloud username (for Basic auth with app password fallback)
 # PRXREF_BITBUCKET_USER=
 
-# Bitbucket app password (for Basic auth fallback)
+# Bitbucket Cloud app password (for Basic auth fallback)
 # PRXREF_BITBUCKET_APP_PASSWORD=
+
+# Bitbucket Server / Data Center HTTP access token (Bearer).
+# Falls back to PRXREF_BITBUCKET_TOKEN when unset.
+# PRXREF_BITBUCKET_SERVER_TOKEN=
+
+# Bitbucket Server / Data Center basic-auth pair, used only when no token is set.
+# PRXREF_BITBUCKET_SERVER_USER=
+# PRXREF_BITBUCKET_SERVER_PASSWORD=
 
 # GitHub token (Personal Access Token or GitHub App installation token for github.com)
 # PRXREF_GITHUB_TOKEN=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,23 @@ a hand-maintained overlay on top of a tagged release.
   reviewable" (Cloud sends `pullrequest:created` / `pullrequest:updated`) and a
   genuine Server webhook produced no URL. Both dialects are now accepted and
   their payloads read correctly, `pr:from_ref_updated` included.
+- **A Data Center PR's REST URL built a doubled API path.** The Server URL
+  pattern captures whatever sits between the host and the `/projects|users/`
+  route as the deployment context path, because Data Center is commonly
+  reverse-proxied under one. Server is also the only forge here whose REST URL
+  has the same path shape as its browse URL — the same route, one prefixed with
+  `/rest/api/1.0` and the other not — so pasting a PR's REST URL into
+  `prxref review` parsed happily with `/rest/api/1.0` captured as the context,
+  and every request then replayed it in front of the adapter's own
+  `/rest/api/1.0`: metadata, diff, activities and comments all went to
+  `…/rest/api/1.0/rest/api/1.0/projects/…` and 404ed. Parsing now strips a REST
+  prefix (`/rest/api/1.0`, other version numbers, and the `/rest/api/latest`
+  alias, case-insensitively) off the captured context while keeping any genuine
+  context underneath it, so `PRRef.url` is the browse URL a human can click and
+  the API base is built exactly once. A REST URL for a personal repository,
+  which names it the API way as `~slug`, likewise normalizes back to its
+  `/users/slug` browse route. Webhooks never hit this: Data Center's payload
+  carries the browse URL in `pullRequest.links.self[].href`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.5.0] — 2026-08-28
+
+The self-hosted Bitbucket release. Bitbucket Server / Data Center was the one
+supported forge family with no self-hosted path; deployments that needed it ran
+a hand-maintained overlay on top of a tagged release.
+
+### Added
+
+- **Bitbucket Server / Data Center forge** (`bitbucket-server`). Self-hosted
+  Bitbucket previously had no path at all: the Cloud adapter pins itself to
+  `bitbucket.org`, while GitHub and GitLab each covered their self-hosted
+  deployment. Data Center is a different API rather than the same one on
+  another host — `/rest/api/1.0`, project keys instead of workspaces, an
+  activity feed instead of a comment list, `start`/`limit` paging — so it is a
+  fourth adapter under the existing `Forge` Protocol, and nothing downstream of
+  `forges/base.py` changed. Handles project and personal (`~slug`)
+  repositories, a deployment context path, anchored inline comments, and the
+  version field Data Center requires when updating a comment. `detect_forge`
+  tries Cloud before Server, though the two parsers are disjoint — Cloud pins
+  `bitbucket.org`, Server requires a `/projects|users/KEY/repos/REPO/` path — so
+  no URL matches both and the order is defensive rather than load-bearing.
+- **`PRXREF_BITBUCKET_SERVER_TOKEN`** (HTTP access token, falls back to
+  `PRXREF_BITBUCKET_TOKEN`), **`PRXREF_BITBUCKET_SERVER_USER`** and
+  **`PRXREF_BITBUCKET_SERVER_PASSWORD`** (basic-auth pair, used only when no
+  token is set).
+
+### Fixed
+
+- **Bitbucket webhooks were broken for both products.** The receiver accepted
+  only `pr:opened` / `pr:modified` — Bitbucket **Server** event names — while
+  reading the PR URL from `pullrequest.links.html.href`, which is Bitbucket
+  **Cloud**'s payload shape. So a genuine Cloud webhook was rejected as "not
+  reviewable" (Cloud sends `pullrequest:created` / `pullrequest:updated`) and a
+  genuine Server webhook produced no URL. Both dialects are now accepted and
+  their payloads read correctly, `pr:from_ref_updated` included.
+
+### Changed
+
+- `prxref review`'s hint for an unparseable PR URL now names the self-hosted
+  deployments alongside the three cloud hosts, and says that the URL must keep
+  the forge's own path shape.
+
 ## [0.4.0] — 2026-08-27
 
 The second half of the on-prem field report: posting controls, the exit-code
@@ -239,6 +281,8 @@ Development baseline. Never published to PyPI and never tagged; superseded by
 - Diff content is sent to whichever OpenAI-compatible endpoint you configure.
 - Requires Python 3.12+. Tested on 3.12 and 3.13.
 
-[Unreleased]: https://github.com/sblattj/prxref/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/sblattj/prxref/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/sblattj/prxref/releases/tag/v0.5.0
+[0.4.0]: https://github.com/sblattj/prxref/releases/tag/v0.4.0
 [0.3.0]: https://github.com/sblattj/prxref/releases/tag/v0.3.0
 [0.2.0]: https://github.com/sblattj/prxref/releases/tag/v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,21 @@ a hand-maintained overlay on top of a tagged release.
   which names it the API way as `~slug`, likewise normalizes back to its
   `/users/slug` browse route. Webhooks never hit this: Data Center's payload
   carries the browse URL in `pullRequest.links.self[].href`.
+- **A plain-HTTP Data Center deployment was silently retargeted to TLS.** The
+  Server URL pattern accepts `http://` as well as `https://`, but normalization
+  and the API base both wrote `https://` back unconditionally, so an
+  `http://host:7990/projects/…` URL parsed happily and then sent every request
+  — metadata, diff, activities, comments — to `https://host:7990/…`. That is
+  not a hypothetical host: a Data Center standalone install serves plain HTTP on
+  port 7990, so the out-of-the-box deployment shape was the one that broke, and
+  it broke as a TLS handshake failure against a URL the operator never typed.
+  `PRRef.url` now carries the scheme it was parsed with, and `_pr_url` reads it
+  back out of `url` the same way the deployment context path is recovered, so an
+  `http://` deployment stays on `http://` end to end and an uppercase `HTTP://`
+  round-trips lowercased. Nothing changes for an `https://` URL. This makes the
+  Server adapter deliberately unlike its three siblings, which all build their
+  API base as `https://` whatever scheme they were handed; only Bitbucket
+  Server ships a default install that is not on TLS.
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,8 +32,9 @@ auto-detects the forge.
 
 ## Commands
 
-- `uv run pytest` — tests
-- `uv run ruff check src tests` — lint
+- `uv run --extra dev pytest` — tests (pytest is a `dev` extra; the bare
+  `uv run pytest` fails with `Failed to spawn: pytest`)
+- `uv run --extra dev ruff check src tests` — lint
 - `uv run prxref review --pr-url ...` — one-shot review
 
 ## Conventions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # prxref
 
-Fast automated AI code review for Bitbucket, GitLab, and GitHub.
+Fast automated AI code review for Bitbucket, GitLab, and GitHub — Cloud and self-hosted.
 
 ## What This Is
 
@@ -15,14 +15,17 @@ auto-detects the forge.
 ## Tech
 
 - Python 3.12+, `uv` for env/lock, hatchling packaging
-- One `Forge` Protocol (src/prxref/forges/base.py), three adapters
-- Forge coverage is asymmetric, on purpose: GitHub Enterprise Server and
-  self-hosted GitLab work on any host (same REST API, different base URL), but
-  **Bitbucket is Cloud only**. `bitbucket.ForgeImpl.parse_pr_url` returns None
-  unless the host is `bitbucket.org`, so a Server/Data Center URL is rejected
-  before any credential is read — a token is never the explanation. Server
-  speaks `/rest/api/1.0` against different resource shapes, so supporting it is
-  a fourth adapter, not a base-URL setting.
+- One `Forge` Protocol (src/prxref/forges/base.py), four adapters
+- Bitbucket needs two of them: Cloud speaks `/2.0` on `bitbucket.org` only,
+  Server / Data Center speaks `/rest/api/1.0` on any host, so the adapter is
+  picked from the URL. `detect_forge` asks Cloud first, but that order is
+  defensive, not load-bearing: Cloud pins `bitbucket.org` and a bare
+  `owner/repo/pull-requests/N` path while Server requires a
+  `/projects|users/KEY/repos/REPO/` prefix, so the two patterns are disjoint and
+  every URL resolves identically under either order. Asking the narrower parser
+  first means a later loosening degrades into a shadowed forge rather than a
+  silently mis-routed one. GitHub and GitLab stay one adapter each, because
+  their self-hosted products differ only in base URL.
 - LLM access via a fallback chain (llm-ferry preferred, litellm optional,
   plain-HTTP client as zero-dependency default) — provider-agnostic, no
   Anthropic key by design

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,8 @@ Both must pass before a PR can merge. CI runs exactly these on Python 3.12 and
 3.13:
 
 ```bash
-uv run pytest              # no network required
-uv run ruff check src tests
+uv run --extra dev pytest  # no network required (pytest is a `dev` extra)
+uv run --extra dev ruff check src tests
 ```
 
 The suite is fully offline — every forge and LLM call is stubbed. If a change

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,107 +1,128 @@
-# HANDOFF — cut v0.5.0: release the Bitbucket Server / Data Center forge
+# HANDOFF — v0.5.0 shipped: the Bitbucket Server / Data Center forge
 
-**Repo:** `sblattj/prxref` (public) · **`main` tip:** `c02cfc4` (v0.4.0) · **Written:** 2026-08-28
+**Repo:** `sblattj/prxref` (public) · **Released:** 2026-08-28 · **Supersedes** the
+"cut v0.5.0" handoff written the same day.
 
-One capability is finished, proven in real use, and has never shipped: the **Bitbucket
-Server / Data Center forge**. It exists only on `origin/feat/bitbucket-server-forge`
-(`cc58915`, *"feat: Bitbucket Server / Data Center forge"*), so every deployment that needs it
-runs a copy of `bitbucket_server.py` overlaid onto a released tree by hand. That overlay is the
-thing to delete, and releasing is how you delete it.
+The Bitbucket Server / Data Center forge is released. It had been finished and
+proven in real use but lived only on `origin/feat/bitbucket-server-forge`
+(`cc58915`), so every deployment that needed it ran a hand-maintained overlay of
+`bitbucket_server.py` on top of a tagged release. **Delete that overlay** — v0.5.0
+carries the forge natively.
 
-## Why it isn't released yet
+## What landed
 
-Not a technical blocker — the work was done on a machine that had no write-scoped GitHub
-credential (read-only token, and git-over-SSH blocked by a network proxy), so it could
-consume releases but not cut one. Anyone running this with a normal `gh auth login` can finish it.
+- `src/prxref/forges/bitbucket_server.py` — project and personal (`~slug`)
+  repositories, deployment context paths, anchored inline comments, `start`/`limit`
+  paging, and the `version` field Data Center requires when updating a comment.
+- Registration in both places that matter: the `detect_forge` module tuple in
+  `forges/base.py` and the `impls` dict in `config.py`'s `make_forge`.
+- Three env vars: `PRXREF_BITBUCKET_SERVER_TOKEN` (falls back to
+  `PRXREF_BITBUCKET_TOKEN`), `PRXREF_BITBUCKET_SERVER_USER` and
+  `PRXREF_BITBUCKET_SERVER_PASSWORD`.
+- **A real bug fix, not just the new forge:** Bitbucket webhooks were broken for
+  *both* products. The receiver accepted only `pr:opened` / `pr:modified` —
+  Bitbucket **Server** event names — while reading the PR URL from
+  `pullrequest.links.html.href`, which is Bitbucket **Cloud**'s payload shape. A
+  genuine Cloud webhook was rejected as not reviewable; a genuine Server webhook
+  produced no URL. Both dialects now work.
+- Docs, README, `CLAUDE.md` and `.env.example` updated, and every "Bitbucket is
+  Cloud only" / "Server is not supported" claim removed.
 
-## Scope of the release
+## Four things the previous handoff got wrong
 
-**v0.5.0 — minor.** A new forge is additive: no existing flag, env var, or forge behaviour
-changes. Nothing here is breaking, so it is not 1.0, and it is more than a patch.
+Recorded because each one would have cost the next person real time.
 
-What lands:
+1. **The Cloud-before-Server ordering rationale was false.** The old handoff said
+   Cloud's parser is the more specific of the two and that Server-first would make
+   Cloud URLs match Server. Tested by reversing the tuple and running six URLs
+   through `detect_forge`: **every case resolved identically.** The parsers are
+   disjoint — Cloud pins `^https?://bitbucket\.org/` plus a bare
+   `owner/repo/pull-requests/N`; Server requires a `/projects|users/KEY/repos/REPO/`
+   prefix. No URL matches both, including the adversarial `bitbucket.org` host with
+   a Server-shaped path, which only Server matches under either order. The Cloud-first
+   order is kept as **defence in depth** — if either parser is later loosened, the
+   failure degrades into a shadowed forge rather than a mis-routed one — but it is
+   not load-bearing, and no document should claim it is.
 
-1. `src/prxref/forges/bitbucket_server.py` from the feature branch.
-2. Registration in **two** places — both must change or the forge is dead code:
-   - `src/prxref/forges/base.py:93` — `detect_forge()` iterates a literal tuple
-     `(bitbucket, github, gitlab)`. Add the Server module, and keep **Cloud before Server**:
-     Cloud's URL parser is the more specific of the two, and flipping the order makes Cloud
-     URLs match Server first.
-   - `src/prxref/config.py:378` — `make_forge()` maps names to implementations in an `impls`
-     dict. Add `"bitbucket-server": bitbucket_server.ForgeImpl`.
-3. Version bump to `0.5.0` in `pyproject.toml` (line 3) **and** `src/prxref/__init__.py`.
-4. `CHANGELOG.md` entry.
+2. **Both registration line numbers pointed at the wrong line.** `forges/base.py:93`
+   and `config.py:378` are the `def` lines; the literals that actually need editing
+   were the tuple at `base.py:97` and the dict at `config.py:386-390`. Cite the
+   construct, not the function.
 
-**Optional, only if cheap:** port the branch's tests, and the `webhooks.py` Server routing (that
-one only matters for the `serve` daemon).
+3. **`uv run pytest` does not work in this repo.** pytest lives in
+   `[project.optional-dependencies] dev`, so the documented command dies with
+   `Failed to spawn: pytest / No such file or directory (os error 2)` — an error that
+   reads like a broken venv rather than a missing extra. The invocation is:
 
-## Why the overlay has been safe, and why merging is therefore low-risk
+   ```bash
+   uv run --extra dev pytest
+   ```
 
-Checked rather than assumed, against v0.4.0: the shared types (`PRRef`, `PRData`,
-`InlineComment`, `Thread`) are identical between the feature branch and the release; the Forge
-protocol methods (`get_pr`, `get_diff`, `post_summary`, `post_inline_comments`, `list_threads`)
-match exactly; and the `review` CLI flags are unchanged. The 18 commits that made up v0.4.0
-touched `llm_backends`, `cli` and chunking — not the forge contract.
+4. **The diff direction that reads "what the branch changed" is backwards here.**
+   `cc58915` was cut from v0.2.0, so `git diff main...cc58915` renders main's own
+   v0.3/v0.4 work as *additions* — applying it literally reverts the entire config-surface
+   release (17 config rows and 4 sections in `docs/env-vars.md` alone). Most hunks on
+   that branch are regressions, not features. Diff the branch's **own** delta instead:
 
-## Steps
+   ```bash
+   git diff a7abbf1 cc58915 -- <path>
+   ```
+
+## The coupling that will catch the next person adding a config key
+
+`tests/test_docs_consistency.py` compiles `docs/env-vars.md` and `.env.example`
+against `config._DEFAULTS` **in both directions**, and asserts two hard-coded
+integers built as `f"**{len(_DEFAULTS)}** configuration keys"` and
+`f"for {len(_DEFAULTS)+len(_LEGACY_ENV_ALIASES)} accepted variable names"`.
+
+So a new config key is not a source change — it is an atomic four-surface change:
+`_DEFAULTS`, the `config.py` docstring, `.env.example`, and `docs/env-vars.md`
+including its counts and its `Per-Forge Auth (N)` section heading. Adding three keys
+here failed five tests until all four surfaces moved together. Current values: **33**
+keys, **1** legacy alias, **34** accepted names.
+
+## Release shape (follow this next time)
 
 ```bash
-git switch -c release/0.5.0 main
-git checkout origin/feat/bitbucket-server-forge -- src/prxref/forges/bitbucket_server.py
-# register in forges/base.py:93 and config.py:378 (see above), bump both version strings,
-# add the CHANGELOG entry
-uv run pytest
-uv run prxref --version          # must print 0.5.0
+uv build                       # produces BOTH sdist and wheel
+gh release upload vX.Y.Z dist/prxref-X.Y.Z.tar.gz dist/prxref-X.Y.Z-py3-none-any.whl
 ```
 
-Then: open a PR, merge it, tag `v0.5.0`, and create the GitHub Release.
+Both assets matter: the v0.4.0 release ships both, and at least one consumer updates
+itself with `gh release download --pattern '*.tar.gz'`, which does **not** match
+GitHub's auto-generated source archive. A release without the attached sdist silently
+breaks those consumers.
 
-**Author identity:** commits and tags use the GitHub noreply address
-(`5125883+sblattj@users.noreply.github.com`). Never a work email.
+## Verified at release
 
-**Do not skip the sdist asset.** The v0.4.0 release ships an attached `*.tar.gz`, and at least one
-consumer updates itself with `gh release download --pattern '*.tar.gz'` — which does **not** match
-GitHub's auto-generated source archive. A release without that asset silently breaks those
-consumers:
-
-```bash
-uv build            # or: python -m build --sdist
-gh release upload v0.5.0 dist/prxref-0.5.0.tar.gz
+```
+840 passed                                    uv run --extra dev pytest
+All checks passed!                            uv run --extra dev ruff check src/ tests/
+0.5.0                                         uv run prxref --version
+bitbucket-server   .../projects/PROJ/repos/app/pull-requests/42
+bitbucket          https://bitbucket.org/ws/app/pull-requests/7
+github             https://github.com/o/r/pull/3
+gitlab             https://gitlab.com/o/r/-/merge_requests/9
+make_forge(ref) -> prxref.forges.bitbucket_server.ForgeImpl, name 'bitbucket-server'
 ```
 
-## How you know it worked
+## Still open — not part of this release
 
-A downstream tree that used to overlay the forge should now report that the release already
-carries it, and stop patching. Directly:
-
-```bash
-python -c "from prxref.forges import bitbucket_server; print(bitbucket_server.ForgeImpl)"
-python -c "from prxref.config import make_forge"   # 'bitbucket-server' resolves
-```
-
-Point it at a Server PR URL (`/rest/api/1.0` style host) and confirm `detect_forge` returns a
-`PRRef` with forge `bitbucket-server`, and that a Cloud URL still detects as `bitbucket`.
-
-## Known-good runtime shape for the Server case
-
-For anyone reproducing the setup this forge was built for: an OpenAI-compatible HTTP backend
-(`PRXREF_LLM_BACKEND=http`, `PRXREF_LLM_BASE_URL`, `PRXREF_LLM_MODELS`, `PRXREF_LLM_TIMEOUT`),
-with the forge token supplied at runtime from a credential store rather than committed anywhere.
-`PRXREF_LLM_TIMEOUT` shipped natively in v0.4.0; a per-run `review --timeout SECONDS` flag does
-**not** exist yet and is still a reasonable follow-up.
-
-## Follow-ups that are NOT part of this release
-
-- **Observability / tracing** — prompt+response tracing, a `PRXREF_TRACE_DIR`, per-finding drop
-  reasons, and a machine-readable run report. None of it landed in v0.4.0; still worth filing.
-- **`review --timeout SECONDS`** — the per-run counterpart to the env knob.
-- A configurable-LLM-timeout issue draft is **obsolete**: v0.4.0 shipped the env knob it asked for.
+- **Observability / tracing** — prompt+response tracing, a `PRXREF_TRACE_DIR`,
+  per-finding drop reasons, a machine-readable run report. Nothing has landed.
+- **`review --timeout SECONDS`** — the per-run counterpart to `PRXREF_LLM_TIMEOUT`,
+  which shipped natively in v0.4.0.
+- **`origin/feat/bitbucket-server-forge` can be deleted** once you are satisfied with
+  v0.5.0. Everything worth keeping from it is on `main`; the rest is v0.2.0-era text.
+- **`CONTRIBUTING.md` has no inbound link any more.** Deleting the
+  `### Bitbucket Server / Data Center (unsupported)` section from `docs/forges.md`
+  removed the docs' only pointer to it. The file still exists and GitHub surfaces it
+  natively, so nothing is broken — but nothing points at it either.
 
 | Item | Value |
 |---|---|
-| Target version | `0.5.0` (minor — new forge, nothing breaking) |
-| Source of the forge | `origin/feat/bitbucket-server-forge` @ `cc58915` |
-| Registration points | `src/prxref/forges/base.py:93`, `src/prxref/config.py:378` |
-| Version strings | `pyproject.toml:3`, `src/prxref/__init__.py` |
-| Release must include | an attached sdist `*.tar.gz` asset |
-| Commit identity | `5125883+sblattj@users.noreply.github.com` |
+| Released version | `0.5.0` (minor — new forge plus a webhook fix, nothing breaking) |
+| Registration points | the tuple in `forges/base.py`, the `impls` dict in `config.py` |
+| Version strings | `pyproject.toml`, `src/prxref/__init__.py`, and `uv.lock` |
+| Test command | `uv run --extra dev pytest` |
+| Release assets | sdist **and** wheel, both attached |

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -112,6 +112,48 @@ make_forge(ref) -> prxref.forges.bitbucket_server.ForgeImpl, name 'bitbucket-ser
   per-finding drop reasons, a machine-readable run report. Nothing has landed.
 - **`review --timeout SECONDS`** — the per-run counterpart to `PRXREF_LLM_TIMEOUT`,
   which shipped natively in v0.4.0.
+
+The next three came out of the v0.5.0 release review, which raised them against
+`bitbucket_server.py`. Each one is real, and each one is **repo-wide, not a porting
+defect**: the new adapter does what its siblings already do, so all three were left
+alone rather than fixed in one adapter and creating a four-way inconsistency. Whoever
+takes one on should change all four adapters in the same commit.
+
+- **Retries re-send non-idempotent writes.** All four retry sessions list `POST` in
+  `allowed_methods` against `status_forcelist [429, 500, 502, 503, 504]` with
+  `total=3` — `bitbucket_server.py:62-65`, `bitbucket.py:33-36`, `gitlab.py:33-36`,
+  `github.py:27-29` (which adds `PATCH`). If a comment POST commits server-side and
+  the response is lost to a 502/504 or a read timeout, urllib3 re-sends it and the
+  comment is duplicated. The fix is to drop the write verbs from `allowed_methods`
+  and let the caller decide, but it changes retry behaviour for every forge.
+- **Comment listings are capped and the cap is silent.** Bitbucket Server reads
+  5 x 100 activities (`bitbucket_server.py:17-18,267`) and Bitbucket Cloud 5 x 100
+  comments (`bitbucket.py:216-220`); GitLab reads a single page of 50
+  (`gitlab.py:232,321`) and GitHub a single unparameterised page, so 30
+  (`github.py:124,167`). Past the cap `list_threads` under-reports and `post_summary`
+  can miss its own `<!-- prxref-summary -->` and post a second summary. Server is the
+  *most* thorough of the four here, not the least. A shared paging helper with an
+  explicit "truncated" signal would fix all four at once.
+- **A failed comment-listing read is treated as "no summary exists".** In
+  `post_summary`, a listing that errors leaves the existing-summary handle unset and
+  control falls through to the create-a-new-comment POST:
+  `bitbucket_server.py:310-311` then `:324`, and `gitlab.py:241-242` then `:254`.
+  GitHub has no `try` at all — a transport error propagates — but a non-`ok`
+  response takes the same fall-through (`github.py:125` -> `:139`). Bitbucket Cloud
+  is furthest from correct: `post_summary` (`bitbucket.py:165`) never looks for an
+  existing summary, so it posts a duplicate on *every* re-review. Distinguishing
+  "read failed" from "nothing found" and skipping the post is the fix, and it is the
+  same three-line change in each adapter.
+- **Move the dev tools to a dependency group.** `pytest` and `ruff` are declared under
+  `[project.optional-dependencies] dev`, and `uv run` never installs a project *extra* —
+  which is why the bare `uv run pytest` fails on a cold checkout with
+  `Failed to spawn: pytest` (reproduced on a pristine `git archive` of this branch,
+  exit 2). Every doc now spells the `--extra dev` form, but replacing
+  `[project.optional-dependencies] dev` with `[dependency-groups] dev` would make the
+  bare command correct and remove the trap at its source. It is a real behaviour change
+  — the `dev` extra stops being installable as `pip install prxref[dev]` — so it needs
+  its own decision rather than riding along with a release.
+
 - **`origin/feat/bitbucket-server-forge` can be deleted** once you are satisfied with
   v0.5.0. Everything worth keeping from it is on `main`; the rest is v0.2.0-era text.
 - **`CONTRIBUTING.md` has no inbound link any more.** Deleting the

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # prxref
 
-Fast automated AI code review for Bitbucket, GitLab, and GitHub.
+Fast automated AI code review for Bitbucket, GitLab, and GitHub — Cloud and self-hosted.
 
 prxref inspects pull and merge requests across the three major code hosting forges in sub-minute review cycles. It parses unified diffs, partitions changes into risk-ranked chunks, fans out parallel single-shot LLM reviews across a cheap-first model fallback chain, filters findings through deterministic quality gates, and publishes inline comments alongside an executive summary.
 
@@ -73,6 +73,9 @@ Pass any PR or MR URL directly. Forge type, repository namespace, and pull reque
 # Bitbucket Cloud
 prxref review --pr-url https://bitbucket.org/workspace/repo/pull-requests/42
 
+# Bitbucket Server / Data Center (self-hosted, any host, with or without a deployment context path)
+prxref review --pr-url https://bitbucket.corp.example/projects/PLAT/repos/api/pull-requests/42
+
 # GitHub & GitHub Enterprise
 prxref review --pr-url https://github.com/owner/repository/pull/108
 
@@ -80,7 +83,7 @@ prxref review --pr-url https://github.com/owner/repository/pull/108
 prxref review --pr-url https://gitlab.com/group/subgroup/project/-/merge_requests/15
 ```
 
-**Supported hosts.** GitHub Enterprise Server and self-hosted GitLab are supported on any host — their self-hosted products speak the same REST API as their SaaS ones. **Bitbucket is Cloud only:** a Bitbucket Server / Data Center URL is rejected on the host check inside `parse_pr_url`, before any credential is read, so a wrong token is never the explanation. Server exposes a different API (`/rest/api/1.0`) from Cloud's v2, which makes this a missing adapter rather than a base-URL setting. See [docs/forges.md](docs/forges.md).
+**Supported hosts.** Every forge is supported on any host. GitHub Enterprise Server and self-hosted GitLab share one adapter each with their SaaS products, which speak the same REST API at a different base URL. Bitbucket does not: Server / Data Center speaks `/rest/api/1.0` against different resource shapes, so it is a separate adapter selected automatically from the URL — `PRXREF_BITBUCKET_SERVER_TOKEN` for Data Center, `PRXREF_BITBUCKET_TOKEN` for Cloud. See [docs/forges.md](docs/forges.md).
 
 ## LLM Configuration
 
@@ -111,8 +114,10 @@ Configure the authentication token matching your forge:
 
 | Forge | Environment Variable | Notes |
 |---|---|---|
-| **Bitbucket** | `PRXREF_BITBUCKET_TOKEN` | Bearer token (workspace or repo access token) |
-| **Bitbucket (Basic)** | `PRXREF_BITBUCKET_USER` + `PRXREF_BITBUCKET_APP_PASSWORD` | App password fallback |
+| **Bitbucket Cloud** | `PRXREF_BITBUCKET_TOKEN` | Bearer token (workspace or repo access token) |
+| **Bitbucket Cloud (Basic)** | `PRXREF_BITBUCKET_USER` + `PRXREF_BITBUCKET_APP_PASSWORD` | App password fallback |
+| **Bitbucket Server / DC** | `PRXREF_BITBUCKET_SERVER_TOKEN` | HTTP access token (falls back to `PRXREF_BITBUCKET_TOKEN`) |
+| **Bitbucket Server (Basic)** | `PRXREF_BITBUCKET_SERVER_USER` + `PRXREF_BITBUCKET_SERVER_PASSWORD` | Basic-auth fallback |
 | **GitHub** | `PRXREF_GITHUB_TOKEN` | Personal Access Token (PAT) or GitHub App token |
 | **GitHub Enterprise** | `PRXREF_GITHUB_ENTERPRISE_TOKEN` | Used when host is not `github.com` (falls back to `PRXREF_GITHUB_TOKEN`) |
 | **GitLab** | `PRXREF_GITLAB_TOKEN` | Personal, project, or group access token (`PRIVATE-TOKEN`) |

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ prxref review --pr-url https://bitbucket.org/workspace/repo/pull-requests/42
 # Bitbucket Server / Data Center (self-hosted, any host, with or without a deployment context path)
 prxref review --pr-url https://bitbucket.corp.example/projects/PLAT/repos/api/pull-requests/42
 
+# ...including a plain-HTTP deployment, e.g. the standalone install's default port
+prxref review --pr-url http://bitbucket.internal:7990/projects/PLAT/repos/api/pull-requests/42
+
 # GitHub & GitHub Enterprise
 prxref review --pr-url https://github.com/owner/repository/pull/108
 

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -35,9 +35,12 @@ Configuration is loaded from built-in defaults, overridden by environment variab
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `PRXREF_BITBUCKET_TOKEN` | *(empty)* | Bitbucket **Cloud** workspace/repository Bearer access token. Preferred over basic authentication. Bitbucket Server / Data Center is not supported — see [docs/forges.md](forges.md). |
+| `PRXREF_BITBUCKET_TOKEN` | *(empty)* | Bitbucket **Cloud** workspace/repository Bearer access token. Preferred over basic authentication. For Bitbucket Server / Data Center use `PRXREF_BITBUCKET_SERVER_TOKEN` below — see [docs/forges.md](forges.md). |
 | `PRXREF_BITBUCKET_USER` | *(empty)* | Bitbucket Cloud username for HTTP Basic authentication (used with `PRXREF_BITBUCKET_APP_PASSWORD`). |
 | `PRXREF_BITBUCKET_APP_PASSWORD` | *(empty)* | Bitbucket Cloud app password for HTTP Basic authentication. |
+| `PRXREF_BITBUCKET_SERVER_TOKEN` | *(empty)* | Bitbucket Server / Data Center HTTP access token (sent as `Bearer`). Falls back to `PRXREF_BITBUCKET_TOKEN` if unset. |
+| `PRXREF_BITBUCKET_SERVER_USER` | *(empty)* | Bitbucket Server / Data Center username for HTTP Basic authentication (used with `PRXREF_BITBUCKET_SERVER_PASSWORD`). |
+| `PRXREF_BITBUCKET_SERVER_PASSWORD` | *(empty)* | Bitbucket Server / Data Center password for HTTP Basic authentication. |
 | `PRXREF_GITHUB_TOKEN` | *(empty)* | GitHub Personal Access Token or GitHub App token for `github.com`. |
 | `PRXREF_GITHUB_ENTERPRISE_TOKEN` | *(empty)* | GitHub Enterprise token for custom/self-hosted GitHub Enterprise Server domains. Falls back to `PRXREF_GITHUB_TOKEN` if unset. |
 | `PRXREF_GITLAB_TOKEN` | *(empty)* | GitLab Personal, Project, or Group Access Token (sent via `PRIVATE-TOKEN` header) for `gitlab.com` or self-hosted GitLab. |
@@ -46,7 +49,7 @@ Configuration is loaded from built-in defaults, overridden by environment variab
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `PRXREF_BITBUCKET_WEBHOOK_SECRET` | *(empty)* | HMAC secret for Bitbucket webhooks (verified against `X-Hub-Signature` via HMAC-SHA256). |
+| `PRXREF_BITBUCKET_WEBHOOK_SECRET` | *(empty)* | HMAC secret for Bitbucket webhooks, Cloud and Server alike (verified against `X-Hub-Signature` via HMAC-SHA256). |
 | `PRXREF_GITHUB_WEBHOOK_SECRET` | *(empty)* | HMAC secret for GitHub webhooks (verified against `X-Hub-Signature-256` via HMAC-SHA256). |
 | `PRXREF_GITLAB_WEBHOOK_SECRET` | *(empty)* | Secret token for GitLab webhooks (verified against `X-Gitlab-Token`). |
 | `PRXREF_ALLOW_UNSIGNED` | `False` | Accepts webhooks without valid HMAC/token signatures (dev/testing only; logs a warning). Must be the literal string `1` — `true`/`yes`/`on` deliberately do **not** enable the bypass, so it cannot be switched on by a stray truthy value. |
@@ -114,10 +117,10 @@ Neither knob affects the exit code — `PRXREF_FAIL_ON` is the only one that can
 
 ## Environment Cross-Check & Defaults
 
-The tables above define all **30** configuration keys in `src/prxref/config.py` (`_DEFAULTS`), and every one of them appears in `.env.example`:
+The tables above define all **33** configuration keys in `src/prxref/config.py` (`_DEFAULTS`), and every one of them appears in `.env.example`:
 
 - **LLM / Pipeline (20):** `PRXREF_LLM_BACKEND`, `PRXREF_LLM_BASE_URL`, `PRXREF_LLM_API_KEY`, `PRXREF_LLM_MODELS`, `PRXREF_LLM_REASONING_EFFORT`, `PRXREF_LLM_MAX_TOKENS`, `PRXREF_LLM_TIMEOUT`, `PRXREF_LLM_TEMPERATURE`, `PRXREF_CONFIDENCE_FLOOR`, `PRXREF_MAX_ERROR_FINDINGS`, `PRXREF_MAX_CHUNKS`, `PRXREF_CHUNK_TOKEN_BUDGET`, `PRXREF_CHUNK_MAX_FILES`, `PRXREF_CHUNK_CONTEXT_LINES`, `PRXREF_MAX_WORKERS`, `PRXREF_MAX_INLINE_COMMENTS`, `PRXREF_DRY_RUN`, `PRXREF_FAIL_ON`, `PRXREF_POST_MODE`, `PRXREF_POST_VERDICT`
-- **Per-Forge Auth (6):** `PRXREF_BITBUCKET_TOKEN`, `PRXREF_BITBUCKET_USER`, `PRXREF_BITBUCKET_APP_PASSWORD`, `PRXREF_GITHUB_TOKEN`, `PRXREF_GITHUB_ENTERPRISE_TOKEN`, `PRXREF_GITLAB_TOKEN`
+- **Per-Forge Auth (9):** `PRXREF_BITBUCKET_TOKEN`, `PRXREF_BITBUCKET_USER`, `PRXREF_BITBUCKET_APP_PASSWORD`, `PRXREF_BITBUCKET_SERVER_TOKEN`, `PRXREF_BITBUCKET_SERVER_USER`, `PRXREF_BITBUCKET_SERVER_PASSWORD`, `PRXREF_GITHUB_TOKEN`, `PRXREF_GITHUB_ENTERPRISE_TOKEN`, `PRXREF_GITLAB_TOKEN`
 - **Webhooks (4):** `PRXREF_BITBUCKET_WEBHOOK_SECRET`, `PRXREF_GITHUB_WEBHOOK_SECRET`, `PRXREF_GITLAB_WEBHOOK_SECRET`, `PRXREF_ALLOW_UNSIGNED`
 
-*(30 configuration keys, plus one deprecated alias — `PRXREF_MAX_ERRORS` for `PRXREF_MAX_ERROR_FINDINGS` — for 31 accepted variable names.)*
+*(33 configuration keys, plus one deprecated alias — `PRXREF_MAX_ERRORS` for `PRXREF_MAX_ERROR_FINDINGS` — for 34 accepted variable names.)*

--- a/docs/forges.md
+++ b/docs/forges.md
@@ -96,6 +96,11 @@ paging rather than `page`/`pagelen`. It therefore gets its own adapter.
   - `https://{host}/users/{userslug}/repos/{slug}/pull-requests/{number}` (personal repository)
   - Either shape behind a deployment context path, e.g. `https://{host}/bitbucket/projects/...`
   - A trailing route (`/overview`, `/diff`, …) is tolerated and normalized away.
+  - The REST form of any of the above — `https://{host}{context}/rest/api/1.0/projects/...`,
+    plus other version numbers and the `/rest/api/latest` alias — is accepted and normalized
+    back to the browse URL. Server is the only forge here whose REST URL has the same path
+    shape as its browse URL, so an unstripped `/rest/api/1.0` reads as a context path and gets
+    replayed in front of the API base.
 - **Project Key Note:** a personal repository browses under `/users/{slug}` but is
   addressed in the API as the project key `~{slug}`. `PRRef.owner` always holds the
   API form, so every request path is built identically for both kinds.

--- a/docs/forges.md
+++ b/docs/forges.md
@@ -92,8 +92,8 @@ paging rather than `page`/`pagelen`. It therefore gets its own adapter.
 
 - **Forge Identifier:** `bitbucket-server`
 - **Supported URL Shapes:**
-  - `https://{host}/projects/{PROJECTKEY}/repos/{slug}/pull-requests/{number}`
-  - `https://{host}/users/{userslug}/repos/{slug}/pull-requests/{number}` (personal repository)
+  - `http(s)://{host}/projects/{PROJECTKEY}/repos/{slug}/pull-requests/{number}`
+  - `http(s)://{host}/users/{userslug}/repos/{slug}/pull-requests/{number}` (personal repository)
   - Either shape behind a deployment context path, e.g. `https://{host}/bitbucket/projects/...`
   - A trailing route (`/overview`, `/diff`, …) is tolerated and normalized away.
   - The REST form of any of the above — `https://{host}{context}/rest/api/1.0/projects/...`,
@@ -101,6 +101,12 @@ paging rather than `page`/`pagelen`. It therefore gets its own adapter.
     back to the browse URL. Server is the only forge here whose REST URL has the same path
     shape as its browse URL, so an unstripped `/rest/api/1.0` reads as a context path and gets
     replayed in front of the API base.
+- **Scheme Note:** the scheme of the URL you pass is preserved, not normalized to
+  `https`. A Data Center standalone install serves plain HTTP on port 7990, so
+  `http://{host}:7990/projects/...` is the product's out-of-the-box shape; the
+  normalized `PRRef.url` and every API request keep that scheme. `HTTP://` is
+  lowercased. This adapter is the exception — the other three build their API base
+  URL as `https://` regardless of the scheme given.
 - **Project Key Note:** a personal repository browses under `/users/{slug}` but is
   addressed in the API as the project key `~{slug}`. `PRRef.owner` always holds the
   API form, so every request path is built identically for both kinds.
@@ -117,7 +123,8 @@ paging rather than `page`/`pagelen`. It therefore gets its own adapter.
     `PRXREF_GITHUB_TOKEN`.
   - `PRXREF_BITBUCKET_SERVER_USER` + `PRXREF_BITBUCKET_SERVER_PASSWORD` (HTTP Basic fallback)
 - **API Endpoints & Behavior:**
-  - **Base URL:** `https://{host}{context}/rest/api/1.0/projects/{key}/repos/{slug}/pull-requests/{number}`
+  - **Base URL:** `{scheme}://{host}{context}/rest/api/1.0/projects/{key}/repos/{slug}/pull-requests/{number}`,
+    where `{scheme}` is the one the PR URL was given with.
   - **Metadata:** `GET` on the base URL. Branches and SHAs come from `fromRef`/`toRef`
     (`displayId`, `latestCommit`); author from `author.user.name`, falling back to
     its `slug` then `displayName`.

--- a/docs/forges.md
+++ b/docs/forges.md
@@ -1,16 +1,16 @@
 # Forge Integrations & Webhooks
 
-`prxref` provides unified pull/merge request reviews across Bitbucket Cloud, GitHub (Cloud and Enterprise Server), and GitLab (SaaS and self-hosted).
+`prxref` provides unified pull/merge request reviews across Bitbucket (Cloud and Server / Data Center), GitHub (Cloud and Enterprise Server), and GitLab (SaaS and self-hosted).
 
 ## Supported Hosts
 
 | Forge | Cloud | Self-hosted |
 |---|---|---|
-| **Bitbucket** | `bitbucket.org` only | **Not supported** — Bitbucket Server / Data Center has no adapter |
+| **Bitbucket** | `bitbucket.org` | Supported — Bitbucket Server / Data Center, any host, including a deployment context path |
 | **GitHub** | `github.com` | Supported — GitHub Enterprise Server, any host |
 | **GitLab** | `gitlab.com` | Supported — any host, including nested subgroups |
 
-The asymmetry is real and worth stating plainly: GitHub and GitLab are host-agnostic because their self-hosted products speak the same REST API as their SaaS ones, differing only in base URL (`/api/v3` for GHES, `/api/v4` for every GitLab). Bitbucket Server / Data Center does not — it exposes a different API surface (`/rest/api/1.0`) with different resource shapes, so supporting it means writing a fourth adapter, not setting a base URL. See [Bitbucket Server / Data Center](#bitbucket-server--data-center-unsupported).
+Every host is covered, but not by the same means. GitHub and GitLab are host-agnostic within one adapter each, because their self-hosted products speak the same REST API as their SaaS ones, differing only in base URL (`/api/v3` for GHES, `/api/v4` for every GitLab). Bitbucket is not: Server / Data Center exposes a different API surface (`/rest/api/1.0`) with different resource shapes, so it is a fourth adapter rather than a base-URL setting, selected automatically from the URL. See [Bitbucket Server / Data Center](#4-bitbucket-server--data-center).
 
 ---
 
@@ -32,23 +32,9 @@ The asymmetry is real and worth stating plainly: GitHub and GitLab are host-agno
   - **Thread List:** `GET /2.0/repositories/{owner}/{repo}/pullrequests/{number}/comments` (paginated, up to 500 comments).
 - **Webhook Integration:**
   - **Event Header:** `X-Event-Key`
-  - **Accepted Events:** `pr:opened`, `pr:modified`
+  - **Accepted Events:** `pullrequest:created`, `pullrequest:updated`
+  - **Payload:** PR URL read from `pullrequest.links.html.href`.
   - **Signature Header:** `X-Hub-Signature` (HMAC-SHA256) validated against `PRXREF_BITBUCKET_WEBHOOK_SECRET`.
-
-### Bitbucket Server / Data Center (unsupported)
-
-Only `bitbucket.org` is recognized. A Bitbucket Server or Data Center URL — `https://<your-host>/projects/{KEY}/repos/{repo}/pull-requests/{n}` — is rejected by `ForgeImpl.parse_pr_url`, which checks the host before anything else:
-
-```python
-if parsed.netloc.lower() != "bitbucket.org":
-    return None
-```
-
-Two consequences follow from *where* that check sits.
-
-**Credentials are never the problem.** `parse_pr_url` is a `staticmethod` that reads no environment; auth is only consulted later, at request time. So a Server URL fails identically whether `PRXREF_BITBUCKET_TOKEN` is correct, wrong, or unset — do not go debugging the token. `detect_forge` returns `None` for the URL, and `prxref review` prints `unrecognized PR URL ...` and exits `0`, because an unusable URL is a review error and review errors never fail a build.
-
-**There is no base-URL setting that would fix it.** The Cloud API root is the module constant `_API_BASE = "https://api.bitbucket.org/2.0"`, and every request path (`/2.0/repositories/{owner}/{repo}/pullrequests/...`) is written against Cloud's v2 resource shapes. Server's `/rest/api/1.0` returns different bodies for the same concepts, so pointing this adapter at a Server host would fail on the first response rather than the first URL. Bitbucket Server support is a fourth adapter implementing the `Forge` Protocol in `forges/base.py` — see [CONTRIBUTING.md](../CONTRIBUTING.md), which is exactly the shape of contribution the Protocol exists for.
 
 ---
 
@@ -94,3 +80,61 @@ Two consequences follow from *where* that check sits.
   - **Event Header:** `X-Gitlab-Event` (normalized to `MergeRequestHook`)
   - **Accepted Actions:** `open`, `update`
   - **Signature Header:** `X-Gitlab-Token` (plain secret token) validated against `PRXREF_GITLAB_WEBHOOK_SECRET`.
+
+---
+
+## 4. Bitbucket Server / Data Center
+
+Self-hosted Bitbucket is a different product from Bitbucket Cloud, not the same
+API on another host: `/rest/api/1.0` rather than `/2.0`, project keys rather
+than workspaces, an activity feed rather than a comment list, and `start`/`limit`
+paging rather than `page`/`pagelen`. It therefore gets its own adapter.
+
+- **Forge Identifier:** `bitbucket-server`
+- **Supported URL Shapes:**
+  - `https://{host}/projects/{PROJECTKEY}/repos/{slug}/pull-requests/{number}`
+  - `https://{host}/users/{userslug}/repos/{slug}/pull-requests/{number}` (personal repository)
+  - Either shape behind a deployment context path, e.g. `https://{host}/bitbucket/projects/...`
+  - A trailing route (`/overview`, `/diff`, …) is tolerated and normalized away.
+- **Project Key Note:** a personal repository browses under `/users/{slug}` but is
+  addressed in the API as the project key `~{slug}`. `PRRef.owner` always holds the
+  API form, so every request path is built identically for both kinds.
+- **Detection Order:** `detect_forge` asks the Cloud parser before this one. The two
+  patterns are disjoint — Cloud pins `bitbucket.org` and a bare
+  `owner/repo/pull-requests/N` path, while Server requires a
+  `/projects|users/{KEY}/repos/{REPO}/` prefix — so every URL resolves the same
+  under either order. The order is defensive, not load-bearing: asking the narrower
+  parser first means a later loosening degrades into a shadowed forge rather than a
+  silently mis-routed one.
+- **Authentication Environment Variables:**
+  - `PRXREF_BITBUCKET_SERVER_TOKEN` (HTTP access token, sent as `Bearer`). Falls back to
+    `PRXREF_BITBUCKET_TOKEN` when unset, mirroring how GitHub Enterprise falls back to
+    `PRXREF_GITHUB_TOKEN`.
+  - `PRXREF_BITBUCKET_SERVER_USER` + `PRXREF_BITBUCKET_SERVER_PASSWORD` (HTTP Basic fallback)
+- **API Endpoints & Behavior:**
+  - **Base URL:** `https://{host}{context}/rest/api/1.0/projects/{key}/repos/{slug}/pull-requests/{number}`
+  - **Metadata:** `GET` on the base URL. Branches and SHAs come from `fromRef`/`toRef`
+    (`displayId`, `latestCommit`); author from `author.user.name`, falling back to
+    its `slug` then `displayName`.
+  - **Diffs:** `GET {base}.diff` with `Accept: text/plain` — the `.diff` suffix on the PR
+    resource, not a `/diff` subpath. Returns one raw unified diff for the whole PR.
+  - **Summary Comments:** `POST {base}/comments` with `{"text": body}`. Dedup scans the
+    activity feed for `<!-- prxref-summary -->` on a comment with no `anchor`, and updates
+    via `PUT {base}/comments/{id}`. **Data Center rejects an update that omits the
+    comment's current `version`**, so the lookup keeps the version, not just the id.
+  - **Inline Comments:** `POST {base}/comments` with an `anchor` object
+    (`path`, `line`, `lineType: ADDED`, `fileType: TO`) rather than Cloud's `inline.path` /
+    `inline.to`. Individual 4xx responses (line outside the diff) are skipped, as elsewhere.
+  - **Thread List:** `GET {base}/activities`, filtered to `action == "COMMENTED"`. There is
+    no flat comment listing on Data Center. Paged with `start`/`limit`, following
+    `nextPageStart` until `isLastPage`, capped at 5 pages.
+  - **Resolution:** read from whichever of `state == "RESOLVED"`, `threadResolved`, or
+    `resolvedDate` the deployment's version exposes.
+- **Webhook Integration:**
+  - **Event Header:** `X-Event-Key` (shared with Cloud; the two are told apart by event
+    name and payload shape)
+  - **Accepted Events:** `pr:opened`, `pr:modified`, `pr:from_ref_updated`
+  - **Payload:** PR URL read from the first entry of `pullRequest.links.self` — note the
+    capital `R`, and the list, both of which differ from Cloud.
+  - **Signature Header:** `X-Hub-Signature` (HMAC-SHA256) validated against
+    `PRXREF_BITBUCKET_WEBHOOK_SECRET`, the same secret Cloud uses.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prxref"
-version = "0.4.0"
+version = "0.5.0"
 description = "Fast automated AI code review for Bitbucket, GitLab, and GitHub"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/prxref/__init__.py
+++ b/src/prxref/__init__.py
@@ -1,3 +1,3 @@
 """prxref — fast automated AI code review for Bitbucket, GitLab, and GitHub."""
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/src/prxref/cli.py
+++ b/src/prxref/cli.py
@@ -281,8 +281,11 @@ def _cmd_review(args: argparse.Namespace) -> int:
 
     if result is None:
         print(
-            f"unrecognized PR URL {args.pr_url!r} — expected bitbucket.org, "
-            "github.com, or gitlab.com PR/MR link",
+            f"unrecognized PR URL {args.pr_url!r} — expected a Bitbucket "
+            "pull-requests, GitHub pull, or GitLab merge_requests link "
+            "(bitbucket.org, github.com, gitlab.com, or a self-hosted "
+            "Bitbucket Data Center, GitHub Enterprise Server, or GitLab "
+            "host); the URL must keep the forge's own path shape.",
             file=sys.stderr,
         )
         return 0

--- a/src/prxref/config.py
+++ b/src/prxref/config.py
@@ -69,9 +69,13 @@ LLM / pipeline:
                                 total-failure notice always names its status.
 
 Per-forge auth:
-  PRXREF_BITBUCKET_TOKEN        Bitbucket bearer token
-  PRXREF_BITBUCKET_USER         Bitbucket username (app-password pair)
-  PRXREF_BITBUCKET_APP_PASSWORD Bitbucket app password
+  PRXREF_BITBUCKET_TOKEN        Bitbucket Cloud bearer token
+  PRXREF_BITBUCKET_USER         Bitbucket Cloud username (app-password pair)
+  PRXREF_BITBUCKET_APP_PASSWORD Bitbucket Cloud app password
+  PRXREF_BITBUCKET_SERVER_TOKEN Bitbucket Server/Data Center HTTP access token
+                                (falls back to PRXREF_BITBUCKET_TOKEN)
+  PRXREF_BITBUCKET_SERVER_USER  Bitbucket Server username (basic-auth pair)
+  PRXREF_BITBUCKET_SERVER_PASSWORD Bitbucket Server password (basic-auth pair)
   PRXREF_GITHUB_TOKEN           GitHub token (github.com)
   PRXREF_GITHUB_ENTERPRISE_TOKEN GitHub Enterprise token (GHES hosts)
   PRXREF_GITLAB_TOKEN           GitLab token
@@ -143,6 +147,9 @@ _DEFAULTS: dict[str, object] = {
     "bitbucket_token": "",
     "bitbucket_user": "",
     "bitbucket_app_password": "",
+    "bitbucket_server_token": "",
+    "bitbucket_server_user": "",
+    "bitbucket_server_password": "",
     "github_token": "",
     "github_enterprise_token": "",
     "gitlab_token": "",
@@ -381,10 +388,11 @@ def make_forge(ref: PRRef, session=None) -> Forge:
     ``session`` optionally injects a custom ``requests.Session`` (tests,
     shared connection pools). Unknown forge names raise ``ValueError``.
     """
-    from prxref.forges import bitbucket, github, gitlab
+    from prxref.forges import bitbucket, bitbucket_server, github, gitlab
 
     impls = {
         "bitbucket": bitbucket.ForgeImpl,
+        "bitbucket-server": bitbucket_server.ForgeImpl,
         "github": github.ForgeImpl,
         "gitlab": gitlab.ForgeImpl,
     }

--- a/src/prxref/forges/base.py
+++ b/src/prxref/forges/base.py
@@ -1,9 +1,12 @@
-"""Forge contract: one Protocol, three implementations (bitbucket, github, gitlab).
+"""Forge contract: one Protocol, four implementations.
+
+The implementations are bitbucket (Cloud), bitbucket_server (Server / Data
+Center), github (Cloud and Enterprise Server) and gitlab (SaaS and self-hosted).
 
 Every value that flows through the pipeline is forge-agnostic past this module.
 Diff handling is deliberately unified: each forge returns ONE raw unified diff
-string; parsing/chunking happens downstream in triage.py, identically for all
-three forges.
+string; parsing/chunking happens downstream in triage.py, identically for every
+forge.
 """
 from __future__ import annotations
 
@@ -16,7 +19,7 @@ from typing import Protocol
 class PRRef:
     """A pull/merge request identity, normalized across forges."""
 
-    forge: str  # "bitbucket" | "github" | "gitlab"
+    forge: str  # "bitbucket" | "bitbucket-server" | "github" | "gitlab"
     host: str  # e.g. "bitbucket.org", "github.com", "gitlab.com", or self-hosted host
     owner: str  # workspace / org / group
     repo: str
@@ -91,10 +94,20 @@ class Forge(Protocol):
 
 
 def detect_forge(url: str) -> PRRef | None:
-    """Try each registered forge's URL parser in order."""
-    from . import bitbucket, github, gitlab
+    """Try each registered forge's URL parser in order.
 
-    for forge in (bitbucket, github, gitlab):
+    Bitbucket Cloud is listed before Bitbucket Server so that the more specific
+    parser gets first refusal: Cloud pins itself to bitbucket.org and to a bare
+    ``owner/repo/pull-requests/N`` path, while Server matches any host and
+    requires a ``/projects|users/KEY/repos/REPO/`` prefix. As written the two
+    patterns are disjoint — no URL matches both, so the order does not change
+    any result today. It is kept deliberately anyway: whichever parser is
+    narrower should be asked first, so that loosening one later degrades into a
+    shadowed forge rather than a silently mis-routed one.
+    """
+    from . import bitbucket, bitbucket_server, github, gitlab
+
+    for forge in (bitbucket, bitbucket_server, github, gitlab):
         ref = forge.ForgeImpl.parse_pr_url(url)
         if ref is not None:
             return ref

--- a/src/prxref/forges/bitbucket_server.py
+++ b/src/prxref/forges/bitbucket_server.py
@@ -18,7 +18,7 @@ _PAGE_LIMIT = 100
 _MAX_PAGES = 5
 
 _BBS_URL_RE = re.compile(
-    r"^https?://(?P<host>[^/]+)"
+    r"^(?P<scheme>https?)://(?P<host>[^/]+)"
     r"(?P<context>(?:/[^/]+)*?)"
     r"/(?P<kind>projects|users)/(?P<key>[^/]+)"
     r"/repos/(?P<repo>[^/]+)"
@@ -97,6 +97,13 @@ class ForgeImpl:
         A PR's REST URL (``/rest/api/1.0/projects/KEY/repos/...``) is accepted
         too and normalized back to the browse URL, because ``url`` is the link
         a human clicks and the value every request path is rebuilt from.
+
+        The scheme is carried through rather than normalized to ``https``. A
+        Data Center standalone install serves plain HTTP on port 7990, so
+        ``http://`` is the product's out-of-the-box shape and not an edge case;
+        rewriting it would aim every request at a TLS listener that is not
+        there. The scheme is lowercased, so ``HTTP://`` round-trips as
+        ``http://``.
         """
         try:
             parsed = urlparse(url)
@@ -110,6 +117,7 @@ class ForgeImpl:
         if not match:
             return None
 
+        scheme = match.group("scheme").lower()
         host = match.group("host")
         context = _strip_rest_prefix(match.group("context") or "")
         kind = match.group("kind").lower()
@@ -126,7 +134,7 @@ class ForgeImpl:
             kind, key = "users", key[1:]
         owner = f"~{key}" if kind == "users" else key
         normalized_url = (
-            f"https://{host}{context}/{kind}/{key}/repos/{repo}/pull-requests/{number}"
+            f"{scheme}://{host}{context}/{kind}/{key}/repos/{repo}/pull-requests/{number}"
         )
 
         return PRRef(
@@ -171,11 +179,24 @@ class ForgeImpl:
             return _strip_rest_prefix(match.group("context") or "")
         return ""
 
+    def _scheme(self, ref: PRRef) -> str:
+        """Recover the URL scheme from the normalized URL.
+
+        ``PRRef`` carries no scheme field, so the value is read back out of
+        ``url`` exactly as the deployment context path is. A hand-built PRRef
+        whose ``url`` this pattern does not match falls back to ``https``,
+        which is what every other adapter here assumes.
+        """
+        match = _BBS_URL_RE.match(ref.url)
+        if match:
+            return match.group("scheme").lower()
+        return "https"
+
     def _pr_url(self, ref: PRRef, suffix: str = "") -> str:
         """Construct the Data Center API endpoint URL for a given PR."""
         context = self._context_path(ref)
         base = (
-            f"https://{ref.host}{context}/rest/api/1.0"
+            f"{self._scheme(ref)}://{ref.host}{context}/rest/api/1.0"
             f"/projects/{ref.owner}/repos/{ref.repo}/pull-requests/{ref.number}"
         )
         return f"{base}{suffix}"

--- a/src/prxref/forges/bitbucket_server.py
+++ b/src/prxref/forges/bitbucket_server.py
@@ -1,0 +1,359 @@
+"""Bitbucket Server / Data Center REST API v1 forge implementation."""
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Sequence
+from urllib.parse import urlparse
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+from prxref.forges.base import InlineComment, PRData, PRRef, Thread
+
+_REQUEST_TIMEOUT = (10.0, 30.0)
+_SUMMARY_MARKER = "<!-- prxref-summary -->"
+_PAGE_LIMIT = 100
+_MAX_PAGES = 5
+
+_BBS_URL_RE = re.compile(
+    r"^https?://(?P<host>[^/]+)"
+    r"(?P<context>(?:/[^/]+)*?)"
+    r"/(?P<kind>projects|users)/(?P<key>[^/]+)"
+    r"/repos/(?P<repo>[^/]+)"
+    r"/pull-requests/(?P<number>\d+)(?:/.*)?$",
+    re.IGNORECASE,
+)
+
+
+def _make_retry_session() -> requests.Session:
+    """Build a requests.Session with bounded retries for transient failures."""
+    session = requests.Session()
+    retry = Retry(
+        total=3,
+        connect=3,
+        read=3,
+        status=3,
+        backoff_factor=1.0,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=frozenset(
+            ["GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS"]
+        ),
+        respect_retry_after_header=True,
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
+
+
+_DEFAULT_SESSION = _make_retry_session()
+
+
+class ForgeImpl:
+    """Bitbucket Server / Data Center Forge adapter."""
+
+    name: str = "bitbucket-server"
+
+    def __init__(self, session: requests.Session | None = None) -> None:
+        """Initialize with an optional custom requests Session."""
+        self._session = session if session is not None else _DEFAULT_SESSION
+
+    @staticmethod
+    def parse_pr_url(url: str) -> PRRef | None:
+        """Return a PRRef if this forge recognizes the URL, else None.
+
+        Accepts both project (``/projects/KEY/repos/...``) and personal
+        (``/users/slug/repos/...``) repositories, and tolerates a deployment
+        context path such as ``/bitbucket`` between host and route. ``owner``
+        holds the API project key, which for a personal repository is the user
+        slug prefixed with ``~``.
+        """
+        try:
+            parsed = urlparse(url)
+        except ValueError:
+            return None
+
+        if not parsed.scheme or not parsed.netloc:
+            return None
+
+        match = _BBS_URL_RE.match(url)
+        if not match:
+            return None
+
+        host = match.group("host")
+        context = match.group("context") or ""
+        kind = match.group("kind").lower()
+        key = match.group("key")
+        repo = match.group("repo")
+        number = int(match.group("number"))
+
+        # Personal repositories live under the ~slug project key in the API,
+        # while their browsable URL uses /users/slug. Keep the API form in
+        # `owner` so every request path is built the same way for both kinds.
+        owner = f"~{key}" if kind == "users" else key
+        normalized_url = (
+            f"https://{host}{context}/{kind}/{key}/repos/{repo}/pull-requests/{number}"
+        )
+
+        return PRRef(
+            forge="bitbucket-server",
+            host=host,
+            owner=owner,
+            repo=repo,
+            number=number,
+            url=normalized_url,
+        )
+
+    def _get_auth(self) -> tuple[dict[str, str], tuple[str, str] | None]:
+        """Read authentication credentials from the environment at call time.
+
+        Mirrors how GitHub Enterprise resolves its token: the deployment-specific
+        variable wins, and the Cloud variable is the fallback so a single-forge
+        setup does not need two names.
+        """
+        token = (
+            os.environ.get("PRXREF_BITBUCKET_SERVER_TOKEN")
+            or os.environ.get("PRXREF_BITBUCKET_TOKEN")
+        )
+        if token:
+            return {"Authorization": f"Bearer {token}"}, None
+
+        user = os.environ.get("PRXREF_BITBUCKET_SERVER_USER")
+        password = os.environ.get("PRXREF_BITBUCKET_SERVER_PASSWORD")
+        if user and password:
+            return {}, (user, password)
+
+        return {}, None
+
+    def _context_path(self, ref: PRRef) -> str:
+        """Recover the deployment context path from the normalized URL."""
+        match = _BBS_URL_RE.match(ref.url)
+        if match:
+            return match.group("context") or ""
+        return ""
+
+    def _pr_url(self, ref: PRRef, suffix: str = "") -> str:
+        """Construct the Data Center API endpoint URL for a given PR."""
+        context = self._context_path(ref)
+        base = (
+            f"https://{ref.host}{context}/rest/api/1.0"
+            f"/projects/{ref.owner}/repos/{ref.repo}/pull-requests/{ref.number}"
+        )
+        return f"{base}{suffix}"
+
+    def get_pr(self, ref: PRRef) -> PRData:
+        """Fetch normalized PR metadata."""
+        headers, auth = self._get_auth()
+        resp = self._session.get(
+            self._pr_url(ref), headers=headers, auth=auth, timeout=_REQUEST_TIMEOUT
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        author_user = ((data.get("author") or {}).get("user")) or {}
+        author = (
+            author_user.get("name")
+            or author_user.get("slug")
+            or author_user.get("displayName")
+            or ""
+        )
+
+        from_ref = data.get("fromRef") or {}
+        to_ref = data.get("toRef") or {}
+
+        return PRData(
+            title=data.get("title") or "",
+            description=data.get("description") or "",
+            author=author,
+            source_branch=from_ref.get("displayId") or "",
+            target_branch=to_ref.get("displayId") or "",
+            source_sha=from_ref.get("latestCommit") or "",
+            target_sha=to_ref.get("latestCommit") or "",
+            raw=data,
+        )
+
+    def get_diff(self, ref: PRRef) -> str:
+        """Fetch the raw unified diff of the PR (all files)."""
+        headers, auth = self._get_auth()
+        headers["Accept"] = "text/plain"
+        resp = self._session.get(
+            self._pr_url(ref, ".diff"),
+            headers=headers,
+            auth=auth,
+            timeout=_REQUEST_TIMEOUT,
+        )
+        resp.raise_for_status()
+        diff_text = resp.text
+
+        if not diff_text or not diff_text.strip():
+            raise ValueError(
+                "Empty or truncated diff received from Bitbucket Server for "
+                f"{ref.owner}/{ref.repo}#{ref.number}"
+            )
+
+        return diff_text
+
+    def _iter_activities(self, ref: PRRef) -> list[dict]:
+        """Page through the PR activity feed and return the COMMENTED entries.
+
+        Data Center has no flat comment listing: comments arrive as entries in
+        an activity stream, paged with start/limit rather than a next URL.
+        """
+        headers, auth = self._get_auth()
+        url = self._pr_url(ref, "/activities")
+        entries: list[dict] = []
+        start = 0
+
+        for _ in range(_MAX_PAGES):
+            resp = self._session.get(
+                url,
+                params={"start": start, "limit": _PAGE_LIMIT},
+                headers=headers,
+                auth=auth,
+                timeout=_REQUEST_TIMEOUT,
+            )
+            resp.raise_for_status()
+            page = resp.json()
+
+            for item in page.get("values", []):
+                if (item.get("action") or "").upper() == "COMMENTED":
+                    entries.append(item)
+
+            if page.get("isLastPage", True):
+                break
+            next_start = page.get("nextPageStart")
+            if next_start is None:
+                break
+            start = next_start
+
+        return entries
+
+    def post_summary(self, ref: PRRef, body: str) -> None:
+        """Post (or update) the top-level review summary comment.
+
+        Data Center rejects a comment update that does not carry the comment's
+        current ``version``, so the existing comment is looked up for its
+        version rather than only its id.
+        """
+        headers, auth = self._get_auth()
+        url = self._pr_url(ref, "/comments")
+
+        existing: dict | None = None
+        try:
+            for item in self._iter_activities(ref):
+                comment = item.get("comment") or {}
+                if comment.get("anchor"):
+                    continue
+                if _SUMMARY_MARKER in (comment.get("text") or ""):
+                    existing = comment
+                    break
+        except requests.RequestException:
+            existing = None
+
+        if existing is not None and existing.get("id") is not None:
+            resp = self._session.put(
+                f"{url}/{existing['id']}",
+                json={"text": body, "version": existing.get("version", 0)},
+                headers=headers,
+                auth=auth,
+                timeout=_REQUEST_TIMEOUT,
+            )
+            resp.raise_for_status()
+            return
+
+        resp = self._session.post(
+            url,
+            json={"text": body},
+            headers=headers,
+            auth=auth,
+            timeout=_REQUEST_TIMEOUT,
+        )
+        resp.raise_for_status()
+
+    def post_inline_comments(self, ref: PRRef, comments: Sequence[InlineComment]) -> int:
+        """Post inline comments; returns the number actually posted."""
+        if not comments:
+            return 0
+
+        headers, auth = self._get_auth()
+        url = self._pr_url(ref, "/comments")
+        posted = 0
+
+        for comment in comments:
+            payload = {
+                "text": comment.body,
+                # lineType ADDED + fileType TO anchor the comment to the line in
+                # the NEW file, matching InlineComment's contract. A line that is
+                # not part of the diff is a 4xx, skipped like every other forge.
+                "anchor": {
+                    "line": comment.line,
+                    "lineType": "ADDED",
+                    "fileType": "TO",
+                    "path": comment.path,
+                },
+            }
+            try:
+                resp = self._session.post(
+                    url,
+                    json=payload,
+                    headers=headers,
+                    auth=auth,
+                    timeout=_REQUEST_TIMEOUT,
+                )
+                if 200 <= resp.status_code < 300:
+                    posted += 1
+                elif 400 <= resp.status_code < 500:
+                    continue
+                else:
+                    resp.raise_for_status()
+            except requests.RequestException:
+                continue
+
+        return posted
+
+    def list_threads(self, ref: PRRef) -> list[Thread]:
+        """List existing discussion threads on the PR."""
+        threads: list[Thread] = []
+        try:
+            entries = self._iter_activities(ref)
+        except requests.RequestException:
+            return threads
+
+        for item in entries:
+            comment = item.get("comment") or {}
+            if not comment:
+                continue
+
+            anchor = comment.get("anchor") or {}
+            path = anchor.get("path")
+            line = anchor.get("line")
+
+            author = comment.get("author") or {}
+            threads.append(
+                Thread(
+                    path=path,
+                    line=line,
+                    resolved=_is_resolved(comment),
+                    author=author.get("name") or author.get("slug") or "",
+                    body_snippet=(comment.get("text") or "")[:200],
+                )
+            )
+
+        return threads
+
+
+def _is_resolved(comment: dict) -> bool:
+    """Decide whether a Data Center comment counts as already-addressed.
+
+    DC exposes resolution three ways depending on version and on whether the
+    comment is the thread root: an explicit RESOLVED state, a threadResolved
+    flag, or a resolvedDate on the root comment.
+    """
+    if (comment.get("state") or "").upper() == "RESOLVED":
+        return True
+    if comment.get("threadResolved"):
+        return True
+    return comment.get("resolvedDate") is not None

--- a/src/prxref/forges/bitbucket_server.py
+++ b/src/prxref/forges/bitbucket_server.py
@@ -26,6 +26,29 @@ _BBS_URL_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Data Center serves its REST API at /rest/api/<version> — 1.0 today, plus the
+# /latest alias — hanging directly off any deployment context path. A PR's REST
+# URL therefore has the same shape as its browse URL, so the pattern above
+# captures /rest/api/1.0 as if it were a context path, and every request built
+# from it would carry /rest/api/1.0 twice. Strip it back off before it is
+# mistaken for a context.
+_BBS_REST_PREFIX_RE = re.compile(
+    r"(?P<context>(?:/[^/]+)*?)/rest/api/(?:latest|\d+(?:\.\d+)*)",
+    re.IGNORECASE,
+)
+
+
+def _strip_rest_prefix(context: str) -> str:
+    """Return a captured context path with any REST API prefix removed.
+
+    ``/rest/api/1.0`` yields ``""``; a REST prefix sitting under a genuine
+    deployment context, ``/bitbucket/rest/api/latest``, yields ``/bitbucket``.
+    Anything that is not a REST prefix is returned untouched, so a deployment
+    context that merely happens to contain ``/rest`` survives.
+    """
+    match = _BBS_REST_PREFIX_RE.fullmatch(context)
+    return match.group("context") if match else context
+
 
 def _make_retry_session() -> requests.Session:
     """Build a requests.Session with bounded retries for transient failures."""
@@ -70,6 +93,10 @@ class ForgeImpl:
         context path such as ``/bitbucket`` between host and route. ``owner``
         holds the API project key, which for a personal repository is the user
         slug prefixed with ``~``.
+
+        A PR's REST URL (``/rest/api/1.0/projects/KEY/repos/...``) is accepted
+        too and normalized back to the browse URL, because ``url`` is the link
+        a human clicks and the value every request path is rebuilt from.
         """
         try:
             parsed = urlparse(url)
@@ -84,7 +111,7 @@ class ForgeImpl:
             return None
 
         host = match.group("host")
-        context = match.group("context") or ""
+        context = _strip_rest_prefix(match.group("context") or "")
         kind = match.group("kind").lower()
         key = match.group("key")
         repo = match.group("repo")
@@ -92,7 +119,11 @@ class ForgeImpl:
 
         # Personal repositories live under the ~slug project key in the API,
         # while their browsable URL uses /users/slug. Keep the API form in
-        # `owner` so every request path is built the same way for both kinds.
+        # `owner` so every request path is built the same way for both kinds,
+        # and put the browse form in the normalized URL — a REST URL names the
+        # repository the API way, so it arrives here as /projects/~slug.
+        if kind == "projects" and len(key) > 1 and key.startswith("~"):
+            kind, key = "users", key[1:]
         owner = f"~{key}" if kind == "users" else key
         normalized_url = (
             f"https://{host}{context}/{kind}/{key}/repos/{repo}/pull-requests/{number}"
@@ -129,10 +160,15 @@ class ForgeImpl:
         return {}, None
 
     def _context_path(self, ref: PRRef) -> str:
-        """Recover the deployment context path from the normalized URL."""
+        """Recover the deployment context path from the normalized URL.
+
+        ``parse_pr_url`` has already stripped any REST prefix out of ``url``;
+        stripping again here costs nothing and keeps a hand-built PRRef from
+        reintroducing the doubled ``/rest/api/1.0`` this recovers into.
+        """
         match = _BBS_URL_RE.match(ref.url)
         if match:
-            return match.group("context") or ""
+            return _strip_rest_prefix(match.group("context") or "")
         return ""
 
     def _pr_url(self, ref: PRRef, suffix: str = "") -> str:

--- a/src/prxref/webhooks.py
+++ b/src/prxref/webhooks.py
@@ -28,7 +28,16 @@ _ALLOW_UNSIGNED_ENV = "PRXREF_ALLOW_UNSIGNED"
 _UNSIGNED_PREFIX = "unsigned:"
 
 _GITHUB_ACTIONS = ("opened", "synchronize")
-_BITBUCKET_EVENTS = ("pr:opened", "pr:modified")
+# Bitbucket Cloud and Bitbucket Server both announce themselves with
+# X-Event-Key, but they do not share an event vocabulary. Cloud sends
+# pullrequest:created / pullrequest:updated; Server sends pr:opened /
+# pr:modified, plus pr:from_ref_updated when the source branch moves.
+# Only the Server names were listed here, against a payload extractor that
+# reads Cloud's shape — so a real Cloud webhook was rejected as "not
+# reviewable" while a real Server webhook failed to yield a URL.
+_BITBUCKET_CLOUD_EVENTS = ("pullrequest:created", "pullrequest:updated")
+_BITBUCKET_SERVER_EVENTS = ("pr:opened", "pr:modified", "pr:from_ref_updated")
+_BITBUCKET_EVENTS = _BITBUCKET_CLOUD_EVENTS + _BITBUCKET_SERVER_EVENTS
 _GITLAB_ACTIONS = ("open", "update")
 
 
@@ -37,8 +46,10 @@ def verify_signature(body: bytes, headers: dict) -> tuple[bool, str]:
 
     The source forge is detected from its event header (X-GitHub-Event,
     X-Event-Key, or X-Gitlab-Event; header names are case-insensitive).
-    Signature is checked per forge: GitHub HMAC-SHA256 in
-    X-Hub-Signature-256, Bitbucket HMAC-SHA256 in X-Hub-Signature,
+    Bitbucket Cloud and Bitbucket Server are both recognized by X-Event-Key
+    and share one verification path; their event names and payload shapes
+    differ and both are accepted. Signature is checked per forge: GitHub
+    HMAC-SHA256 in X-Hub-Signature-256, Bitbucket HMAC-SHA256 in X-Hub-Signature,
     GitLab plain token in X-Gitlab-Token — each against its
     PRXREF_<FORGE>_WEBHOOK_SECRET env var. Only PR-open/update events are
     reviewable; anything else is ignored.
@@ -203,12 +214,33 @@ def _verify_bitbucket(body: bytes, h: dict) -> tuple[bool, str]:
     payload = _parse_json(body)
     if payload is None:
         return False, "invalid JSON payload"
-    pullrequest = payload.get("pullrequest") or {}
-    links = pullrequest.get("links") or {}
-    url = (links.get("html") or {}).get("href")
+    url = _bitbucket_pr_url(payload)
     if not url:
-        return False, "bitbucket payload missing pullrequest.links.html.href"
+        return False, (
+            "bitbucket payload missing pullrequest.links.html.href "
+            "(Cloud) or pullRequest.links.self[].href (Server)"
+        )
     return _result(state, url)
+
+
+def _bitbucket_pr_url(payload: dict) -> str | None:
+    """Extract the PR URL from either a Cloud or a Server webhook payload.
+
+    Cloud nests the browsable link under pullrequest.links.html.href. Server
+    uses a differently-cased pullRequest key and exposes the link as the first
+    entry of a links.self list.
+    """
+    cloud = payload.get("pullrequest") or {}
+    url = ((cloud.get("links") or {}).get("html") or {}).get("href")
+    if url:
+        return url
+
+    server = payload.get("pullRequest") or {}
+    self_links = (server.get("links") or {}).get("self") or []
+    for link in self_links:
+        if isinstance(link, dict) and link.get("href"):
+            return link["href"]
+    return None
 
 
 def _verify_gitlab(body: bytes, h: dict) -> tuple[bool, str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -226,7 +226,16 @@ class TestReviewSubcommand:
 
         _, err = capsys.readouterr()
         assert "unrecognized PR URL" in err
-        assert "bitbucket.org" in err
+        # The hint has to name both halves of every forge. Three of the four
+        # adapters serve self-hosted deployments, so listing only the SaaS
+        # hostnames would read as a restriction that no longer exists.
+        for forge in ("Bitbucket", "GitHub", "GitLab"):
+            assert forge in err
+        for host in ("bitbucket.org", "github.com", "gitlab.com"):
+            assert host in err
+        assert "self-hosted" in err
+        assert "Bitbucket Data Center" in err
+        assert "GitHub Enterprise Server" in err
 
     def test_orchestration_exception_exits_0_non_blocking(
         self, fake_runtime, monkeypatch, capsys

--- a/tests/test_forge_bitbucket_server.py
+++ b/tests/test_forge_bitbucket_server.py
@@ -1,0 +1,456 @@
+"""Tests for the Bitbucket Server / Data Center forge adapter."""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from prxref.config import make_forge
+from prxref.forges.base import InlineComment, PRRef, detect_forge
+from prxref.forges.bitbucket_server import ForgeImpl
+from prxref.triage import parse_unified_diff
+
+
+def _mock_response(status_code=200, json_data=None, text=""):
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status_code
+    resp.ok = 200 <= status_code < 300
+    if json_data is not None:
+        resp.json.return_value = json_data
+        resp.text = json.dumps(json_data)
+    else:
+        resp.text = text
+        resp.json.side_effect = ValueError("No JSON")
+    resp.raise_for_status.side_effect = (
+        None if resp.ok else requests.HTTPError(response=resp)
+    )
+    return resp
+
+
+def _ref(url="https://bitbucket.corp.example/projects/PLAT/repos/api/pull-requests/42"):
+    ref = ForgeImpl.parse_pr_url(url)
+    assert ref is not None
+    return ref
+
+
+# --- URL parsing ------------------------------------------------------------
+
+
+def test_parse_pr_url_project_repo():
+    ref = ForgeImpl.parse_pr_url(
+        "https://bitbucket.corp.example/projects/PLAT/repos/api/pull-requests/42"
+    )
+    assert ref is not None
+    assert ref.forge == "bitbucket-server"
+    assert ref.host == "bitbucket.corp.example"
+    assert ref.owner == "PLAT"
+    assert ref.repo == "api"
+    assert ref.number == 42
+    assert ref.url == (
+        "https://bitbucket.corp.example/projects/PLAT/repos/api/pull-requests/42"
+    )
+
+
+def test_parse_pr_url_personal_repo_becomes_tilde_project_key():
+    # A personal repo browses as /users/jdoe but is addressed as ~jdoe in the
+    # API. Getting this wrong 404s every request for a personal-repo PR.
+    ref = ForgeImpl.parse_pr_url(
+        "https://bitbucket.corp.example/users/jdoe/repos/scratch/pull-requests/7"
+    )
+    assert ref is not None
+    assert ref.owner == "~jdoe"
+    assert ref.repo == "scratch"
+    assert ref.url == (
+        "https://bitbucket.corp.example/users/jdoe/repos/scratch/pull-requests/7"
+    )
+
+
+def test_parse_pr_url_with_deployment_context_path():
+    # Data Center is commonly reverse-proxied under a context path.
+    ref = ForgeImpl.parse_pr_url(
+        "https://tools.corp.example/bitbucket/projects/PLAT/repos/api/pull-requests/9"
+    )
+    assert ref is not None
+    assert ref.host == "tools.corp.example"
+    assert ref.owner == "PLAT"
+    assert ref.number == 9
+    assert "/bitbucket/projects/PLAT/" in ref.url
+
+
+def test_parse_pr_url_tolerates_trailing_route():
+    ref = ForgeImpl.parse_pr_url(
+        "https://bitbucket.corp.example/projects/PLAT/repos/api/pull-requests/42/overview"
+    )
+    assert ref is not None
+    assert ref.number == 42
+    assert ref.url.endswith("/pull-requests/42")
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://bitbucket.org/team/repo/pull-requests/1",  # Cloud, not Server
+        "https://github.com/o/r/pull/1",
+        "https://gitlab.com/g/p/-/merge_requests/1",
+        "https://bitbucket.corp.example/projects/PLAT/repos/api/pull-requests/abc",
+        "https://bitbucket.corp.example/projects/PLAT/repos/api",
+        "not-a-url",
+        "",
+    ],
+)
+def test_parse_pr_url_rejects_foreign_urls(url):
+    assert ForgeImpl.parse_pr_url(url) is None
+
+
+def test_cloud_url_is_not_claimed_by_server():
+    # Ordering guard: bitbucket.org must resolve to the Cloud adapter even
+    # though the Server pattern matches any host.
+    ref = detect_forge("https://bitbucket.org/team/repo/pull-requests/1")
+    assert ref is not None
+    assert ref.forge == "bitbucket"
+
+
+def test_detect_forge_routes_server_urls_here():
+    ref = detect_forge(
+        "https://bitbucket.corp.example/projects/PLAT/repos/api/pull-requests/42"
+    )
+    assert ref is not None
+    assert ref.forge == "bitbucket-server"
+
+
+def test_make_forge_builds_the_server_adapter():
+    forge = make_forge(_ref(), session=MagicMock())
+    assert isinstance(forge, ForgeImpl)
+    assert forge.name == "bitbucket-server"
+
+
+# --- auth -------------------------------------------------------------------
+
+
+def test_bearer_token_prefers_the_server_specific_variable(monkeypatch):
+    monkeypatch.setenv("PRXREF_BITBUCKET_SERVER_TOKEN", "dc-token")
+    monkeypatch.setenv("PRXREF_BITBUCKET_TOKEN", "cloud-token")
+    headers, auth = ForgeImpl()._get_auth()
+    assert headers == {"Authorization": "Bearer dc-token"}
+    assert auth is None
+
+
+def test_bearer_token_falls_back_to_the_cloud_variable(monkeypatch):
+    monkeypatch.delenv("PRXREF_BITBUCKET_SERVER_TOKEN", raising=False)
+    monkeypatch.setenv("PRXREF_BITBUCKET_TOKEN", "cloud-token")
+    headers, auth = ForgeImpl()._get_auth()
+    assert headers == {"Authorization": "Bearer cloud-token"}
+
+
+def test_basic_auth_when_no_token(monkeypatch):
+    for var in ("PRXREF_BITBUCKET_SERVER_TOKEN", "PRXREF_BITBUCKET_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("PRXREF_BITBUCKET_SERVER_USER", "svc")
+    monkeypatch.setenv("PRXREF_BITBUCKET_SERVER_PASSWORD", "pw")
+    headers, auth = ForgeImpl()._get_auth()
+    assert headers == {}
+    assert auth == ("svc", "pw")
+
+
+# --- API paths --------------------------------------------------------------
+
+
+def test_api_path_uses_rest_v1_and_the_project_key():
+    session = MagicMock()
+    session.get.return_value = _mock_response(json_data={})
+    ForgeImpl(session=session).get_pr(_ref())
+    url = session.get.call_args[0][0]
+    assert url == (
+        "https://bitbucket.corp.example/rest/api/1.0"
+        "/projects/PLAT/repos/api/pull-requests/42"
+    )
+
+
+def test_api_path_preserves_the_context_path():
+    session = MagicMock()
+    session.get.return_value = _mock_response(json_data={})
+    ref = _ref("https://tools.corp.example/bitbucket/projects/PLAT/repos/api/pull-requests/9")
+    ForgeImpl(session=session).get_pr(ref)
+    assert session.get.call_args[0][0].startswith(
+        "https://tools.corp.example/bitbucket/rest/api/1.0/"
+    )
+
+
+def test_api_path_for_a_personal_repo():
+    session = MagicMock()
+    session.get.return_value = _mock_response(json_data={})
+    ref = _ref("https://bitbucket.corp.example/users/jdoe/repos/scratch/pull-requests/7")
+    ForgeImpl(session=session).get_pr(ref)
+    assert "/projects/~jdoe/repos/scratch/" in session.get.call_args[0][0]
+
+
+# --- get_pr -----------------------------------------------------------------
+
+
+def test_get_pr_normalizes_data_center_fields():
+    payload = {
+        "title": "Add retry",
+        "description": "why",
+        "author": {"user": {"name": "jdoe", "displayName": "J Doe"}},
+        "fromRef": {"displayId": "feature/x", "latestCommit": "aaa111"},
+        "toRef": {"displayId": "main", "latestCommit": "bbb222"},
+    }
+    session = MagicMock()
+    session.get.return_value = _mock_response(json_data=payload)
+
+    data = ForgeImpl(session=session).get_pr(_ref())
+    assert data.title == "Add retry"
+    assert data.description == "why"
+    assert data.author == "jdoe"
+    assert data.source_branch == "feature/x"
+    assert data.target_branch == "main"
+    assert data.source_sha == "aaa111"
+    assert data.target_sha == "bbb222"
+    assert data.raw is payload
+
+
+def test_get_pr_tolerates_a_sparse_payload():
+    session = MagicMock()
+    session.get.return_value = _mock_response(json_data={})
+    data = ForgeImpl(session=session).get_pr(_ref())
+    assert data.title == ""
+    assert data.author == ""
+    assert data.source_sha == ""
+
+
+# --- get_diff ---------------------------------------------------------------
+
+
+DIFF = """diff --git a/src/app.py b/src/app.py
+--- a/src/app.py
++++ b/src/app.py
+@@ -1,3 +1,4 @@
+ import os
++import sys
+
+ def main():
+"""
+
+
+def test_get_diff_uses_the_dot_diff_suffix_and_parses():
+    session = MagicMock()
+    session.get.return_value = _mock_response(text=DIFF)
+    diff = ForgeImpl(session=session).get_diff(_ref())
+
+    assert session.get.call_args[0][0].endswith("/pull-requests/42.diff")
+    files = parse_unified_diff(diff)
+    assert len(files) == 1
+    assert files[0].new_path == "src/app.py"
+
+
+def test_get_diff_rejects_an_empty_body():
+    session = MagicMock()
+    session.get.return_value = _mock_response(text="   ")
+    with pytest.raises(ValueError, match="Empty or truncated diff"):
+        ForgeImpl(session=session).get_diff(_ref())
+
+
+# --- comments ---------------------------------------------------------------
+
+
+def test_post_inline_comment_anchors_to_the_new_file():
+    session = MagicMock()
+    session.post.return_value = _mock_response(status_code=201, json_data={"id": 1})
+
+    posted = ForgeImpl(session=session).post_inline_comments(
+        _ref(), [InlineComment(path="src/app.py", line=12, body="nit")]
+    )
+    assert posted == 1
+    payload = session.post.call_args.kwargs["json"]
+    assert payload["text"] == "nit"
+    assert payload["anchor"] == {
+        "line": 12,
+        "lineType": "ADDED",
+        "fileType": "TO",
+        "path": "src/app.py",
+    }
+
+
+def test_post_inline_comments_skips_4xx_and_keeps_going():
+    session = MagicMock()
+    session.post.side_effect = [
+        _mock_response(status_code=400),
+        _mock_response(status_code=201, json_data={"id": 2}),
+    ]
+    posted = ForgeImpl(session=session).post_inline_comments(
+        _ref(),
+        [
+            InlineComment(path="a.py", line=1, body="x"),
+            InlineComment(path="b.py", line=2, body="y"),
+        ],
+    )
+    assert posted == 1
+
+
+def test_post_inline_comments_no_op_on_empty_list():
+    session = MagicMock()
+    assert ForgeImpl(session=session).post_inline_comments(_ref(), []) == 0
+    session.post.assert_not_called()
+
+
+def test_post_summary_creates_when_absent():
+    session = MagicMock()
+    session.get.return_value = _mock_response(
+        json_data={"values": [], "isLastPage": True}
+    )
+    session.post.return_value = _mock_response(status_code=201, json_data={"id": 5})
+
+    ForgeImpl(session=session).post_summary(_ref(), "summary body")
+    assert session.post.call_args.kwargs["json"] == {"text": "summary body"}
+    session.put.assert_not_called()
+
+
+def test_post_summary_updates_and_sends_the_version():
+    # Data Center rejects a comment update that omits the current version.
+    session = MagicMock()
+    session.get.return_value = _mock_response(
+        json_data={
+            "values": [
+                {
+                    "action": "COMMENTED",
+                    "comment": {
+                        "id": 77,
+                        "version": 3,
+                        "text": "old <!-- prxref-summary -->",
+                    },
+                }
+            ],
+            "isLastPage": True,
+        }
+    )
+    session.put.return_value = _mock_response(json_data={"id": 77})
+
+    ForgeImpl(session=session).post_summary(_ref(), "new body")
+    session.post.assert_not_called()
+    assert session.put.call_args[0][0].endswith("/comments/77")
+    assert session.put.call_args.kwargs["json"] == {"text": "new body", "version": 3}
+
+
+def test_post_summary_ignores_an_inline_comment_carrying_the_marker():
+    session = MagicMock()
+    session.get.return_value = _mock_response(
+        json_data={
+            "values": [
+                {
+                    "action": "COMMENTED",
+                    "comment": {
+                        "id": 9,
+                        "version": 1,
+                        "text": "quoted <!-- prxref-summary -->",
+                        "anchor": {"path": "a.py", "line": 3},
+                    },
+                }
+            ],
+            "isLastPage": True,
+        }
+    )
+    session.post.return_value = _mock_response(status_code=201, json_data={"id": 10})
+
+    ForgeImpl(session=session).post_summary(_ref(), "body")
+    session.put.assert_not_called()
+    session.post.assert_called_once()
+
+
+# --- threads ----------------------------------------------------------------
+
+
+def test_list_threads_reads_the_activity_feed():
+    session = MagicMock()
+    session.get.return_value = _mock_response(
+        json_data={
+            "values": [
+                {
+                    "action": "COMMENTED",
+                    "comment": {
+                        "text": "please fix",
+                        "author": {"name": "reviewer"},
+                        "anchor": {"path": "src/app.py", "line": 12},
+                        "state": "OPEN",
+                    },
+                },
+                {"action": "APPROVED", "user": {"name": "someone"}},
+                {
+                    "action": "COMMENTED",
+                    "comment": {
+                        "text": "done",
+                        "author": {"name": "author"},
+                        "anchor": {"path": "src/app.py", "line": 30},
+                        "state": "RESOLVED",
+                    },
+                },
+            ],
+            "isLastPage": True,
+        }
+    )
+
+    threads = ForgeImpl(session=session).list_threads(_ref())
+    assert len(threads) == 2  # the APPROVED activity is not a thread
+    assert threads[0].path == "src/app.py"
+    assert threads[0].line == 12
+    assert threads[0].author == "reviewer"
+    assert threads[0].resolved is False
+    assert threads[1].resolved is True
+
+
+def test_list_threads_follows_start_limit_pagination():
+    session = MagicMock()
+    session.get.side_effect = [
+        _mock_response(
+            json_data={
+                "values": [{"action": "COMMENTED", "comment": {"text": "one"}}],
+                "isLastPage": False,
+                "nextPageStart": 100,
+            }
+        ),
+        _mock_response(
+            json_data={
+                "values": [{"action": "COMMENTED", "comment": {"text": "two"}}],
+                "isLastPage": True,
+            }
+        ),
+    ]
+
+    threads = ForgeImpl(session=session).list_threads(_ref())
+    assert [t.body_snippet for t in threads] == ["one", "two"]
+    assert session.get.call_args_list[1].kwargs["params"]["start"] == 100
+
+
+def test_list_threads_returns_empty_on_transport_error():
+    session = MagicMock()
+    session.get.side_effect = requests.ConnectionError("down")
+    assert ForgeImpl(session=session).list_threads(_ref()) == []
+
+
+@pytest.mark.parametrize(
+    "comment,expected",
+    [
+        ({"state": "RESOLVED"}, True),
+        ({"threadResolved": True}, True),
+        ({"resolvedDate": 1700000000}, True),
+        ({"state": "OPEN"}, False),
+        ({}, False),
+    ],
+)
+def test_resolution_is_read_from_any_of_the_three_shapes(comment, expected):
+    session = MagicMock()
+    session.get.return_value = _mock_response(
+        json_data={
+            "values": [{"action": "COMMENTED", "comment": {"text": "x", **comment}}],
+            "isLastPage": True,
+        }
+    )
+    threads = ForgeImpl(session=session).list_threads(_ref())
+    assert threads[0].resolved is expected
+
+
+def test_ref_round_trips_through_the_protocol_dataclass():
+    ref = _ref()
+    assert isinstance(ref, PRRef)
+    assert ForgeImpl.parse_pr_url(ref.url) == ref

--- a/tests/test_forge_bitbucket_server.py
+++ b/tests/test_forge_bitbucket_server.py
@@ -88,6 +88,32 @@ def test_parse_pr_url_tolerates_trailing_route():
     assert ref.url.endswith("/pull-requests/42")
 
 
+def test_parse_pr_url_preserves_a_plain_http_scheme():
+    # Data Center's standalone install serves plain HTTP on :7990, so an
+    # http:// PR URL is the out-of-the-box shape, not an edge case. The pattern
+    # accepts the scheme, so normalization must keep it: rewriting it to https
+    # points every later request at a TLS listener that is not there.
+    ref = ForgeImpl.parse_pr_url(
+        "http://bitbucket.internal:7990/projects/PLAT/repos/api/pull-requests/42"
+    )
+    assert ref is not None
+    assert ref.host == "bitbucket.internal:7990"
+    assert ref.url == (
+        "http://bitbucket.internal:7990/projects/PLAT/repos/api/pull-requests/42"
+    )
+    # The normalized URL must parse back to itself, or the scheme is lost the
+    # second time a PRRef is rebuilt from its own url.
+    assert ForgeImpl.parse_pr_url(ref.url) == ref
+
+
+def test_parse_pr_url_lowercases_an_uppercase_scheme():
+    ref = ForgeImpl.parse_pr_url(
+        "HTTP://bitbucket.corp.example/projects/PLAT/repos/api/pull-requests/42"
+    )
+    assert ref is not None
+    assert ref.url.startswith("http://bitbucket.corp.example/")
+
+
 def test_parse_pr_url_normalizes_a_rest_api_url_to_the_browse_url():
     # /rest/api/1.0 is a route, not a deployment context path. Captured as a
     # context it gets replayed into the API base, so every request path carries
@@ -253,6 +279,36 @@ def test_api_path_preserves_the_context_path():
     assert session.get.call_args[0][0].startswith(
         "https://tools.corp.example/bitbucket/rest/api/1.0/"
     )
+
+
+def test_api_path_preserves_a_plain_http_scheme():
+    # The scheme parsed off the PR URL has to reach the API base. Hardcoding
+    # https here sends every request to a TLS port an http-only deployment is
+    # not listening on, and the failure names a URL the operator never typed.
+    session = MagicMock()
+    session.get.return_value = _mock_response(json_data={})
+    ref = _ref("http://bitbucket.internal:7990/projects/PLAT/repos/api/pull-requests/42")
+    ForgeImpl(session=session).get_pr(ref)
+    assert session.get.call_args[0][0] == (
+        "http://bitbucket.internal:7990/rest/api/1.0"
+        "/projects/PLAT/repos/api/pull-requests/42"
+    )
+
+
+def test_api_path_over_http_keeps_the_context_path_and_the_rest_stripping():
+    session = MagicMock()
+    session.get.return_value = _mock_response(json_data={})
+    ref = _ref(
+        "http://tools.internal:7990/bitbucket/rest/api/latest"
+        "/projects/PLAT/repos/api/pull-requests/9"
+    )
+    ForgeImpl(session=session).get_pr(ref)
+    url = session.get.call_args[0][0]
+    assert url == (
+        "http://tools.internal:7990/bitbucket/rest/api/1.0"
+        "/projects/PLAT/repos/api/pull-requests/9"
+    )
+    assert url.count("/rest/api/") == 1
 
 
 def test_api_path_for_a_personal_repo():

--- a/tests/test_forge_bitbucket_server.py
+++ b/tests/test_forge_bitbucket_server.py
@@ -88,6 +88,83 @@ def test_parse_pr_url_tolerates_trailing_route():
     assert ref.url.endswith("/pull-requests/42")
 
 
+def test_parse_pr_url_normalizes_a_rest_api_url_to_the_browse_url():
+    # /rest/api/1.0 is a route, not a deployment context path. Captured as a
+    # context it gets replayed into the API base, so every request path carries
+    # /rest/api/1.0 twice and 404s.
+    ref = ForgeImpl.parse_pr_url(
+        "https://bitbucket.corp.example/rest/api/1.0/projects/PLAT/repos/api/pull-requests/42"
+    )
+    assert ref is not None
+    assert ref.owner == "PLAT"
+    assert ref.repo == "api"
+    assert ref.number == 42
+    assert ref.url == (
+        "https://bitbucket.corp.example/projects/PLAT/repos/api/pull-requests/42"
+    )
+
+
+def test_parse_pr_url_keeps_the_context_when_a_rest_prefix_follows_it():
+    # A reverse-proxied deployment's REST URL carries both: the context path is
+    # real and must survive, the REST prefix is not and must not.
+    ref = ForgeImpl.parse_pr_url(
+        "https://tools.corp.example/bitbucket/rest/api/1.0/projects/PLAT/repos/api/pull-requests/9"
+    )
+    assert ref is not None
+    assert ref.host == "tools.corp.example"
+    assert ref.url == (
+        "https://tools.corp.example/bitbucket/projects/PLAT/repos/api/pull-requests/9"
+    )
+
+
+@pytest.mark.parametrize("version", ["1.0", "latest", "LATEST", "2", "2.1"])
+def test_parse_pr_url_strips_any_rest_api_version_alias(version):
+    # Data Center serves the versioned path and the /latest alias alike, and the
+    # surrounding pattern is case-insensitive.
+    ref = ForgeImpl.parse_pr_url(
+        f"https://bitbucket.corp.example/rest/api/{version}/projects/PLAT/repos/api/pull-requests/42"
+    )
+    assert ref is not None
+    assert ref.url == (
+        "https://bitbucket.corp.example/projects/PLAT/repos/api/pull-requests/42"
+    )
+
+
+def test_parse_pr_url_strips_a_rest_prefix_in_any_case():
+    ref = ForgeImpl.parse_pr_url(
+        "https://bitbucket.corp.example/REST/API/1.0/projects/PLAT/repos/api/pull-requests/42"
+    )
+    assert ref is not None
+    assert ref.url == (
+        "https://bitbucket.corp.example/projects/PLAT/repos/api/pull-requests/42"
+    )
+
+
+def test_parse_pr_url_rest_form_of_a_personal_repo_normalizes_to_the_users_route():
+    # The API addresses a personal repo as the ~slug project key; it browses as
+    # /users/slug. PRRef.url is the link a human clicks, so it gets the browse
+    # form while owner keeps the API form.
+    ref = ForgeImpl.parse_pr_url(
+        "https://bitbucket.corp.example/rest/api/1.0/projects/~jdoe/repos/scratch/pull-requests/7"
+    )
+    assert ref is not None
+    assert ref.owner == "~jdoe"
+    assert ref.url == (
+        "https://bitbucket.corp.example/users/jdoe/repos/scratch/pull-requests/7"
+    )
+
+
+def test_parse_pr_url_does_not_mistake_a_repo_named_rest_for_the_api_prefix():
+    # Only a genuine /rest/api/<version> tail is stripped.
+    ref = ForgeImpl.parse_pr_url(
+        "https://bitbucket.corp.example/rest/projects/PLAT/repos/api/pull-requests/42"
+    )
+    assert ref is not None
+    assert ref.url == (
+        "https://bitbucket.corp.example/rest/projects/PLAT/repos/api/pull-requests/42"
+    )
+
+
 @pytest.mark.parametrize(
     "url",
     [
@@ -184,6 +261,38 @@ def test_api_path_for_a_personal_repo():
     ref = _ref("https://bitbucket.corp.example/users/jdoe/repos/scratch/pull-requests/7")
     ForgeImpl(session=session).get_pr(ref)
     assert "/projects/~jdoe/repos/scratch/" in session.get.call_args[0][0]
+
+
+def test_api_path_is_not_doubled_for_a_rest_form_url():
+    # Pasting a PR's REST URL into `prxref review` must not yield
+    # /rest/api/1.0/rest/api/1.0/projects/...
+    session = MagicMock()
+    session.get.return_value = _mock_response(json_data={})
+    ref = _ref(
+        "https://bitbucket.corp.example/rest/api/1.0/projects/PLAT/repos/api/pull-requests/42"
+    )
+    ForgeImpl(session=session).get_pr(ref)
+    url = session.get.call_args[0][0]
+    assert url == (
+        "https://bitbucket.corp.example/rest/api/1.0"
+        "/projects/PLAT/repos/api/pull-requests/42"
+    )
+    assert url.count("/rest/api/") == 1
+
+
+def test_api_path_from_a_rest_form_url_replays_only_the_deployment_context():
+    session = MagicMock()
+    session.get.return_value = _mock_response(json_data={})
+    ref = _ref(
+        "https://tools.corp.example/bitbucket/rest/api/latest/projects/PLAT/repos/api/pull-requests/9"
+    )
+    ForgeImpl(session=session).get_pr(ref)
+    url = session.get.call_args[0][0]
+    assert url == (
+        "https://tools.corp.example/bitbucket/rest/api/1.0"
+        "/projects/PLAT/repos/api/pull-requests/9"
+    )
+    assert url.count("/rest/api/") == 1
 
 
 # --- get_pr -----------------------------------------------------------------

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -10,6 +10,8 @@ import threading
 import types
 from http.server import ThreadingHTTPServer
 
+import pytest
+
 from prxref.webhooks import _worker_loop, make_webhook_handler, verify_signature
 
 GH_SECRET = "gh-secret"
@@ -455,3 +457,87 @@ class TestHTTPEndpoints:
         server = ThreadingHTTPServer(("127.0.0.1", 0), make_webhook_handler(review_queue))
         assert server.server_address[1] > 0
         server.server_close()
+
+
+BBS_URL = "https://bitbucket.corp.example/projects/PLAT/repos/api/pull-requests/42"
+
+
+def _bb_cloud_body(url: str = BB_URL) -> bytes:
+    """A real Bitbucket Cloud payload."""
+    return json.dumps({"pullrequest": {"links": {"html": {"href": url}}}}).encode()
+
+
+def _bb_server_body(url: str = BBS_URL) -> bytes:
+    """A real Bitbucket Server / Data Center payload.
+
+    Different key casing (pullRequest) and the browsable link is the first
+    entry of a links.self list rather than a links.html object.
+    """
+    return json.dumps({"pullRequest": {"links": {"self": [{"href": url}]}}}).encode()
+
+
+class TestBitbucketDialects:
+    """Cloud and Server both arrive as X-Event-Key and must both be accepted.
+
+    These pair each product's real event names with its real payload shape.
+    The older cases above pair a Server event key with a Cloud payload — a
+    combination neither product sends, which is how the mismatch went unnoticed:
+    only the Server event names were accepted, against a Cloud-only extractor,
+    so every genuine Cloud webhook was rejected as "not reviewable" and every
+    genuine Server webhook yielded no URL.
+    """
+
+    @pytest.mark.parametrize("event", ["pullrequest:created", "pullrequest:updated"])
+    def test_real_cloud_event_and_payload(self, monkeypatch, event):
+        monkeypatch.setenv("PRXREF_BITBUCKET_WEBHOOK_SECRET", BB_SECRET)
+        body = _bb_cloud_body()
+        headers = {"X-Event-Key": event, "X-Hub-Signature": _sign(BB_SECRET, body)}
+        ok, detail = verify_signature(body, headers)
+        assert ok is True
+        assert detail == BB_URL
+
+    @pytest.mark.parametrize(
+        "event", ["pr:opened", "pr:modified", "pr:from_ref_updated"]
+    )
+    def test_real_server_event_and_payload(self, monkeypatch, event):
+        monkeypatch.setenv("PRXREF_BITBUCKET_WEBHOOK_SECRET", BB_SECRET)
+        body = _bb_server_body()
+        headers = {"X-Event-Key": event, "X-Hub-Signature": _sign(BB_SECRET, body)}
+        ok, detail = verify_signature(body, headers)
+        assert ok is True
+        assert detail == BBS_URL
+
+    def test_server_payload_without_a_self_link_is_reported(self, monkeypatch):
+        monkeypatch.setenv("PRXREF_BITBUCKET_WEBHOOK_SECRET", BB_SECRET)
+        body = json.dumps({"pullRequest": {"links": {"self": []}}}).encode()
+        headers = {"X-Event-Key": "pr:opened", "X-Hub-Signature": _sign(BB_SECRET, body)}
+        ok, detail = verify_signature(body, headers)
+        assert ok is False
+        assert "missing" in detail
+
+    def test_an_unreviewable_bitbucket_event_is_still_ignored(self, monkeypatch):
+        monkeypatch.setenv("PRXREF_BITBUCKET_WEBHOOK_SECRET", BB_SECRET)
+        body = _bb_cloud_body()
+        headers = {
+            "X-Event-Key": "pullrequest:comment_created",
+            "X-Hub-Signature": _sign(BB_SECRET, body),
+        }
+        ok, detail = verify_signature(body, headers)
+        assert ok is False
+        assert detail.startswith("ignored:")
+
+    def test_a_server_webhook_url_routes_to_the_server_forge(self, monkeypatch):
+        # End to end: the URL the webhook hands off must be one detect_forge
+        # resolves, or the review dies one step later with "unknown forge".
+        from prxref.forges.base import detect_forge
+
+        monkeypatch.setenv("PRXREF_BITBUCKET_WEBHOOK_SECRET", BB_SECRET)
+        body = _bb_server_body()
+        headers = {"X-Event-Key": "pr:opened", "X-Hub-Signature": _sign(BB_SECRET, body)}
+        ok, url = verify_signature(body, headers)
+        assert ok is True
+        ref = detect_forge(url)
+        assert ref is not None
+        assert ref.forge == "bitbucket-server"
+        assert ref.owner == "PLAT"
+        assert ref.number == 42

--- a/uv.lock
+++ b/uv.lock
@@ -1153,7 +1153,7 @@ wheels = [
 
 [[package]]
 name = "prxref"
-version = "0.3.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
Releases the **Bitbucket Server / Data Center forge**, which has been finished and proven in real use but never shipped — it lived only on `feat/bitbucket-server-forge`, so every deployment that needed it ran a hand-maintained overlay of `bitbucket_server.py` on top of a tagged release. Releasing it is how that overlay gets deleted.

Self-hosted Bitbucket was the one supported forge family with no path at all: GitHub and GitLab each covered their self-hosted deployment, while the Bitbucket adapter pinned itself to `bitbucket.org`. Data Center is not the Cloud API on another host — `/rest/api/1.0`, project keys instead of workspaces, an activity feed instead of a comment list, `start`/`limit` paging — so it is a fourth adapter under the existing `Forge` protocol, and nothing downstream of `forges/base.py` changed.

### Not purely additive — a real bug surfaced while porting

Bitbucket webhooks were broken for **both** products. The receiver accepted only `pr:opened` / `pr:modified` — Bitbucket **Server** event names — while reading the PR URL from `pullrequest.links.html.href`, which is Bitbucket **Cloud**'s payload shape. A genuine Cloud webhook was rejected as not reviewable; a genuine Server webhook produced no URL. Both dialects now work, `pr:from_ref_updated` included. `docs/forges.md` had documented the Server event names as Cloud's; corrected.

### A claim that did not survive checking

The release plan asserted that `detect_forge` must try Cloud before Server, because Cloud's parser is the more specific of the two and Server-first would shadow Cloud URLs.

Reversing the tuple and running six URLs through `detect_forge` resolved **every case identically**. The parsers are disjoint — Cloud pins `bitbucket.org`, Server requires a `/projects|users/KEY/repos/REPO/` prefix — so no URL matches both, including the adversarial case of a `bitbucket.org` host carrying a Server-shaped path, which only Server matches under either order. The Cloud-first order is kept as defence in depth against a later loosening, but it is not load-bearing, and every document that called it so has been reworded.

### The coupling worth knowing about

Adding three config keys turned out to be a four-surface change rather than a source change. `tests/test_docs_consistency.py` compiles `docs/env-vars.md` and `.env.example` against `config._DEFAULTS` in both directions and asserts two counts built from `len(_DEFAULTS)` and `len(_LEGACY_ENV_ALIASES)`. Five tests stayed red until `_DEFAULTS`, the `config.py` docstring, `.env.example` and `docs/env-vars.md` — counts and the `Per-Forge Auth (N)` heading included — all moved together. Now 33 keys, 34 accepted names.

### Verification

```
840 passed                     uv run --extra dev pytest
All checks passed!             uv run --extra dev ruff check src/ tests/
0.5.0                          uv run prxref --version

bitbucket-server   https://bitbucket.example.com/projects/PROJ/repos/app/pull-requests/42
bitbucket          https://bitbucket.org/ws/app/pull-requests/7
github             https://github.com/o/r/pull/3
gitlab             https://gitlab.com/o/r/-/merge_requests/9

make_forge(ref) -> prxref.forges.bitbucket_server.ForgeImpl, name 'bitbucket-server'
```

Note: `uv run pytest` alone does not work in this repo — pytest is in the `dev` optional-dependency group, so it needs `uv run --extra dev pytest`. That is now recorded in `HANDOFF.md`.

🤖 Authored with Claude Code — Opus 5 (session `1722c3bc`)
