### PR TITLE
release: 0.6.0 — three ways prxref posted the same thing twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync
 
       - name: Lint with ruff
-        run: uv run --extra dev ruff check src tests
+        run: uv run ruff check src tests
 
       - name: Run tests with pytest
-        run: uv run --extra dev pytest -q
+        run: uv run pytest -q
 
   build:
     name: build

--- a/.github/workflows/prxref-review.yml
+++ b/.github/workflows/prxref-review.yml
@@ -55,5 +55,17 @@ jobs:
           PRXREF_LLM_API_KEY: ${{ secrets.PRXREF_LLM_API_KEY }}
           PRXREF_LLM_MODELS: ${{ vars.PRXREF_LLM_MODELS }}
           PRXREF_LLM_REASONING_EFFORT: ${{ vars.PRXREF_LLM_REASONING_EFFORT }}
+          # Per-WORKER-CHUNK completion budget, not a per-run one: each chunk gets
+          # its own call with this ceiling, so raising it does not multiply into a
+          # single huge request. It needs a literal fallback where the neighbours
+          # above do not, because an unset repository variable renders as the empty
+          # string and prxref then falls back to its own default of 4096 — silently
+          # restoring the bug. The configured model is a reasoning model, and the
+          # hidden reasoning trace is drawn from this same completion budget, so at
+          # 4096 the response hit finish_reason=length before the findings JSON was
+          # emitted: a real PR reviewed 2 of 4 chunks and posted "Findings may be
+          # incomplete". The same PR at 32000 completed 4/4. Override per repo by
+          # setting the variable.
+          PRXREF_LLM_MAX_TOKENS: ${{ vars.PRXREF_LLM_MAX_TOKENS || '32000' }}
         run: |
           .venv/bin/prxref review --pr-url "${{ github.event.pull_request.html_url }}" -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,29 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   per worker chunk, not per run, so raising it widens each chunk's headroom
   rather than one large request.
 
+- **A retry could post the same review comment four times.** All four forge
+  adapters built their `requests.Session` with the write verbs in
+  `allowed_methods` — `POST`, `PUT`, `DELETE`, plus `PATCH` on GitHub — against
+  a `status_forcelist` of `[429, 500, 502, 503, 504]` with `total=3`. urllib3
+  retries underneath the `requests` adapter, so what it re-sends is the whole
+  request: a comment `POST` the forge had already committed, whose `2xx` was
+  then lost on the way back — a 502 or 504 from a proxy in front of the API, or
+  a read timeout — was sent again, up to three more times, and the PR ended up
+  carrying the same summary or the same inline finding two, three, or four
+  times. Nothing downstream could notice, because from the client's side a
+  duplicated comment is a successful POST. `allowed_methods` is now
+  `GET`/`HEAD`/`OPTIONS` on all four adapters: reads still retry, writes are
+  attempted exactly once. A write that fails is left to the caller, which
+  already logs a failed post and finishes the run; a duplicated comment needs a
+  human to delete it. The one case given up is 429, where replaying a write
+  would in fact have been safe — the server is stating it did not process the
+  request — but `Retry.is_retry` tests the method before it consults
+  `status_forcelist`, so no single policy can retry a `POST` on 429 while
+  holding it back on 502, and the safe half of that pair is the one worth
+  keeping. Connection errors are unaffected and still retry for every verb:
+  urllib3 gates only its read-error path on the method, and a connection that
+  was never established carried no write to duplicate.
+
 ## [0.5.0] — 2026-08-28
 
 The self-hosted Bitbucket release. Bitbucket Server / Data Center was the one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- **Every re-review posted a second summary comment, on all four forges.**
+  Each adapter's `post_summary` is meant to find its own previous summary by
+  the hidden `<!-- prxref-summary -->` marker and update that comment instead
+  of posting beside it — but nothing ever put the marker into the body.
+  `orchestrator._render_summary` and `prompts/summary.md` render the verdict,
+  the findings and the attribution and no marker, so the lookup matched
+  nothing on the second run, and every run after the first left another
+  summary on the PR. The three adapters that looked were looking for something
+  that was never written; the fourth did not look at all (below). The marker is
+  now stamped by the adapter that searches for it — `forges/base.py` owns
+  `SUMMARY_MARKER` and an idempotent `with_summary_marker()`, so a body that
+  already carries one (a caller's, or a template's) is left alone.
+- **Bitbucket Cloud never looked for an existing summary.** Its `post_summary`
+  was an unconditional POST, with no lookup of any kind, so it duplicated on
+  every re-review even once the marker was present. It now does what the other
+  three do: walk the comment feed for a top-level comment carrying the marker
+  and `PUT` over that one. Inline comments quoting the marker are skipped, as
+  are deleted comments — Bitbucket keeps those in the feed with the body
+  blanked, and an update aimed at one lands where nobody can read it.
+- **A busy PR hid the existing summary past the end of the read.** The comment
+  and activity walks all stopped early, each in its own way: Bitbucket Cloud
+  and Data Center capped at 5 pages of 100, GitLab read one page of 50 with no
+  loop at all, and both GitHub reads went out unparameterised — one default
+  page of 30. Past that window a summary simply did not exist as far as the
+  adapter was concerned, so `post_summary` missed its own marker and posted a
+  duplicate, and `list_threads` under-reported the threads that suppress
+  already-discussed findings. Every walk now pages to the end of the feed at
+  100 per page, stopping the moment the marker turns up — the common case is
+  still one request — and the marker is searched for page by page rather than
+  after collecting the whole feed. The bound is 50 pages rather than 5, and
+  reaching it is now an error rather than a silent short read. GitLab's note
+  walk asks for oldest-first explicitly: GitLab lists notes newest-first, and
+  offset paging over a feed that grows at the front steps over entries, which
+  is the same miss by another route.
+- **A feed read that failed was treated as "no summary exists".** Bitbucket
+  Data Center caught `RequestException` and set `existing = None`; GitLab
+  caught it and left `existing_note_id` unset; GitHub branched on
+  `if list_resp.ok:` with no else. All three then fell through to the POST — so
+  a rate-limited or briefly unreachable forge turned a re-review into a second
+  summary on someone's PR. An incomplete read now raises `FeedReadError`
+  (`forges/base.py`) and no summary is posted at all. This is a deliberate
+  trade: a summary that failed to post is recoverable by re-running, and the
+  orchestrator already logs it and reports `posted=False`, while a duplicate
+  comment on a PR is not recoverable without a human deleting it. `list_threads`
+  makes the opposite trade on purpose — its output only feeds best-effort
+  dedup, and the orchestrator substitutes an empty list for any exception, so
+  raising would throw away the pages that were read. It keeps them and logs a
+  warning naming how many it got, rather than under-reporting in silence.
+
 ## [0.5.0] — 2026-08-28
 
 The self-hosted Bitbucket release. Bitbucket Server / Data Center was the one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.6.0] — 2026-08-28
+
+The duplicate-comment release. Three ways prxref could post the same thing twice,
+and the test command the repo documented but could not run.
+
 ### Changed
 
 - **The dev tools moved from a project extra to a PEP 735 dependency group, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,55 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   urllib3 gates only its read-error path on the method, and a connection that
   was never established carried no write to duplicate.
 
+- **Every re-review posted a second summary comment, on all four forges.**
+  Each adapter's `post_summary` is meant to find its own previous summary by
+  the hidden `<!-- prxref-summary -->` marker and update that comment instead
+  of posting beside it — but nothing ever put the marker into the body.
+  `orchestrator._render_summary` and `prompts/summary.md` render the verdict,
+  the findings and the attribution and no marker, so the lookup matched
+  nothing on the second run, and every run after the first left another
+  summary on the PR. The three adapters that looked were looking for something
+  that was never written; the fourth did not look at all (below). The marker is
+  now stamped by the adapter that searches for it — `forges/base.py` owns
+  `SUMMARY_MARKER` and an idempotent `with_summary_marker()`, so a body that
+  already carries one (a caller's, or a template's) is left alone.
+- **Bitbucket Cloud never looked for an existing summary.** Its `post_summary`
+  was an unconditional POST, with no lookup of any kind, so it duplicated on
+  every re-review even once the marker was present. It now does what the other
+  three do: walk the comment feed for a top-level comment carrying the marker
+  and `PUT` over that one. Inline comments quoting the marker are skipped, as
+  are deleted comments — Bitbucket keeps those in the feed with the body
+  blanked, and an update aimed at one lands where nobody can read it.
+- **A busy PR hid the existing summary past the end of the read.** The comment
+  and activity walks all stopped early, each in its own way: Bitbucket Cloud
+  and Data Center capped at 5 pages of 100, GitLab read one page of 50 with no
+  loop at all, and both GitHub reads went out unparameterised — one default
+  page of 30. Past that window a summary simply did not exist as far as the
+  adapter was concerned, so `post_summary` missed its own marker and posted a
+  duplicate, and `list_threads` under-reported the threads that suppress
+  already-discussed findings. Every walk now pages to the end of the feed at
+  100 per page, stopping the moment the marker turns up — the common case is
+  still one request — and the marker is searched for page by page rather than
+  after collecting the whole feed. The bound is 50 pages rather than 5, and
+  reaching it is now an error rather than a silent short read. GitLab's note
+  walk asks for oldest-first explicitly: GitLab lists notes newest-first, and
+  offset paging over a feed that grows at the front steps over entries, which
+  is the same miss by another route.
+- **A feed read that failed was treated as "no summary exists".** Bitbucket
+  Data Center caught `RequestException` and set `existing = None`; GitLab
+  caught it and left `existing_note_id` unset; GitHub branched on
+  `if list_resp.ok:` with no else. All three then fell through to the POST — so
+  a rate-limited or briefly unreachable forge turned a re-review into a second
+  summary on someone's PR. An incomplete read now raises `FeedReadError`
+  (`forges/base.py`) and no summary is posted at all. This is a deliberate
+  trade: a summary that failed to post is recoverable by re-running, and the
+  orchestrator already logs it and reports `posted=False`, while a duplicate
+  comment on a PR is not recoverable without a human deleting it. `list_threads`
+  makes the opposite trade on purpose — its output only feeds best-effort
+  dedup, and the orchestrator substitutes an empty list for any exception, so
+  raising would throw away the pages that were read. It keeps them and logs a
+  warning naming how many it got, rather than under-reporting in silence.
+
 ## [0.5.0] — 2026-08-28
 
 The self-hosted Bitbucket release. Bitbucket Server / Data Center was the one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- **A retry could post the same review comment four times.** All four forge
+  adapters built their `requests.Session` with the write verbs in
+  `allowed_methods` — `POST`, `PUT`, `DELETE`, plus `PATCH` on GitHub — against
+  a `status_forcelist` of `[429, 500, 502, 503, 504]` with `total=3`. urllib3
+  retries underneath the `requests` adapter, so what it re-sends is the whole
+  request: a comment `POST` the forge had already committed, whose `2xx` was
+  then lost on the way back — a 502 or 504 from a proxy in front of the API, or
+  a read timeout — was sent again, up to three more times, and the PR ended up
+  carrying the same summary or the same inline finding two, three, or four
+  times. Nothing downstream could notice, because from the client's side a
+  duplicated comment is a successful POST. `allowed_methods` is now
+  `GET`/`HEAD`/`OPTIONS` on all four adapters: reads still retry, writes are
+  attempted exactly once. A write that fails is left to the caller, which
+  already logs a failed post and finishes the run; a duplicated comment needs a
+  human to delete it. The one case given up is 429, where replaying a write
+  would in fact have been safe — the server is stating it did not process the
+  request — but `Retry.is_retry` tests the method before it consults
+  `status_forcelist`, so no single policy can retry a `POST` on 429 while
+  holding it back on 502, and the safe half of that pair is the one worth
+  keeping. Connection errors are unaffected and still retry for every verb:
+  urllib3 gates only its read-error path on the method, and a connection that
+  was never established carried no write to duplicate.
+
 ## [0.5.0] — 2026-08-28
 
 The self-hosted Bitbucket release. Bitbucket Server / Data Center was the one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- **The dev tools moved from a project extra to a PEP 735 dependency group, so
+  the test command is now the bare `uv run pytest`.** `pytest`, `pytest-cov` and
+  `ruff` lived in `[project.optional-dependencies] dev`, and `uv run` never
+  installs a project *extra* — only `--extra dev` does. On a cold checkout the
+  documented-everywhere-else `uv run pytest` therefore exited 2 with
+  `Failed to spawn: pytest / No such file or directory (os error 2)`, printed
+  immediately after a cheerful `Installed N packages`, which reads as a broken
+  virtualenv rather than a missing flag. uv installs the default `dev` group
+  automatically on both `uv run` and `uv sync`, so `[dependency-groups] dev`
+  removes the trap at its source rather than documenting around it. Every
+  surface dropped the flag with it: `uv sync`, `uv run pytest`,
+  `uv run ruff check src tests` in CI, `CONTRIBUTING.md`, `CLAUDE.md` and
+  `HANDOFF.md`.
+
+  **`pip install prxref[dev]` no longer works.** Dependency groups are a
+  lockfile-and-workspace concept: they are never written into wheel or sdist
+  metadata, so the built distribution now carries no `Provides-Extra: dev` and
+  `prxref[dev]` resolves to plain `prxref`. That failure is quiet by design on
+  pip's side: the install exits 0 having shipped none of the tools (`uv pip`
+  warns "does not have an extra named `dev`"; pip installing the wheel directly
+  says nothing at all). Contributors clone the repo and run `uv sync`; with pip,
+  install the tools directly (`pip install pytest pytest-cov ruff`). The
+  `litellm` extra is untouched — that one is a genuine runtime extra for users,
+  and `pip install 'prxref[litellm]'` still works.
+
+### Fixed
+
+- **The GitHub Actions review workflow reviewed only part of a PR and said so in
+  a banner nobody was meant to see in normal operation.**
+  `.github/workflows/prxref-review.yml` set no `PRXREF_LLM_MAX_TOKENS`, so every
+  worker call ran on prxref's built-in default of 4096. The model configured
+  there is a reasoning model, and a reasoning model draws its hidden reasoning
+  trace from the *same* completion budget as the answer — so the budget was
+  spent before the findings JSON began, the provider returned
+  `finish_reason=length`, and prxref counted that chunk as failed. Nothing about
+  the run looked wrong: HTTP 200, plausible usage numbers, exit 0. On a real PR
+  it reviewed 2 of 4 chunks and posted "Findings may be incomplete"; the same PR
+  reviewed locally at 32000 completed 4/4. The workflow now passes
+  `PRXREF_LLM_MAX_TOKENS: ${{ vars.PRXREF_LLM_MAX_TOKENS || '32000' }}` —
+  operator-tunable through a repository variable like its neighbours, but with a
+  literal fallback they do not need, because an unset variable renders as the
+  empty string and prxref falls back to the 4096 that caused this. The budget is
+  per worker chunk, not per run, so raising it widens each chunk's headroom
+  rather than one large request.
+
 ## [0.5.0] — 2026-08-28
 
 The self-hosted Bitbucket release. Bitbucket Server / Data Center was the one

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,9 +32,9 @@ auto-detects the forge.
 
 ## Commands
 
-- `uv run --extra dev pytest` — tests (pytest is a `dev` extra; the bare
-  `uv run pytest` fails with `Failed to spawn: pytest`)
-- `uv run --extra dev ruff check src tests` — lint
+- `uv run pytest` — tests (pytest lives in the `dev` dependency group, which
+  uv installs by default; it is not a project extra, so no flag is needed)
+- `uv run ruff check src tests` — lint
 - `uv run prxref review --pr-url ...` — one-shot review
 
 ## Conventions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,17 @@ prxref uses [uv](https://docs.astral.sh/uv/) for environments and locking.
 ```bash
 git clone https://github.com/sblattj/prxref
 cd prxref
-uv sync --extra dev
+uv sync
 ```
+
+The dev tools (`pytest`, `pytest-cov`, `ruff`) live in the `dev` **dependency
+group**, which uv installs by default — that is why nothing below needs a flag.
+They are deliberately not a project extra: `uv run` never installs an extra, so
+as `[project.optional-dependencies] dev` the bare `uv run pytest` died with
+`Failed to spawn: pytest`. The cost of the fix is that dependency groups are not
+published in package metadata, so **`pip install prxref[dev]` no longer works**.
+Clone the repo and `uv sync`; if you must use pip, install the tools directly
+(`pip install pytest pytest-cov ruff`).
 
 ## The Checks
 
@@ -19,8 +28,8 @@ Both must pass before a PR can merge. CI runs exactly these on Python 3.12 and
 3.13:
 
 ```bash
-uv run --extra dev pytest  # no network required (pytest is a `dev` extra)
-uv run --extra dev ruff check src tests
+uv run pytest  # no network required
+uv run ruff check src tests
 ```
 
 The suite is fully offline — every forge and LLM call is stubbed. If a change

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -49,13 +49,15 @@ Recorded because each one would have cost the next person real time.
    were the tuple at `base.py:97` and the dict at `config.py:386-390`. Cite the
    construct, not the function.
 
-3. **`uv run pytest` does not work in this repo.** pytest lives in
-   `[project.optional-dependencies] dev`, so the documented command dies with
-   `Failed to spawn: pytest / No such file or directory (os error 2)` — an error that
-   reads like a broken venv rather than a missing extra. The invocation is:
+3. **`uv run pytest` works again — the invocation is now the bare one.** It used
+   to die with `Failed to spawn: pytest / No such file or directory (os error 2)`,
+   because pytest lived in `[project.optional-dependencies] dev` and `uv run` never
+   installs a project *extra*; the error reads like a broken venv rather than a
+   missing flag. The dev tools now live in `[dependency-groups] dev`, which uv
+   installs by default, so the `--extra dev` form is gone from every surface:
 
    ```bash
-   uv run --extra dev pytest
+   uv run pytest
    ```
 
 4. **The diff direction that reads "what the branch changed" is backwards here.**
@@ -96,8 +98,8 @@ breaks those consumers.
 ## Verified at release
 
 ```
-840 passed                                    uv run --extra dev pytest
-All checks passed!                            uv run --extra dev ruff check src/ tests/
+840 passed                                    uv run pytest
+All checks passed!                            uv run ruff check src/ tests/
 0.5.0                                         uv run prxref --version
 bitbucket-server   .../projects/PROJ/repos/app/pull-requests/42
 bitbucket          https://bitbucket.org/ws/app/pull-requests/7
@@ -105,6 +107,10 @@ github             https://github.com/o/r/pull/3
 gitlab             https://gitlab.com/o/r/-/merge_requests/9
 make_forge(ref) -> prxref.forges.bitbucket_server.ForgeImpl, name 'bitbucket-server'
 ```
+
+The counts are the ones the v0.5.0 release run produced; the commands are written
+in today's form. That run spelled them `uv run --extra dev …`, which was correct
+before the dev tools moved to `[dependency-groups]` and does not work now.
 
 ## Still open — not part of this release
 
@@ -144,15 +150,12 @@ takes one on should change all four adapters in the same commit.
   existing summary, so it posts a duplicate on *every* re-review. Distinguishing
   "read failed" from "nothing found" and skipping the post is the fix, and it is the
   same three-line change in each adapter.
-- **Move the dev tools to a dependency group.** `pytest` and `ruff` are declared under
-  `[project.optional-dependencies] dev`, and `uv run` never installs a project *extra* —
-  which is why the bare `uv run pytest` fails on a cold checkout with
-  `Failed to spawn: pytest` (reproduced on a pristine `git archive` of this branch,
-  exit 2). Every doc now spells the `--extra dev` form, but replacing
-  `[project.optional-dependencies] dev` with `[dependency-groups] dev` would make the
-  bare command correct and remove the trap at its source. It is a real behaviour change
-  — the `dev` extra stops being installable as `pip install prxref[dev]` — so it needs
-  its own decision rather than riding along with a release.
+- ~~**Move the dev tools to a dependency group.**~~ **Done** — the dev tools moved
+  from `[project.optional-dependencies] dev` to `[dependency-groups] dev`, so the bare
+  `uv run pytest` and `uv run ruff check` work on a cold checkout and the `--extra dev`
+  form is gone from CI and every doc. The behaviour change was accepted deliberately:
+  dependency groups are not published in package metadata, so `pip install prxref[dev]`
+  no longer resolves the tools. See the `Unreleased` section of `CHANGELOG.md`.
 
 - **`origin/feat/bitbucket-server-forge` can be deleted** once you are satisfied with
   v0.5.0. Everything worth keeping from it is on `main`; the rest is v0.2.0-era text.
@@ -166,5 +169,5 @@ takes one on should change all four adapters in the same commit.
 | Released version | `0.5.0` (minor — new forge plus a webhook fix, nothing breaking) |
 | Registration points | the tuple in `forges/base.py`, the `impls` dict in `config.py` |
 | Version strings | `pyproject.toml`, `src/prxref/__init__.py`, and `uv.lock` |
-| Test command | `uv run --extra dev pytest` |
+| Test command | `uv run pytest` (dev tools are a `[dependency-groups]` group, not an extra) |
 | Release assets | sdist **and** wheel, both attached |

--- a/docs/forges.md
+++ b/docs/forges.md
@@ -27,9 +27,9 @@ Every host is covered, but not by the same means. GitHub and GitLab are host-agn
 - **API Endpoints & Behavior:**
   - **Metadata:** `GET /2.0/repositories/{owner}/{repo}/pullrequests/{number}`
   - **Diffs:** `GET /2.0/repositories/{owner}/{repo}/pullrequests/{number}/diff` with `Accept: text/plain`. Note that Bitbucket's `/diff` endpoint enforces an upstream size ceiling of ~5–10MB.
-  - **Summary Comments:** `POST /2.0/repositories/{owner}/{repo}/pullrequests/{number}/comments` with `{"content": {"raw": body}}`.
+  - **Summary Comments:** `POST /2.0/repositories/{owner}/{repo}/pullrequests/{number}/comments` with `{"content": {"raw": body}}`, or `PUT .../comments/{id}` when a previous prxref summary is found. The comment feed is scanned for the summary marker first, so a re-review updates its own summary rather than adding another one; inline comments and tombstoned deletions are skipped as update targets.
   - **Inline Comments:** `POST /2.0/repositories/{owner}/{repo}/pullrequests/{number}/comments` with `inline.path` and `inline.to`. Non-fatal 4xx errors on individual inline comments are skipped.
-  - **Thread List:** `GET /2.0/repositories/{owner}/{repo}/pullrequests/{number}/comments` (paginated, up to 500 comments).
+  - **Thread List:** `GET /2.0/repositories/{owner}/{repo}/pullrequests/{number}/comments`, following the cursor until the feed is exhausted. A walk that stops early logs a warning naming the count rather than silently under-reporting.
 - **Webhook Integration:**
   - **Event Header:** `X-Event-Key`
   - **Accepted Events:** `pullrequest:created`, `pullrequest:updated`
@@ -139,7 +139,10 @@ paging rather than `page`/`pagelen`. It therefore gets its own adapter.
     `inline.to`. Individual 4xx responses (line outside the diff) are skipped, as elsewhere.
   - **Thread List:** `GET {base}/activities`, filtered to `action == "COMMENTED"`. There is
     no flat comment listing on Data Center. Paged with `start`/`limit`, following
-    `nextPageStart` until `isLastPage`, capped at 5 pages.
+    `nextPageStart` until `isLastPage` or the page cap. The summary lookup exits as soon
+    as it finds the marker, so the common case is one request; exhausting the cap is an
+    error rather than a silent stop, because a summary hidden past the window is how a
+    re-review ends up posting a second one.
   - **Resolution:** read from whichever of `state == "RESOLVED"`, `threadResolved`, or
     `resolvedDate` the deployment's version exposes.
 - **Webhook Integration:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,12 +17,23 @@ Issues = "https://github.com/sblattj/prxref/issues"
 Changelog = "https://github.com/sblattj/prxref/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
+litellm = ["litellm>=1.40"]
+
+# The dev tools are a PEP 735 dependency group, NOT a project extra. uv installs
+# the default `dev` group automatically on `uv run` and `uv sync`; it installs an
+# extra only when the caller passes `--extra dev`. As an extra, the bare
+# `uv run pytest` died with `Failed to spawn: pytest` right after a cheerful
+# "Installed N packages" — which reads as a broken virtualenv, not a missing flag.
+# The trade-off is deliberate and one-way: dependency groups are not published in
+# wheel/sdist metadata, so `pip install prxref[dev]` no longer resolves them.
+# Contributors clone the repo and use uv; only `litellm` above is a real runtime
+# extra for users.
+[dependency-groups]
 dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",
     "ruff>=0.6",
 ]
-litellm = ["litellm>=1.40"]
 
 [project.scripts]
 prxref = "prxref.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prxref"
-version = "0.5.0"
+version = "0.6.0"
 description = "Fast automated AI code review for Bitbucket, GitLab, and GitHub"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/prxref/__init__.py
+++ b/src/prxref/__init__.py
@@ -1,3 +1,3 @@
 """prxref — fast automated AI code review for Bitbucket, GitLab, and GitHub."""
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/src/prxref/forges/base.py
+++ b/src/prxref/forges/base.py
@@ -62,6 +62,44 @@ class PRData:
     raw: dict  # forge-native payload, for forge-specific needs
 
 
+SUMMARY_MARKER = "<!-- prxref-summary -->"
+
+
+class FeedReadError(RuntimeError):
+    """A PR's comment/activity feed could not be read all the way to the end.
+
+    ``post_summary`` finds its own previous summary by scanning that feed for
+    ``SUMMARY_MARKER``; finding it is the only thing standing between a
+    re-review and a SECOND summary comment on someone's PR. A scan that did
+    not finish — a transport failure, a non-OK response, a page budget spent
+    before the feed ran out — therefore cannot be read as "no summary exists".
+    Every adapter raises this instead of falling through to the POST, so the
+    caller sees a review that failed to post (recoverable: re-run it) rather
+    than a duplicate comment (not recoverable without a human deleting it).
+
+    ``list_threads`` makes the opposite trade and never raises it: its output
+    only feeds best-effort dedup, and the orchestrator already substitutes an
+    empty list for any exception, so returning the pages that WERE read beats
+    throwing them away. It logs a warning instead, so the under-read is
+    visible rather than silent.
+    """
+
+
+def with_summary_marker(body: str) -> str:
+    """Return ``body`` guaranteed to carry ``SUMMARY_MARKER``.
+
+    The marker is what a later run matches on, so the adapter that looks for
+    it is also the one that has to put it there — nothing upstream of the
+    forge layer adds it, and a summary posted without it is invisible to the
+    next run's lookup, which then posts a duplicate. Idempotent: a body that
+    already carries the marker (from a template, or from a caller that stamps
+    its own) is returned untouched.
+    """
+    if SUMMARY_MARKER in body:
+        return body
+    return f"{SUMMARY_MARKER}\n{body}"
+
+
 class Forge(Protocol):
     """The contract every forge adapter implements."""
 

--- a/src/prxref/forges/bitbucket.py
+++ b/src/prxref/forges/bitbucket.py
@@ -1,19 +1,35 @@
 """Bitbucket Cloud REST API v2 forge implementation."""
 from __future__ import annotations
 
+import logging
 import os
 import re
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from urllib.parse import urlparse
 
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from prxref.forges.base import InlineComment, PRData, PRRef, Thread
+from prxref.forges.base import (
+    SUMMARY_MARKER,
+    FeedReadError,
+    InlineComment,
+    PRData,
+    PRRef,
+    Thread,
+    with_summary_marker,
+)
+
+logger = logging.getLogger(__name__)
 
 _API_BASE = "https://api.bitbucket.org/2.0"
 _REQUEST_TIMEOUT = (10.0, 30.0)
+_PAGE_SIZE = 100
+# The comment walk used to stop at 5 pages, which silently truncated dedup at
+# 500 comments. 50 puts the ceiling far past any real PR, and running out of
+# budget is now a refusal to post rather than an invisible short read.
+_MAX_PAGES = 50
 
 _BB_URL_RE = re.compile(
     r"^https?://bitbucket\.org/(?P<owner>[^/]+)/(?P<repo>[^/]+)/(?:pull-requests|pullrequests|pullrequest)/(?P<number>\d+)(?:/.*)?$",
@@ -177,18 +193,110 @@ class ForgeImpl:
 
         return diff_text
 
+    def _iter_comment_pages(self, ref: PRRef) -> Iterator[list[dict]]:
+        """Yield the PR's comments one page at a time, following ``next``.
+
+        A page at a time rather than one flat list, so a caller hunting for a
+        single comment stops at the page it appears on instead of paying for
+        the whole feed. Any read that does not reach the end — transport
+        failure, non-OK status, unparseable body, or the page budget running
+        out — raises ``FeedReadError`` instead of returning short, so no
+        caller can mistake "I stopped early" for "that was all".
+        """
+        headers, auth = self._get_auth()
+        url: str | None = self._pr_url(ref, "/comments")
+        params: dict[str, int | str] | None = {"pagelen": _PAGE_SIZE}
+        where = f"{ref.owner}/{ref.repo}#{ref.number}"
+
+        for _ in range(_MAX_PAGES):
+            try:
+                resp = self._session.get(
+                    url,
+                    params=params,
+                    headers=headers,
+                    auth=auth,
+                    timeout=_REQUEST_TIMEOUT,
+                )
+            except requests.RequestException as e:
+                raise FeedReadError(
+                    f"comment feed for {where} could not be read: {e}"
+                ) from e
+            if not resp.ok:
+                raise FeedReadError(
+                    f"comment feed for {where} returned HTTP {resp.status_code}"
+                )
+            try:
+                data = resp.json()
+            except ValueError as e:
+                raise FeedReadError(
+                    f"comment feed for {where} returned an unreadable body: {e}"
+                ) from e
+            if not isinstance(data, dict):
+                raise FeedReadError(
+                    f"comment feed for {where} returned "
+                    f"{type(data).__name__}, not a page object"
+                )
+
+            yield [v for v in (data.get("values") or []) if isinstance(v, dict)]
+
+            url = data.get("next")
+            params = None
+            if not url:
+                return
+
+        raise FeedReadError(
+            f"comment feed for {where} outran the {_MAX_PAGES}-page budget "
+            f"({_MAX_PAGES * _PAGE_SIZE} comments) without reaching the end"
+        )
+
     def post_summary(self, ref: PRRef, body: str) -> None:
-        """Post the top-level review summary comment."""
+        """Post (or update) the top-level review summary comment.
+
+        This adapter used to POST unconditionally — no lookup at all — so
+        every re-review left another summary on the PR. It now does what the
+        other three do: scan the comment feed for ``SUMMARY_MARKER`` on a
+        top-level comment and PUT over that one if it is there.
+
+        A ``FeedReadError`` from the lookup propagates rather than being
+        swallowed. A summary that fails to post is recoverable by re-running;
+        a second summary on someone's PR is not recoverable without a human
+        deleting it, so the unreadable feed loses the tie.
+        """
         headers, auth = self._get_auth()
         url = self._pr_url(ref, "/comments")
+        body = with_summary_marker(body)
+
+        existing_id = None
+        for page in self._iter_comment_pages(ref):
+            for item in page:
+                # An inline comment quoting the marker is not the summary, and
+                # a deleted comment is a slot nobody can read an update in.
+                if item.get("inline") or _is_deleted(item):
+                    continue
+                raw = (item.get("content") or {}).get("raw") or ""
+                if SUMMARY_MARKER in raw:
+                    existing_id = item.get("id")
+                    break
+            if existing_id is not None:
+                break
+
         payload = {"content": {"raw": body}}
-        resp = self._session.post(
-            url,
-            json=payload,
-            headers=headers,
-            auth=auth,
-            timeout=_REQUEST_TIMEOUT,
-        )
+        if existing_id is not None:
+            resp = self._session.put(
+                f"{url}/{existing_id}",
+                json=payload,
+                headers=headers,
+                auth=auth,
+                timeout=_REQUEST_TIMEOUT,
+            )
+        else:
+            resp = self._session.post(
+                url,
+                json=payload,
+                headers=headers,
+                auth=auth,
+                timeout=_REQUEST_TIMEOUT,
+            )
         resp.raise_for_status()
 
     def post_inline_comments(self, ref: PRRef, comments: Sequence[InlineComment]) -> int:
@@ -225,56 +333,59 @@ class ForgeImpl:
         return posted
 
     def list_threads(self, ref: PRRef) -> list[Thread]:
-        """List existing discussion threads on the PR."""
-        headers, auth = self._get_auth()
-        url: str | None = self._pr_url(ref, "/comments")
-        params: dict[str, int | str] | None = {"pagelen": 100}
+        """List existing discussion threads on the PR.
+
+        Unlike ``post_summary`` this keeps whatever it managed to read: the
+        threads only feed best-effort dedup, and the orchestrator substitutes
+        an empty list for any exception, so raising would throw away pages
+        that were read successfully. The shortfall is logged rather than
+        swallowed — an under-read here shows up as findings re-posted on a
+        re-review, with nothing in the output to explain why.
+        """
         threads: list[Thread] = []
-        page_count = 0
+        try:
+            for page in self._iter_comment_pages(ref):
+                for item in page:
+                    inline = item.get("inline")
+                    path = inline.get("path") if inline else None
+                    line = inline.get("to") if inline else None
 
-        while url and page_count < 5:
-            page_count += 1
-            resp = self._session.get(
-                url,
-                params=params,
-                headers=headers,
-                auth=auth,
-                timeout=_REQUEST_TIMEOUT,
-            )
-            resp.raise_for_status()
-            data = resp.json()
-
-            for item in data.get("values", []):
-                inline = item.get("inline")
-                path = inline.get("path") if inline else None
-                line = inline.get("to") if inline else None
-
-                is_deleted = bool(item.get("deleted", False)) or item.get("deleted_on") is not None
-                resolved = is_deleted
-
-                user = item.get("user") or item.get("author") or {}
-                author = (
-                    user.get("uuid")
-                    or user.get("nickname")
-                    or user.get("display_name")
-                    or ""
-                )
-
-                content = item.get("content") or {}
-                raw_body = content.get("raw") or ""
-                body_snippet = raw_body[:200]
-
-                threads.append(
-                    Thread(
-                        path=path,
-                        line=line,
-                        resolved=resolved,
-                        author=author,
-                        body_snippet=body_snippet,
+                    user = item.get("user") or item.get("author") or {}
+                    author = (
+                        user.get("uuid")
+                        or user.get("nickname")
+                        or user.get("display_name")
+                        or ""
                     )
-                )
 
-            url = data.get("next")
-            params = None
+                    content = item.get("content") or {}
+                    raw_body = content.get("raw") or ""
+                    body_snippet = raw_body[:200]
+
+                    threads.append(
+                        Thread(
+                            path=path,
+                            line=line,
+                            resolved=_is_deleted(item),
+                            author=author,
+                            body_snippet=body_snippet,
+                        )
+                    )
+        except FeedReadError as e:
+            logger.warning(
+                "comment feed read was incomplete for %s/%s#%s; thread dedup "
+                "is working from the %d comments that were read: %s",
+                ref.owner, ref.repo, ref.number, len(threads), e,
+            )
 
         return threads
+
+
+def _is_deleted(comment: dict) -> bool:
+    """Whether Bitbucket has tombstoned this comment.
+
+    A deleted comment stays in the feed with its body blanked. It counts as
+    resolved for dedup, and it is not a slot ``post_summary`` may update into:
+    the update would land somewhere nobody can read.
+    """
+    return bool(comment.get("deleted", False)) or comment.get("deleted_on") is not None

--- a/src/prxref/forges/bitbucket.py
+++ b/src/prxref/forges/bitbucket.py
@@ -1,19 +1,35 @@
 """Bitbucket Cloud REST API v2 forge implementation."""
 from __future__ import annotations
 
+import logging
 import os
 import re
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from urllib.parse import urlparse
 
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from prxref.forges.base import InlineComment, PRData, PRRef, Thread
+from prxref.forges.base import (
+    SUMMARY_MARKER,
+    FeedReadError,
+    InlineComment,
+    PRData,
+    PRRef,
+    Thread,
+    with_summary_marker,
+)
+
+logger = logging.getLogger(__name__)
 
 _API_BASE = "https://api.bitbucket.org/2.0"
 _REQUEST_TIMEOUT = (10.0, 30.0)
+_PAGE_SIZE = 100
+# The comment walk used to stop at 5 pages, which silently truncated dedup at
+# 500 comments. 50 puts the ceiling far past any real PR, and running out of
+# budget is now a refusal to post rather than an invisible short read.
+_MAX_PAGES = 50
 
 _BB_URL_RE = re.compile(
     r"^https?://bitbucket\.org/(?P<owner>[^/]+)/(?P<repo>[^/]+)/(?:pull-requests|pullrequests|pullrequest)/(?P<number>\d+)(?:/.*)?$",
@@ -162,18 +178,110 @@ class ForgeImpl:
 
         return diff_text
 
+    def _iter_comment_pages(self, ref: PRRef) -> Iterator[list[dict]]:
+        """Yield the PR's comments one page at a time, following ``next``.
+
+        A page at a time rather than one flat list, so a caller hunting for a
+        single comment stops at the page it appears on instead of paying for
+        the whole feed. Any read that does not reach the end — transport
+        failure, non-OK status, unparseable body, or the page budget running
+        out — raises ``FeedReadError`` instead of returning short, so no
+        caller can mistake "I stopped early" for "that was all".
+        """
+        headers, auth = self._get_auth()
+        url: str | None = self._pr_url(ref, "/comments")
+        params: dict[str, int | str] | None = {"pagelen": _PAGE_SIZE}
+        where = f"{ref.owner}/{ref.repo}#{ref.number}"
+
+        for _ in range(_MAX_PAGES):
+            try:
+                resp = self._session.get(
+                    url,
+                    params=params,
+                    headers=headers,
+                    auth=auth,
+                    timeout=_REQUEST_TIMEOUT,
+                )
+            except requests.RequestException as e:
+                raise FeedReadError(
+                    f"comment feed for {where} could not be read: {e}"
+                ) from e
+            if not resp.ok:
+                raise FeedReadError(
+                    f"comment feed for {where} returned HTTP {resp.status_code}"
+                )
+            try:
+                data = resp.json()
+            except ValueError as e:
+                raise FeedReadError(
+                    f"comment feed for {where} returned an unreadable body: {e}"
+                ) from e
+            if not isinstance(data, dict):
+                raise FeedReadError(
+                    f"comment feed for {where} returned "
+                    f"{type(data).__name__}, not a page object"
+                )
+
+            yield [v for v in (data.get("values") or []) if isinstance(v, dict)]
+
+            url = data.get("next")
+            params = None
+            if not url:
+                return
+
+        raise FeedReadError(
+            f"comment feed for {where} outran the {_MAX_PAGES}-page budget "
+            f"({_MAX_PAGES * _PAGE_SIZE} comments) without reaching the end"
+        )
+
     def post_summary(self, ref: PRRef, body: str) -> None:
-        """Post the top-level review summary comment."""
+        """Post (or update) the top-level review summary comment.
+
+        This adapter used to POST unconditionally — no lookup at all — so
+        every re-review left another summary on the PR. It now does what the
+        other three do: scan the comment feed for ``SUMMARY_MARKER`` on a
+        top-level comment and PUT over that one if it is there.
+
+        A ``FeedReadError`` from the lookup propagates rather than being
+        swallowed. A summary that fails to post is recoverable by re-running;
+        a second summary on someone's PR is not recoverable without a human
+        deleting it, so the unreadable feed loses the tie.
+        """
         headers, auth = self._get_auth()
         url = self._pr_url(ref, "/comments")
+        body = with_summary_marker(body)
+
+        existing_id = None
+        for page in self._iter_comment_pages(ref):
+            for item in page:
+                # An inline comment quoting the marker is not the summary, and
+                # a deleted comment is a slot nobody can read an update in.
+                if item.get("inline") or _is_deleted(item):
+                    continue
+                raw = (item.get("content") or {}).get("raw") or ""
+                if SUMMARY_MARKER in raw:
+                    existing_id = item.get("id")
+                    break
+            if existing_id is not None:
+                break
+
         payload = {"content": {"raw": body}}
-        resp = self._session.post(
-            url,
-            json=payload,
-            headers=headers,
-            auth=auth,
-            timeout=_REQUEST_TIMEOUT,
-        )
+        if existing_id is not None:
+            resp = self._session.put(
+                f"{url}/{existing_id}",
+                json=payload,
+                headers=headers,
+                auth=auth,
+                timeout=_REQUEST_TIMEOUT,
+            )
+        else:
+            resp = self._session.post(
+                url,
+                json=payload,
+                headers=headers,
+                auth=auth,
+                timeout=_REQUEST_TIMEOUT,
+            )
         resp.raise_for_status()
 
     def post_inline_comments(self, ref: PRRef, comments: Sequence[InlineComment]) -> int:
@@ -210,56 +318,59 @@ class ForgeImpl:
         return posted
 
     def list_threads(self, ref: PRRef) -> list[Thread]:
-        """List existing discussion threads on the PR."""
-        headers, auth = self._get_auth()
-        url: str | None = self._pr_url(ref, "/comments")
-        params: dict[str, int | str] | None = {"pagelen": 100}
+        """List existing discussion threads on the PR.
+
+        Unlike ``post_summary`` this keeps whatever it managed to read: the
+        threads only feed best-effort dedup, and the orchestrator substitutes
+        an empty list for any exception, so raising would throw away pages
+        that were read successfully. The shortfall is logged rather than
+        swallowed — an under-read here shows up as findings re-posted on a
+        re-review, with nothing in the output to explain why.
+        """
         threads: list[Thread] = []
-        page_count = 0
+        try:
+            for page in self._iter_comment_pages(ref):
+                for item in page:
+                    inline = item.get("inline")
+                    path = inline.get("path") if inline else None
+                    line = inline.get("to") if inline else None
 
-        while url and page_count < 5:
-            page_count += 1
-            resp = self._session.get(
-                url,
-                params=params,
-                headers=headers,
-                auth=auth,
-                timeout=_REQUEST_TIMEOUT,
-            )
-            resp.raise_for_status()
-            data = resp.json()
-
-            for item in data.get("values", []):
-                inline = item.get("inline")
-                path = inline.get("path") if inline else None
-                line = inline.get("to") if inline else None
-
-                is_deleted = bool(item.get("deleted", False)) or item.get("deleted_on") is not None
-                resolved = is_deleted
-
-                user = item.get("user") or item.get("author") or {}
-                author = (
-                    user.get("uuid")
-                    or user.get("nickname")
-                    or user.get("display_name")
-                    or ""
-                )
-
-                content = item.get("content") or {}
-                raw_body = content.get("raw") or ""
-                body_snippet = raw_body[:200]
-
-                threads.append(
-                    Thread(
-                        path=path,
-                        line=line,
-                        resolved=resolved,
-                        author=author,
-                        body_snippet=body_snippet,
+                    user = item.get("user") or item.get("author") or {}
+                    author = (
+                        user.get("uuid")
+                        or user.get("nickname")
+                        or user.get("display_name")
+                        or ""
                     )
-                )
 
-            url = data.get("next")
-            params = None
+                    content = item.get("content") or {}
+                    raw_body = content.get("raw") or ""
+                    body_snippet = raw_body[:200]
+
+                    threads.append(
+                        Thread(
+                            path=path,
+                            line=line,
+                            resolved=_is_deleted(item),
+                            author=author,
+                            body_snippet=body_snippet,
+                        )
+                    )
+        except FeedReadError as e:
+            logger.warning(
+                "comment feed read was incomplete for %s/%s#%s; thread dedup "
+                "is working from the %d comments that were read: %s",
+                ref.owner, ref.repo, ref.number, len(threads), e,
+            )
 
         return threads
+
+
+def _is_deleted(comment: dict) -> bool:
+    """Whether Bitbucket has tombstoned this comment.
+
+    A deleted comment stays in the feed with its body blanked. It counts as
+    resolved for dedup, and it is not a slot ``post_summary`` may update into:
+    the update would land somewhere nobody can read.
+    """
+    return bool(comment.get("deleted", False)) or comment.get("deleted_on") is not None

--- a/src/prxref/forges/bitbucket.py
+++ b/src/prxref/forges/bitbucket.py
@@ -31,9 +31,24 @@ def _make_retry_session() -> requests.Session:
         status=3,
         backoff_factor=1.0,
         status_forcelist=[429, 500, 502, 503, 504],
-        allowed_methods=frozenset(
-            ["GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS"]
-        ),
+        # Read verbs only, deliberately. urllib3 retries beneath the
+        # requests adapter, so a re-sent write is sent whole: a comment POST
+        # that commits server-side and then loses its 2xx to a 502/504 or a
+        # read timeout would be posted a second time, and the PR carries a
+        # duplicate comment — the most visible failure this tool has. No
+        # response status tells the client whether the origin processed the
+        # request, and `Retry.is_retry` tests the method before it looks at
+        # `status_forcelist`, so a single policy cannot retry a POST on 429
+        # (which the server states it did not process) while holding it back
+        # on 502. Writes are therefore left to the caller, which already logs
+        # a failed post and carries on; a duplicated comment needs a human to
+        # delete it. The other write verbs go with POST: no adapter issues a
+        # DELETE, and the summary update (PUT, or PATCH on GitHub) is at best
+        # a no-op on replay and at worst a version conflict. Connection
+        # errors are still retried for every verb: urllib3 gates only its
+        # read-error path on the method, and a connection that was never
+        # established carried no write to duplicate.
+        allowed_methods=frozenset(["GET", "HEAD", "OPTIONS"]),
         respect_retry_after_header=True,
         raise_on_status=False,
     )

--- a/src/prxref/forges/bitbucket_server.py
+++ b/src/prxref/forges/bitbucket_server.py
@@ -1,21 +1,36 @@
 """Bitbucket Server / Data Center REST API v1 forge implementation."""
 from __future__ import annotations
 
+import logging
 import os
 import re
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from urllib.parse import urlparse
 
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from prxref.forges.base import InlineComment, PRData, PRRef, Thread
+from prxref.forges.base import (
+    SUMMARY_MARKER,
+    FeedReadError,
+    InlineComment,
+    PRData,
+    PRRef,
+    Thread,
+    with_summary_marker,
+)
+
+logger = logging.getLogger(__name__)
 
 _REQUEST_TIMEOUT = (10.0, 30.0)
-_SUMMARY_MARKER = "<!-- prxref-summary -->"
 _PAGE_LIMIT = 100
-_MAX_PAGES = 5
+# 5 pages of 100 was the old ceiling: a summary sitting at activity 501 was
+# invisible, so post_summary missed its own marker and posted a second comment.
+# 50 keeps the walk bounded (a feed that long is pathological, and the budget
+# is a refusal to post rather than a silent short read) while putting the
+# ceiling far past any real PR.
+_MAX_PAGES = 50
 
 _BBS_URL_RE = re.compile(
     r"^(?P<scheme>https?)://(?P<host>[^/]+)"
@@ -268,40 +283,74 @@ class ForgeImpl:
 
         return diff_text
 
-    def _iter_activities(self, ref: PRRef) -> list[dict]:
-        """Page through the PR activity feed and return the COMMENTED entries.
+    def _iter_activity_pages(self, ref: PRRef) -> Iterator[list[dict]]:
+        """Yield the COMMENTED activity entries one page at a time.
 
         Data Center has no flat comment listing: comments arrive as entries in
         an activity stream, paged with start/limit rather than a next URL.
+
+        A page at a time rather than one flat list, so a caller that is
+        hunting for one entry stops at the page it appears on instead of
+        paying for the whole feed. Any read that does not reach the end of the
+        feed — transport failure, non-OK status, unparseable body, or the page
+        budget running out — raises ``FeedReadError`` instead of returning
+        short, so no caller can mistake "I stopped early" for "that was all".
         """
         headers, auth = self._get_auth()
         url = self._pr_url(ref, "/activities")
-        entries: list[dict] = []
+        where = f"{ref.owner}/{ref.repo}#{ref.number}"
         start = 0
 
         for _ in range(_MAX_PAGES):
-            resp = self._session.get(
-                url,
-                params={"start": start, "limit": _PAGE_LIMIT},
-                headers=headers,
-                auth=auth,
-                timeout=_REQUEST_TIMEOUT,
-            )
-            resp.raise_for_status()
-            page = resp.json()
+            try:
+                resp = self._session.get(
+                    url,
+                    params={"start": start, "limit": _PAGE_LIMIT},
+                    headers=headers,
+                    auth=auth,
+                    timeout=_REQUEST_TIMEOUT,
+                )
+            except requests.RequestException as e:
+                raise FeedReadError(
+                    f"activity feed for {where} could not be read at "
+                    f"start={start}: {e}"
+                ) from e
+            if not resp.ok:
+                raise FeedReadError(
+                    f"activity feed for {where} returned HTTP "
+                    f"{resp.status_code} at start={start}"
+                )
+            try:
+                page = resp.json()
+            except ValueError as e:
+                raise FeedReadError(
+                    f"activity feed for {where} returned an unreadable body at "
+                    f"start={start}: {e}"
+                ) from e
+            if not isinstance(page, dict):
+                raise FeedReadError(
+                    f"activity feed for {where} returned "
+                    f"{type(page).__name__}, not a page object"
+                )
 
-            for item in page.get("values", []):
-                if (item.get("action") or "").upper() == "COMMENTED":
-                    entries.append(item)
+            yield [
+                item
+                for item in (page.get("values") or [])
+                if isinstance(item, dict)
+                and (item.get("action") or "").upper() == "COMMENTED"
+            ]
 
             if page.get("isLastPage", True):
-                break
+                return
             next_start = page.get("nextPageStart")
             if next_start is None:
-                break
+                return
             start = next_start
 
-        return entries
+        raise FeedReadError(
+            f"activity feed for {where} outran the {_MAX_PAGES}-page budget "
+            f"({_MAX_PAGES * _PAGE_LIMIT} entries) without reaching the end"
+        )
 
     def post_summary(self, ref: PRRef, body: str) -> None:
         """Post (or update) the top-level review summary comment.
@@ -309,21 +358,27 @@ class ForgeImpl:
         Data Center rejects a comment update that does not carry the comment's
         current ``version``, so the existing comment is looked up for its
         version rather than only its id.
+
+        A ``FeedReadError`` from the lookup propagates rather than being
+        swallowed: it used to be caught here and turned into ``existing =
+        None``, which fell straight through to the POST and put a second
+        summary on a PR that already had one.
         """
         headers, auth = self._get_auth()
         url = self._pr_url(ref, "/comments")
+        body = with_summary_marker(body)
 
         existing: dict | None = None
-        try:
-            for item in self._iter_activities(ref):
+        for entries in self._iter_activity_pages(ref):
+            for item in entries:
                 comment = item.get("comment") or {}
                 if comment.get("anchor"):
                     continue
-                if _SUMMARY_MARKER in (comment.get("text") or ""):
+                if SUMMARY_MARKER in (comment.get("text") or ""):
                     existing = comment
                     break
-        except requests.RequestException:
-            existing = None
+            if existing is not None:
+                break
 
         if existing is not None and existing.get("id") is not None:
             resp = self._session.put(
@@ -387,31 +442,42 @@ class ForgeImpl:
         return posted
 
     def list_threads(self, ref: PRRef) -> list[Thread]:
-        """List existing discussion threads on the PR."""
+        """List existing discussion threads on the PR.
+
+        Unlike ``post_summary`` this keeps whatever it managed to read: the
+        threads only feed best-effort dedup, and the orchestrator substitutes
+        an empty list for any exception, so raising would throw away pages
+        that were read successfully. The shortfall is logged rather than
+        swallowed — an under-read here shows up as findings re-posted on a
+        re-review, with nothing in the output to explain why.
+        """
         threads: list[Thread] = []
         try:
-            entries = self._iter_activities(ref)
-        except requests.RequestException:
-            return threads
+            for entries in self._iter_activity_pages(ref):
+                for item in entries:
+                    comment = item.get("comment") or {}
+                    if not comment:
+                        continue
 
-        for item in entries:
-            comment = item.get("comment") or {}
-            if not comment:
-                continue
+                    anchor = comment.get("anchor") or {}
+                    path = anchor.get("path")
+                    line = anchor.get("line")
 
-            anchor = comment.get("anchor") or {}
-            path = anchor.get("path")
-            line = anchor.get("line")
-
-            author = comment.get("author") or {}
-            threads.append(
-                Thread(
-                    path=path,
-                    line=line,
-                    resolved=_is_resolved(comment),
-                    author=author.get("name") or author.get("slug") or "",
-                    body_snippet=(comment.get("text") or "")[:200],
-                )
+                    author = comment.get("author") or {}
+                    threads.append(
+                        Thread(
+                            path=path,
+                            line=line,
+                            resolved=_is_resolved(comment),
+                            author=author.get("name") or author.get("slug") or "",
+                            body_snippet=(comment.get("text") or "")[:200],
+                        )
+                    )
+        except FeedReadError as e:
+            logger.warning(
+                "activity feed read was incomplete for %s/%s#%s; thread dedup "
+                "is working from the %d entries that were read: %s",
+                ref.owner, ref.repo, ref.number, len(threads), e,
             )
 
         return threads

--- a/src/prxref/forges/bitbucket_server.py
+++ b/src/prxref/forges/bitbucket_server.py
@@ -1,21 +1,36 @@
 """Bitbucket Server / Data Center REST API v1 forge implementation."""
 from __future__ import annotations
 
+import logging
 import os
 import re
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from urllib.parse import urlparse
 
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from prxref.forges.base import InlineComment, PRData, PRRef, Thread
+from prxref.forges.base import (
+    SUMMARY_MARKER,
+    FeedReadError,
+    InlineComment,
+    PRData,
+    PRRef,
+    Thread,
+    with_summary_marker,
+)
+
+logger = logging.getLogger(__name__)
 
 _REQUEST_TIMEOUT = (10.0, 30.0)
-_SUMMARY_MARKER = "<!-- prxref-summary -->"
 _PAGE_LIMIT = 100
-_MAX_PAGES = 5
+# 5 pages of 100 was the old ceiling: a summary sitting at activity 501 was
+# invisible, so post_summary missed its own marker and posted a second comment.
+# 50 keeps the walk bounded (a feed that long is pathological, and the budget
+# is a refusal to post rather than a silent short read) while putting the
+# ceiling far past any real PR.
+_MAX_PAGES = 50
 
 _BBS_URL_RE = re.compile(
     r"^(?P<scheme>https?)://(?P<host>[^/]+)"
@@ -253,40 +268,74 @@ class ForgeImpl:
 
         return diff_text
 
-    def _iter_activities(self, ref: PRRef) -> list[dict]:
-        """Page through the PR activity feed and return the COMMENTED entries.
+    def _iter_activity_pages(self, ref: PRRef) -> Iterator[list[dict]]:
+        """Yield the COMMENTED activity entries one page at a time.
 
         Data Center has no flat comment listing: comments arrive as entries in
         an activity stream, paged with start/limit rather than a next URL.
+
+        A page at a time rather than one flat list, so a caller that is
+        hunting for one entry stops at the page it appears on instead of
+        paying for the whole feed. Any read that does not reach the end of the
+        feed — transport failure, non-OK status, unparseable body, or the page
+        budget running out — raises ``FeedReadError`` instead of returning
+        short, so no caller can mistake "I stopped early" for "that was all".
         """
         headers, auth = self._get_auth()
         url = self._pr_url(ref, "/activities")
-        entries: list[dict] = []
+        where = f"{ref.owner}/{ref.repo}#{ref.number}"
         start = 0
 
         for _ in range(_MAX_PAGES):
-            resp = self._session.get(
-                url,
-                params={"start": start, "limit": _PAGE_LIMIT},
-                headers=headers,
-                auth=auth,
-                timeout=_REQUEST_TIMEOUT,
-            )
-            resp.raise_for_status()
-            page = resp.json()
+            try:
+                resp = self._session.get(
+                    url,
+                    params={"start": start, "limit": _PAGE_LIMIT},
+                    headers=headers,
+                    auth=auth,
+                    timeout=_REQUEST_TIMEOUT,
+                )
+            except requests.RequestException as e:
+                raise FeedReadError(
+                    f"activity feed for {where} could not be read at "
+                    f"start={start}: {e}"
+                ) from e
+            if not resp.ok:
+                raise FeedReadError(
+                    f"activity feed for {where} returned HTTP "
+                    f"{resp.status_code} at start={start}"
+                )
+            try:
+                page = resp.json()
+            except ValueError as e:
+                raise FeedReadError(
+                    f"activity feed for {where} returned an unreadable body at "
+                    f"start={start}: {e}"
+                ) from e
+            if not isinstance(page, dict):
+                raise FeedReadError(
+                    f"activity feed for {where} returned "
+                    f"{type(page).__name__}, not a page object"
+                )
 
-            for item in page.get("values", []):
-                if (item.get("action") or "").upper() == "COMMENTED":
-                    entries.append(item)
+            yield [
+                item
+                for item in (page.get("values") or [])
+                if isinstance(item, dict)
+                and (item.get("action") or "").upper() == "COMMENTED"
+            ]
 
             if page.get("isLastPage", True):
-                break
+                return
             next_start = page.get("nextPageStart")
             if next_start is None:
-                break
+                return
             start = next_start
 
-        return entries
+        raise FeedReadError(
+            f"activity feed for {where} outran the {_MAX_PAGES}-page budget "
+            f"({_MAX_PAGES * _PAGE_LIMIT} entries) without reaching the end"
+        )
 
     def post_summary(self, ref: PRRef, body: str) -> None:
         """Post (or update) the top-level review summary comment.
@@ -294,21 +343,27 @@ class ForgeImpl:
         Data Center rejects a comment update that does not carry the comment's
         current ``version``, so the existing comment is looked up for its
         version rather than only its id.
+
+        A ``FeedReadError`` from the lookup propagates rather than being
+        swallowed: it used to be caught here and turned into ``existing =
+        None``, which fell straight through to the POST and put a second
+        summary on a PR that already had one.
         """
         headers, auth = self._get_auth()
         url = self._pr_url(ref, "/comments")
+        body = with_summary_marker(body)
 
         existing: dict | None = None
-        try:
-            for item in self._iter_activities(ref):
+        for entries in self._iter_activity_pages(ref):
+            for item in entries:
                 comment = item.get("comment") or {}
                 if comment.get("anchor"):
                     continue
-                if _SUMMARY_MARKER in (comment.get("text") or ""):
+                if SUMMARY_MARKER in (comment.get("text") or ""):
                     existing = comment
                     break
-        except requests.RequestException:
-            existing = None
+            if existing is not None:
+                break
 
         if existing is not None and existing.get("id") is not None:
             resp = self._session.put(
@@ -372,31 +427,42 @@ class ForgeImpl:
         return posted
 
     def list_threads(self, ref: PRRef) -> list[Thread]:
-        """List existing discussion threads on the PR."""
+        """List existing discussion threads on the PR.
+
+        Unlike ``post_summary`` this keeps whatever it managed to read: the
+        threads only feed best-effort dedup, and the orchestrator substitutes
+        an empty list for any exception, so raising would throw away pages
+        that were read successfully. The shortfall is logged rather than
+        swallowed — an under-read here shows up as findings re-posted on a
+        re-review, with nothing in the output to explain why.
+        """
         threads: list[Thread] = []
         try:
-            entries = self._iter_activities(ref)
-        except requests.RequestException:
-            return threads
+            for entries in self._iter_activity_pages(ref):
+                for item in entries:
+                    comment = item.get("comment") or {}
+                    if not comment:
+                        continue
 
-        for item in entries:
-            comment = item.get("comment") or {}
-            if not comment:
-                continue
+                    anchor = comment.get("anchor") or {}
+                    path = anchor.get("path")
+                    line = anchor.get("line")
 
-            anchor = comment.get("anchor") or {}
-            path = anchor.get("path")
-            line = anchor.get("line")
-
-            author = comment.get("author") or {}
-            threads.append(
-                Thread(
-                    path=path,
-                    line=line,
-                    resolved=_is_resolved(comment),
-                    author=author.get("name") or author.get("slug") or "",
-                    body_snippet=(comment.get("text") or "")[:200],
-                )
+                    author = comment.get("author") or {}
+                    threads.append(
+                        Thread(
+                            path=path,
+                            line=line,
+                            resolved=_is_resolved(comment),
+                            author=author.get("name") or author.get("slug") or "",
+                            body_snippet=(comment.get("text") or "")[:200],
+                        )
+                    )
+        except FeedReadError as e:
+            logger.warning(
+                "activity feed read was incomplete for %s/%s#%s; thread dedup "
+                "is working from the %d entries that were read: %s",
+                ref.owner, ref.repo, ref.number, len(threads), e,
             )
 
         return threads

--- a/src/prxref/forges/bitbucket_server.py
+++ b/src/prxref/forges/bitbucket_server.py
@@ -60,9 +60,24 @@ def _make_retry_session() -> requests.Session:
         status=3,
         backoff_factor=1.0,
         status_forcelist=[429, 500, 502, 503, 504],
-        allowed_methods=frozenset(
-            ["GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS"]
-        ),
+        # Read verbs only, deliberately. urllib3 retries beneath the
+        # requests adapter, so a re-sent write is sent whole: a comment POST
+        # that commits server-side and then loses its 2xx to a 502/504 or a
+        # read timeout would be posted a second time, and the PR carries a
+        # duplicate comment — the most visible failure this tool has. No
+        # response status tells the client whether the origin processed the
+        # request, and `Retry.is_retry` tests the method before it looks at
+        # `status_forcelist`, so a single policy cannot retry a POST on 429
+        # (which the server states it did not process) while holding it back
+        # on 502. Writes are therefore left to the caller, which already logs
+        # a failed post and carries on; a duplicated comment needs a human to
+        # delete it. The other write verbs go with POST: no adapter issues a
+        # DELETE, and the summary update (PUT, or PATCH on GitHub) is at best
+        # a no-op on replay and at worst a version conflict. Connection
+        # errors are still retried for every verb: urllib3 gates only its
+        # read-error path on the method, and a connection that was never
+        # established carried no write to duplicate.
+        allowed_methods=frozenset(["GET", "HEAD", "OPTIONS"]),
         respect_retry_after_header=True,
         raise_on_status=False,
     )

--- a/src/prxref/forges/github.py
+++ b/src/prxref/forges/github.py
@@ -291,7 +291,7 @@ class ForgeImpl:
         except FeedReadError as e:
             logger.warning(
                 "review-comment feed read was incomplete for %s/%s#%s; thread "
-                "dedup is working from the %d comments that were read: %s",
+                "dedup is working from the %d threads recovered so far: %s",
                 ref.owner, ref.repo, ref.number, len(threads), e,
             )
 

--- a/src/prxref/forges/github.py
+++ b/src/prxref/forges/github.py
@@ -1,22 +1,39 @@
 """GitHub forge implementation for PR metadata, diffs, comments, and threads."""
 from __future__ import annotations
 
+import logging
 import os
 import re
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from typing import Any
 
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
 
-from .base import InlineComment, PRData, PRRef, Thread
+from .base import (
+    SUMMARY_MARKER,
+    FeedReadError,
+    InlineComment,
+    PRData,
+    PRRef,
+    Thread,
+    with_summary_marker,
+)
+
+logger = logging.getLogger(__name__)
 
 _PR_URL_RE = re.compile(
     r"^https?://([^/]+)/([^/]+)/([^/]+)/pull/(\d+)(?:[/#?].*)?$",
     re.IGNORECASE,
 )
-_SUMMARY_MARKER = "<!-- prxref-summary -->"
+# Both comment reads used to go out unparameterised, which is GitHub's default
+# page of 30 and no second page: a summary or a thread past the 30th comment
+# did not exist as far as this adapter was concerned. 100 is the API maximum;
+# 50 pages puts the ceiling far past any real PR, and running out of budget is
+# a refusal to post rather than an invisible short read.
+_PAGE_SIZE = 100
+_MAX_PAGES = 50
 
 
 def _create_default_session() -> requests.Session:
@@ -115,21 +132,83 @@ class ForgeImpl:
         resp.raise_for_status()
         return resp.text
 
+    def _iter_comment_pages(
+        self, ref: PRRef, url: str, headers: dict[str, str]
+    ) -> Iterator[list[dict]]:
+        """Yield a comment listing one page at a time, oldest page first.
+
+        A page at a time rather than one flat list, so a caller hunting for a
+        single comment stops at the page it appears on instead of paying for
+        the whole feed. Any read that does not reach the end — transport
+        failure, non-OK status, unparseable body, or the page budget running
+        out — raises ``FeedReadError`` instead of returning short, so no
+        caller can mistake "I stopped early" for "that was all".
+
+        A short page ends the walk. A page that comes back exactly full costs
+        one extra request to confirm the end, which is the price of GitHub
+        stating the total nowhere in the body.
+        """
+        where = f"{ref.owner}/{ref.repo}#{ref.number}"
+        for page_number in range(1, _MAX_PAGES + 1):
+            try:
+                resp = self.session.get(
+                    url,
+                    headers=headers,
+                    params={"per_page": _PAGE_SIZE, "page": page_number},
+                )
+            except requests.RequestException as e:
+                raise FeedReadError(
+                    f"comment feed for {where} could not be read at page "
+                    f"{page_number}: {e}"
+                ) from e
+            if not resp.ok:
+                raise FeedReadError(
+                    f"comment feed for {where} returned HTTP "
+                    f"{resp.status_code} at page {page_number}"
+                )
+            try:
+                items = resp.json()
+            except ValueError as e:
+                raise FeedReadError(
+                    f"comment feed for {where} returned an unreadable body at "
+                    f"page {page_number}: {e}"
+                ) from e
+            if not isinstance(items, list):
+                raise FeedReadError(
+                    f"comment feed for {where} returned "
+                    f"{type(items).__name__}, not a list of comments"
+                )
+
+            yield [item for item in items if isinstance(item, dict)]
+
+            if len(items) < _PAGE_SIZE:
+                return
+
+        raise FeedReadError(
+            f"comment feed for {where} outran the {_MAX_PAGES}-page budget "
+            f"({_MAX_PAGES * _PAGE_SIZE} comments) without reaching the end"
+        )
+
     def post_summary(self, ref: PRRef, body: str) -> None:
-        """Post (or update) the top-level review summary comment."""
+        """Post (or update) the top-level review summary comment.
+
+        A ``FeedReadError`` from the lookup propagates. The old code branched
+        on ``if list_resp.ok:`` with no else, so a rate-limited or otherwise
+        failed listing fell straight through to the POST and put a second
+        summary on a PR that already had one.
+        """
         list_url = f"{self._api_base(ref)}/repos/{ref.owner}/{ref.repo}/issues/{ref.number}/comments"
         headers = self._headers(ref.host)
+        body = with_summary_marker(body)
 
         existing_comment_id: int | None = None
-        list_resp = self.session.get(list_url, headers=headers)
-        if list_resp.ok:
-            comments = list_resp.json()
-            if isinstance(comments, list):
-                for c in comments:
-                    c_body = c.get("body") or ""
-                    if _SUMMARY_MARKER in c_body:
-                        existing_comment_id = c.get("id")
-                        break
+        for comments in self._iter_comment_pages(ref, list_url, headers):
+            for c in comments:
+                if SUMMARY_MARKER in (c.get("body") or ""):
+                    existing_comment_id = c.get("id")
+                    break
+            if existing_comment_id is not None:
+                break
 
         if existing_comment_id is not None:
             patch_url = f"{self._api_base(ref)}/repos/{ref.owner}/{ref.repo}/issues/comments/{existing_comment_id}"
@@ -161,30 +240,42 @@ class ForgeImpl:
         return posted
 
     def list_threads(self, ref: PRRef) -> list[Thread]:
-        """List existing threads so re-reviews skip already-discussed findings."""
+        """List existing threads so re-reviews skip already-discussed findings.
+
+        Unlike ``post_summary`` this keeps whatever it managed to read: the
+        threads only feed best-effort dedup, and the orchestrator substitutes
+        an empty list for any exception, so raising would throw away pages
+        that were read successfully. The shortfall is logged rather than
+        swallowed — an under-read here shows up as findings re-posted on a
+        re-review, with nothing in the output to explain why.
+        """
         url = f"{self._api_base(ref)}/repos/{ref.owner}/{ref.repo}/pulls/{ref.number}/comments"
         headers = self._headers(ref.host)
-        resp = self.session.get(url, headers=headers)
-        resp.raise_for_status()
-        data = resp.json()
 
         threads: list[Thread] = []
-        if isinstance(data, list):
-            for item in data:
-                path = item.get("path")
-                line = item.get("line") or item.get("original_line") or item.get("position")
-                user = item.get("user") or {}
-                author = user.get("login", "") if isinstance(user, dict) else ""
-                body = item.get("body") or ""
-                snippet = body[:120]
-                threads.append(
-                    Thread(
-                        path=path,
-                        line=line,
-                        resolved=False,
-                        author=author,
-                        body_snippet=snippet,
+        try:
+            for data in self._iter_comment_pages(ref, url, headers):
+                for item in data:
+                    path = item.get("path")
+                    line = item.get("line") or item.get("original_line") or item.get("position")
+                    user = item.get("user") or {}
+                    author = user.get("login", "") if isinstance(user, dict) else ""
+                    body = item.get("body") or ""
+                    snippet = body[:120]
+                    threads.append(
+                        Thread(
+                            path=path,
+                            line=line,
+                            resolved=False,
+                            author=author,
+                            body_snippet=snippet,
+                        )
                     )
-                )
+        except FeedReadError as e:
+            logger.warning(
+                "review-comment feed read was incomplete for %s/%s#%s; thread "
+                "dedup is working from the %d comments that were read: %s",
+                ref.owner, ref.repo, ref.number, len(threads), e,
+            )
 
         return threads

--- a/src/prxref/forges/github.py
+++ b/src/prxref/forges/github.py
@@ -1,22 +1,39 @@
 """GitHub forge implementation for PR metadata, diffs, comments, and threads."""
 from __future__ import annotations
 
+import logging
 import os
 import re
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from typing import Any
 
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
 
-from .base import InlineComment, PRData, PRRef, Thread
+from .base import (
+    SUMMARY_MARKER,
+    FeedReadError,
+    InlineComment,
+    PRData,
+    PRRef,
+    Thread,
+    with_summary_marker,
+)
+
+logger = logging.getLogger(__name__)
 
 _PR_URL_RE = re.compile(
     r"^https?://([^/]+)/([^/]+)/([^/]+)/pull/(\d+)(?:[/#?].*)?$",
     re.IGNORECASE,
 )
-_SUMMARY_MARKER = "<!-- prxref-summary -->"
+# Both comment reads used to go out unparameterised, which is GitHub's default
+# page of 30 and no second page: a summary or a thread past the 30th comment
+# did not exist as far as this adapter was concerned. 100 is the API maximum;
+# 50 pages puts the ceiling far past any real PR, and running out of budget is
+# a refusal to post rather than an invisible short read.
+_PAGE_SIZE = 100
+_MAX_PAGES = 50
 
 
 def _create_default_session() -> requests.Session:
@@ -132,21 +149,83 @@ class ForgeImpl:
         resp.raise_for_status()
         return resp.text
 
+    def _iter_comment_pages(
+        self, ref: PRRef, url: str, headers: dict[str, str]
+    ) -> Iterator[list[dict]]:
+        """Yield a comment listing one page at a time, oldest page first.
+
+        A page at a time rather than one flat list, so a caller hunting for a
+        single comment stops at the page it appears on instead of paying for
+        the whole feed. Any read that does not reach the end — transport
+        failure, non-OK status, unparseable body, or the page budget running
+        out — raises ``FeedReadError`` instead of returning short, so no
+        caller can mistake "I stopped early" for "that was all".
+
+        A short page ends the walk. A page that comes back exactly full costs
+        one extra request to confirm the end, which is the price of GitHub
+        stating the total nowhere in the body.
+        """
+        where = f"{ref.owner}/{ref.repo}#{ref.number}"
+        for page_number in range(1, _MAX_PAGES + 1):
+            try:
+                resp = self.session.get(
+                    url,
+                    headers=headers,
+                    params={"per_page": _PAGE_SIZE, "page": page_number},
+                )
+            except requests.RequestException as e:
+                raise FeedReadError(
+                    f"comment feed for {where} could not be read at page "
+                    f"{page_number}: {e}"
+                ) from e
+            if not resp.ok:
+                raise FeedReadError(
+                    f"comment feed for {where} returned HTTP "
+                    f"{resp.status_code} at page {page_number}"
+                )
+            try:
+                items = resp.json()
+            except ValueError as e:
+                raise FeedReadError(
+                    f"comment feed for {where} returned an unreadable body at "
+                    f"page {page_number}: {e}"
+                ) from e
+            if not isinstance(items, list):
+                raise FeedReadError(
+                    f"comment feed for {where} returned "
+                    f"{type(items).__name__}, not a list of comments"
+                )
+
+            yield [item for item in items if isinstance(item, dict)]
+
+            if len(items) < _PAGE_SIZE:
+                return
+
+        raise FeedReadError(
+            f"comment feed for {where} outran the {_MAX_PAGES}-page budget "
+            f"({_MAX_PAGES * _PAGE_SIZE} comments) without reaching the end"
+        )
+
     def post_summary(self, ref: PRRef, body: str) -> None:
-        """Post (or update) the top-level review summary comment."""
+        """Post (or update) the top-level review summary comment.
+
+        A ``FeedReadError`` from the lookup propagates. The old code branched
+        on ``if list_resp.ok:`` with no else, so a rate-limited or otherwise
+        failed listing fell straight through to the POST and put a second
+        summary on a PR that already had one.
+        """
         list_url = f"{self._api_base(ref)}/repos/{ref.owner}/{ref.repo}/issues/{ref.number}/comments"
         headers = self._headers(ref.host)
+        body = with_summary_marker(body)
 
         existing_comment_id: int | None = None
-        list_resp = self.session.get(list_url, headers=headers)
-        if list_resp.ok:
-            comments = list_resp.json()
-            if isinstance(comments, list):
-                for c in comments:
-                    c_body = c.get("body") or ""
-                    if _SUMMARY_MARKER in c_body:
-                        existing_comment_id = c.get("id")
-                        break
+        for comments in self._iter_comment_pages(ref, list_url, headers):
+            for c in comments:
+                if SUMMARY_MARKER in (c.get("body") or ""):
+                    existing_comment_id = c.get("id")
+                    break
+            if existing_comment_id is not None:
+                break
 
         if existing_comment_id is not None:
             patch_url = f"{self._api_base(ref)}/repos/{ref.owner}/{ref.repo}/issues/comments/{existing_comment_id}"
@@ -178,30 +257,42 @@ class ForgeImpl:
         return posted
 
     def list_threads(self, ref: PRRef) -> list[Thread]:
-        """List existing threads so re-reviews skip already-discussed findings."""
+        """List existing threads so re-reviews skip already-discussed findings.
+
+        Unlike ``post_summary`` this keeps whatever it managed to read: the
+        threads only feed best-effort dedup, and the orchestrator substitutes
+        an empty list for any exception, so raising would throw away pages
+        that were read successfully. The shortfall is logged rather than
+        swallowed — an under-read here shows up as findings re-posted on a
+        re-review, with nothing in the output to explain why.
+        """
         url = f"{self._api_base(ref)}/repos/{ref.owner}/{ref.repo}/pulls/{ref.number}/comments"
         headers = self._headers(ref.host)
-        resp = self.session.get(url, headers=headers)
-        resp.raise_for_status()
-        data = resp.json()
 
         threads: list[Thread] = []
-        if isinstance(data, list):
-            for item in data:
-                path = item.get("path")
-                line = item.get("line") or item.get("original_line") or item.get("position")
-                user = item.get("user") or {}
-                author = user.get("login", "") if isinstance(user, dict) else ""
-                body = item.get("body") or ""
-                snippet = body[:120]
-                threads.append(
-                    Thread(
-                        path=path,
-                        line=line,
-                        resolved=False,
-                        author=author,
-                        body_snippet=snippet,
+        try:
+            for data in self._iter_comment_pages(ref, url, headers):
+                for item in data:
+                    path = item.get("path")
+                    line = item.get("line") or item.get("original_line") or item.get("position")
+                    user = item.get("user") or {}
+                    author = user.get("login", "") if isinstance(user, dict) else ""
+                    body = item.get("body") or ""
+                    snippet = body[:120]
+                    threads.append(
+                        Thread(
+                            path=path,
+                            line=line,
+                            resolved=False,
+                            author=author,
+                            body_snippet=snippet,
+                        )
                     )
-                )
+        except FeedReadError as e:
+            logger.warning(
+                "review-comment feed read was incomplete for %s/%s#%s; thread "
+                "dedup is working from the %d comments that were read: %s",
+                ref.owner, ref.repo, ref.number, len(threads), e,
+            )
 
         return threads

--- a/src/prxref/forges/github.py
+++ b/src/prxref/forges/github.py
@@ -26,7 +26,24 @@ def _create_default_session() -> requests.Session:
         backoff_factor=1,
         status_forcelist=[429, 500, 502, 503, 504],
         respect_retry_after_header=True,
-        allowed_methods=["GET", "POST", "PATCH", "PUT", "DELETE", "HEAD", "OPTIONS"],
+        # Read verbs only, deliberately. urllib3 retries beneath the
+        # requests adapter, so a re-sent write is sent whole: a comment POST
+        # that commits server-side and then loses its 2xx to a 502/504 or a
+        # read timeout would be posted a second time, and the PR carries a
+        # duplicate comment — the most visible failure this tool has. No
+        # response status tells the client whether the origin processed the
+        # request, and `Retry.is_retry` tests the method before it looks at
+        # `status_forcelist`, so a single policy cannot retry a POST on 429
+        # (which the server states it did not process) while holding it back
+        # on 502. Writes are therefore left to the caller, which already logs
+        # a failed post and carries on; a duplicated comment needs a human to
+        # delete it. The other write verbs go with POST: no adapter issues a
+        # DELETE, and the summary update (PUT, or PATCH on GitHub) is at best
+        # a no-op on replay and at worst a version conflict. Connection
+        # errors are still retried for every verb: urllib3 gates only its
+        # read-error path on the method, and a connection that was never
+        # established carried no write to duplicate.
+        allowed_methods=frozenset(["GET", "HEAD", "OPTIONS"]),
     )
     adapter = HTTPAdapter(max_retries=retry_strategy)
     session.mount("https://", adapter)

--- a/src/prxref/forges/gitlab.py
+++ b/src/prxref/forges/gitlab.py
@@ -1,19 +1,41 @@
 """GitLab REST API v4 forge implementation."""
 from __future__ import annotations
 
+import logging
 import os
 import re
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from urllib.parse import quote, urlparse
 
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from prxref.forges.base import InlineComment, PRData, PRRef, Thread
+from prxref.forges.base import (
+    SUMMARY_MARKER,
+    FeedReadError,
+    InlineComment,
+    PRData,
+    PRRef,
+    Thread,
+    with_summary_marker,
+)
+
+logger = logging.getLogger(__name__)
 
 _REQUEST_TIMEOUT = (10.0, 30.0)
-_SUMMARY_MARKER = "<!-- prxref-summary -->"
+# Both reads used to take a single page of 50 with no loop, so a summary or a
+# discussion past the 50th entry did not exist as far as this adapter was
+# concerned. 100 is the API maximum; 50 pages puts the ceiling far past any
+# real MR, and running out of budget is a refusal to post rather than an
+# invisible short read.
+_PAGE_SIZE = 100
+_MAX_PAGES = 50
+# Oldest-first. GitLab lists notes newest-first by default, and offset paging
+# over a feed that grows at the front skips entries: a note added between two
+# page requests shifts every later window back by one. Ascending order appends
+# at the END, past the cursor, so a walk in progress cannot step over anything.
+_NOTE_ORDER = {"order_by": "created_at", "sort": "asc"}
 
 _GL_URL_RE = re.compile(
     r"^https?://(?P<host>[^/]+)/(?P<path>.+?)/-/merge_requests/(?P<number>\d+)(?:/.*)?$",
@@ -233,28 +255,92 @@ class ForgeImpl:
 
         return "".join(diff_parts)
 
+    def _iter_pages(
+        self,
+        ref: PRRef,
+        url: str,
+        headers: dict[str, str],
+        *,
+        what: str,
+        extra_params: dict[str, str] | None = None,
+    ) -> Iterator[list[dict]]:
+        """Yield a paginated GitLab collection one page at a time.
+
+        A page at a time rather than one flat list, so a caller hunting for a
+        single entry stops at the page it appears on instead of paying for the
+        whole feed. Any read that does not reach the end — transport failure,
+        non-OK status, unparseable body, or the page budget running out —
+        raises ``FeedReadError`` instead of returning short, so no caller can
+        mistake "I stopped early" for "that was all".
+        """
+        where = f"{ref.owner}/{ref.repo}#{ref.number}"
+        for page_number in range(1, _MAX_PAGES + 1):
+            params: dict[str, int | str] = {
+                "per_page": _PAGE_SIZE,
+                "page": page_number,
+            }
+            if extra_params:
+                params.update(extra_params)
+            try:
+                resp = self._session.get(
+                    url, headers=headers, params=params, timeout=_REQUEST_TIMEOUT
+                )
+            except requests.RequestException as e:
+                raise FeedReadError(
+                    f"{what} for {where} could not be read at page "
+                    f"{page_number}: {e}"
+                ) from e
+            if not resp.ok:
+                raise FeedReadError(
+                    f"{what} for {where} returned HTTP {resp.status_code} at "
+                    f"page {page_number}"
+                )
+            try:
+                items = resp.json()
+            except ValueError as e:
+                raise FeedReadError(
+                    f"{what} for {where} returned an unreadable body at page "
+                    f"{page_number}: {e}"
+                ) from e
+            if not isinstance(items, list):
+                raise FeedReadError(
+                    f"{what} for {where} returned {type(items).__name__}, not "
+                    "a list"
+                )
+
+            yield [item for item in items if isinstance(item, dict)]
+
+            if len(items) < _PAGE_SIZE:
+                return
+
+        raise FeedReadError(
+            f"{what} for {where} outran the {_MAX_PAGES}-page budget "
+            f"({_MAX_PAGES * _PAGE_SIZE} entries) without reaching the end"
+        )
+
     def post_summary(self, ref: PRRef, body: str) -> None:
-        """Post (or update) the top-level review summary comment."""
+        """Post (or update) the top-level review summary comment.
+
+        A ``FeedReadError`` from the lookup propagates rather than being
+        swallowed: the transport error used to be caught and dropped, leaving
+        ``existing_note_id`` at ``None``, which fell straight through to the
+        POST and put a second summary on an MR that already had one.
+        """
         headers = self._get_auth_headers()
         base = self._api_base(ref)
         notes_url = f"{base}/merge_requests/{ref.number}/notes"
+        body = with_summary_marker(body)
 
         existing_note_id: int | None = None
-        try:
-            list_resp = self._session.get(
-                notes_url,
-                headers=headers,
-                params={"per_page": 50},
-                timeout=_REQUEST_TIMEOUT,
-            )
-            if list_resp.ok:
-                notes = list_resp.json()
-                for note in notes:
-                    if _SUMMARY_MARKER in (note.get("body") or ""):
-                        existing_note_id = note.get("id")
-                        break
-        except requests.RequestException:
-            pass
+        for notes in self._iter_pages(
+            ref, notes_url, headers, what="note feed", extra_params=_NOTE_ORDER,
+        ):
+            for note in notes:
+                if SUMMARY_MARKER in (note.get("body") or ""):
+                    existing_note_id = note.get("id")
+                    break
+            if existing_note_id is not None:
+                break
 
         if existing_note_id is not None:
             update_url = f"{notes_url}/{existing_note_id}"
@@ -329,56 +415,70 @@ class ForgeImpl:
         return posted
 
     def list_threads(self, ref: PRRef) -> list[Thread]:
-        """List existing discussion threads on the PR."""
+        """List existing discussion threads on the PR.
+
+        Unlike ``post_summary`` this keeps whatever it managed to read: the
+        threads only feed best-effort dedup, and the orchestrator substitutes
+        an empty list for any exception, so raising would throw away pages
+        that were read successfully. The shortfall is logged rather than
+        swallowed — an under-read here shows up as findings re-posted on a
+        re-review, with nothing in the output to explain why.
+
+        The discussions endpoint takes no ordering parameters, so this walk
+        gets plain page/per_page rather than the notes walk's explicit
+        oldest-first order.
+        """
         headers = self._get_auth_headers()
         base = self._api_base(ref)
         url = f"{base}/merge_requests/{ref.number}/discussions"
-        params = {"per_page": 50}
 
         threads: list[Thread] = []
         try:
-            resp = self._session.get(url, headers=headers, params=params, timeout=_REQUEST_TIMEOUT)
-            resp.raise_for_status()
-            discussions = resp.json()
-        except requests.RequestException:
-            return threads
+            for discussions in self._iter_pages(
+                ref, url, headers, what="discussion feed",
+            ):
+                for disc in discussions:
+                    notes = disc.get("notes") or []
+                    if not notes:
+                        continue
 
-        for disc in discussions:
-            notes = disc.get("notes") or []
-            if not notes:
-                continue
+                    disc_resolved = False
+                    if "resolved" in disc:
+                        disc_resolved = bool(disc["resolved"])
 
-            disc_resolved = False
-            if "resolved" in disc:
-                disc_resolved = bool(disc["resolved"])
+                    first_path: str | None = None
+                    first_line: int | None = None
 
-            first_path: str | None = None
-            first_line: int | None = None
+                    for note in notes:
+                        pos = note.get("position")
+                        if pos and isinstance(pos, dict):
+                            if not first_path:
+                                first_path = pos.get("new_path") or pos.get("old_path")
+                            if first_line is None:
+                                first_line = pos.get("new_line") or pos.get("old_line")
+                        if "resolved" in note and not disc_resolved:
+                            disc_resolved = bool(note["resolved"])
 
-            for note in notes:
-                pos = note.get("position")
-                if pos and isinstance(pos, dict):
-                    if not first_path:
-                        first_path = pos.get("new_path") or pos.get("old_path")
-                    if first_line is None:
-                        first_line = pos.get("new_line") or pos.get("old_line")
-                if "resolved" in note and not disc_resolved:
-                    disc_resolved = bool(note["resolved"])
+                    for note in notes:
+                        author_info = note.get("author") or {}
+                        author = author_info.get("username") or author_info.get("name") or ""
+                        body = note.get("body") or ""
+                        note_resolved = note.get("resolved", disc_resolved)
 
-            for note in notes:
-                author_info = note.get("author") or {}
-                author = author_info.get("username") or author_info.get("name") or ""
-                body = note.get("body") or ""
-                note_resolved = note.get("resolved", disc_resolved)
-
-                threads.append(
-                    Thread(
-                        path=first_path,
-                        line=first_line,
-                        resolved=bool(note_resolved),
-                        author=author,
-                        body_snippet=body[:200],
-                    )
-                )
+                        threads.append(
+                            Thread(
+                                path=first_path,
+                                line=first_line,
+                                resolved=bool(note_resolved),
+                                author=author,
+                                body_snippet=body[:200],
+                            )
+                        )
+        except FeedReadError as e:
+            logger.warning(
+                "discussion feed read was incomplete for %s/%s#%s; thread "
+                "dedup is working from the %d notes that were read: %s",
+                ref.owner, ref.repo, ref.number, len(threads), e,
+            )
 
         return threads

--- a/src/prxref/forges/gitlab.py
+++ b/src/prxref/forges/gitlab.py
@@ -31,9 +31,24 @@ def _make_retry_session() -> requests.Session:
         status=3,
         backoff_factor=1.0,
         status_forcelist=[429, 500, 502, 503, 504],
-        allowed_methods=frozenset(
-            ["GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS"]
-        ),
+        # Read verbs only, deliberately. urllib3 retries beneath the
+        # requests adapter, so a re-sent write is sent whole: a comment POST
+        # that commits server-side and then loses its 2xx to a 502/504 or a
+        # read timeout would be posted a second time, and the PR carries a
+        # duplicate comment — the most visible failure this tool has. No
+        # response status tells the client whether the origin processed the
+        # request, and `Retry.is_retry` tests the method before it looks at
+        # `status_forcelist`, so a single policy cannot retry a POST on 429
+        # (which the server states it did not process) while holding it back
+        # on 502. Writes are therefore left to the caller, which already logs
+        # a failed post and carries on; a duplicated comment needs a human to
+        # delete it. The other write verbs go with POST: no adapter issues a
+        # DELETE, and the summary update (PUT, or PATCH on GitHub) is at best
+        # a no-op on replay and at worst a version conflict. Connection
+        # errors are still retried for every verb: urllib3 gates only its
+        # read-error path on the method, and a connection that was never
+        # established carried no write to duplicate.
+        allowed_methods=frozenset(["GET", "HEAD", "OPTIONS"]),
         respect_retry_after_header=True,
         raise_on_status=False,
     )

--- a/src/prxref/forges/gitlab.py
+++ b/src/prxref/forges/gitlab.py
@@ -1,19 +1,41 @@
 """GitLab REST API v4 forge implementation."""
 from __future__ import annotations
 
+import logging
 import os
 import re
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from urllib.parse import quote, urlparse
 
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from prxref.forges.base import InlineComment, PRData, PRRef, Thread
+from prxref.forges.base import (
+    SUMMARY_MARKER,
+    FeedReadError,
+    InlineComment,
+    PRData,
+    PRRef,
+    Thread,
+    with_summary_marker,
+)
+
+logger = logging.getLogger(__name__)
 
 _REQUEST_TIMEOUT = (10.0, 30.0)
-_SUMMARY_MARKER = "<!-- prxref-summary -->"
+# Both reads used to take a single page of 50 with no loop, so a summary or a
+# discussion past the 50th entry did not exist as far as this adapter was
+# concerned. 100 is the API maximum; 50 pages puts the ceiling far past any
+# real MR, and running out of budget is a refusal to post rather than an
+# invisible short read.
+_PAGE_SIZE = 100
+_MAX_PAGES = 50
+# Oldest-first. GitLab lists notes newest-first by default, and offset paging
+# over a feed that grows at the front skips entries: a note added between two
+# page requests shifts every later window back by one. Ascending order appends
+# at the END, past the cursor, so a walk in progress cannot step over anything.
+_NOTE_ORDER = {"order_by": "created_at", "sort": "asc"}
 
 _GL_URL_RE = re.compile(
     r"^https?://(?P<host>[^/]+)/(?P<path>.+?)/-/merge_requests/(?P<number>\d+)(?:/.*)?$",
@@ -218,28 +240,92 @@ class ForgeImpl:
 
         return "".join(diff_parts)
 
+    def _iter_pages(
+        self,
+        ref: PRRef,
+        url: str,
+        headers: dict[str, str],
+        *,
+        what: str,
+        extra_params: dict[str, str] | None = None,
+    ) -> Iterator[list[dict]]:
+        """Yield a paginated GitLab collection one page at a time.
+
+        A page at a time rather than one flat list, so a caller hunting for a
+        single entry stops at the page it appears on instead of paying for the
+        whole feed. Any read that does not reach the end — transport failure,
+        non-OK status, unparseable body, or the page budget running out —
+        raises ``FeedReadError`` instead of returning short, so no caller can
+        mistake "I stopped early" for "that was all".
+        """
+        where = f"{ref.owner}/{ref.repo}#{ref.number}"
+        for page_number in range(1, _MAX_PAGES + 1):
+            params: dict[str, int | str] = {
+                "per_page": _PAGE_SIZE,
+                "page": page_number,
+            }
+            if extra_params:
+                params.update(extra_params)
+            try:
+                resp = self._session.get(
+                    url, headers=headers, params=params, timeout=_REQUEST_TIMEOUT
+                )
+            except requests.RequestException as e:
+                raise FeedReadError(
+                    f"{what} for {where} could not be read at page "
+                    f"{page_number}: {e}"
+                ) from e
+            if not resp.ok:
+                raise FeedReadError(
+                    f"{what} for {where} returned HTTP {resp.status_code} at "
+                    f"page {page_number}"
+                )
+            try:
+                items = resp.json()
+            except ValueError as e:
+                raise FeedReadError(
+                    f"{what} for {where} returned an unreadable body at page "
+                    f"{page_number}: {e}"
+                ) from e
+            if not isinstance(items, list):
+                raise FeedReadError(
+                    f"{what} for {where} returned {type(items).__name__}, not "
+                    "a list"
+                )
+
+            yield [item for item in items if isinstance(item, dict)]
+
+            if len(items) < _PAGE_SIZE:
+                return
+
+        raise FeedReadError(
+            f"{what} for {where} outran the {_MAX_PAGES}-page budget "
+            f"({_MAX_PAGES * _PAGE_SIZE} entries) without reaching the end"
+        )
+
     def post_summary(self, ref: PRRef, body: str) -> None:
-        """Post (or update) the top-level review summary comment."""
+        """Post (or update) the top-level review summary comment.
+
+        A ``FeedReadError`` from the lookup propagates rather than being
+        swallowed: the transport error used to be caught and dropped, leaving
+        ``existing_note_id`` at ``None``, which fell straight through to the
+        POST and put a second summary on an MR that already had one.
+        """
         headers = self._get_auth_headers()
         base = self._api_base(ref)
         notes_url = f"{base}/merge_requests/{ref.number}/notes"
+        body = with_summary_marker(body)
 
         existing_note_id: int | None = None
-        try:
-            list_resp = self._session.get(
-                notes_url,
-                headers=headers,
-                params={"per_page": 50},
-                timeout=_REQUEST_TIMEOUT,
-            )
-            if list_resp.ok:
-                notes = list_resp.json()
-                for note in notes:
-                    if _SUMMARY_MARKER in (note.get("body") or ""):
-                        existing_note_id = note.get("id")
-                        break
-        except requests.RequestException:
-            pass
+        for notes in self._iter_pages(
+            ref, notes_url, headers, what="note feed", extra_params=_NOTE_ORDER,
+        ):
+            for note in notes:
+                if SUMMARY_MARKER in (note.get("body") or ""):
+                    existing_note_id = note.get("id")
+                    break
+            if existing_note_id is not None:
+                break
 
         if existing_note_id is not None:
             update_url = f"{notes_url}/{existing_note_id}"
@@ -314,56 +400,70 @@ class ForgeImpl:
         return posted
 
     def list_threads(self, ref: PRRef) -> list[Thread]:
-        """List existing discussion threads on the PR."""
+        """List existing discussion threads on the PR.
+
+        Unlike ``post_summary`` this keeps whatever it managed to read: the
+        threads only feed best-effort dedup, and the orchestrator substitutes
+        an empty list for any exception, so raising would throw away pages
+        that were read successfully. The shortfall is logged rather than
+        swallowed — an under-read here shows up as findings re-posted on a
+        re-review, with nothing in the output to explain why.
+
+        The discussions endpoint takes no ordering parameters, so this walk
+        gets plain page/per_page rather than the notes walk's explicit
+        oldest-first order.
+        """
         headers = self._get_auth_headers()
         base = self._api_base(ref)
         url = f"{base}/merge_requests/{ref.number}/discussions"
-        params = {"per_page": 50}
 
         threads: list[Thread] = []
         try:
-            resp = self._session.get(url, headers=headers, params=params, timeout=_REQUEST_TIMEOUT)
-            resp.raise_for_status()
-            discussions = resp.json()
-        except requests.RequestException:
-            return threads
+            for discussions in self._iter_pages(
+                ref, url, headers, what="discussion feed",
+            ):
+                for disc in discussions:
+                    notes = disc.get("notes") or []
+                    if not notes:
+                        continue
 
-        for disc in discussions:
-            notes = disc.get("notes") or []
-            if not notes:
-                continue
+                    disc_resolved = False
+                    if "resolved" in disc:
+                        disc_resolved = bool(disc["resolved"])
 
-            disc_resolved = False
-            if "resolved" in disc:
-                disc_resolved = bool(disc["resolved"])
+                    first_path: str | None = None
+                    first_line: int | None = None
 
-            first_path: str | None = None
-            first_line: int | None = None
+                    for note in notes:
+                        pos = note.get("position")
+                        if pos and isinstance(pos, dict):
+                            if not first_path:
+                                first_path = pos.get("new_path") or pos.get("old_path")
+                            if first_line is None:
+                                first_line = pos.get("new_line") or pos.get("old_line")
+                        if "resolved" in note and not disc_resolved:
+                            disc_resolved = bool(note["resolved"])
 
-            for note in notes:
-                pos = note.get("position")
-                if pos and isinstance(pos, dict):
-                    if not first_path:
-                        first_path = pos.get("new_path") or pos.get("old_path")
-                    if first_line is None:
-                        first_line = pos.get("new_line") or pos.get("old_line")
-                if "resolved" in note and not disc_resolved:
-                    disc_resolved = bool(note["resolved"])
+                    for note in notes:
+                        author_info = note.get("author") or {}
+                        author = author_info.get("username") or author_info.get("name") or ""
+                        body = note.get("body") or ""
+                        note_resolved = note.get("resolved", disc_resolved)
 
-            for note in notes:
-                author_info = note.get("author") or {}
-                author = author_info.get("username") or author_info.get("name") or ""
-                body = note.get("body") or ""
-                note_resolved = note.get("resolved", disc_resolved)
-
-                threads.append(
-                    Thread(
-                        path=first_path,
-                        line=first_line,
-                        resolved=bool(note_resolved),
-                        author=author,
-                        body_snippet=body[:200],
-                    )
-                )
+                        threads.append(
+                            Thread(
+                                path=first_path,
+                                line=first_line,
+                                resolved=bool(note_resolved),
+                                author=author,
+                                body_snippet=body[:200],
+                            )
+                        )
+        except FeedReadError as e:
+            logger.warning(
+                "discussion feed read was incomplete for %s/%s#%s; thread "
+                "dedup is working from the %d notes that were read: %s",
+                ref.owner, ref.repo, ref.number, len(threads), e,
+            )
 
         return threads

--- a/tests/test_forge_bitbucket.py
+++ b/tests/test_forge_bitbucket.py
@@ -1,0 +1,108 @@
+"""Tests for the Bitbucket Cloud forge adapter.
+
+URL parsing is covered across the cross-forge matrix in ``test_integration.py``;
+this module holds the adapter-level invariants that are cheaper to state
+directly against the adapter itself.
+"""
+from __future__ import annotations
+
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from prxref.forges.bitbucket import _make_retry_session
+
+# --- retry policy -----------------------------------------------------------
+
+
+class _RetryProbe:
+    """A localhost server that counts arriving requests and replays statuses.
+
+    The retry policy lives in urllib3, underneath the ``requests`` adapter, so
+    a ``MagicMock`` session cannot exercise it — a mock never re-sends anything,
+    which is precisely the behaviour under test. This runs the real session
+    against a real socket and counts what actually arrives.
+
+    ``statuses`` is replayed one per request and its last entry repeats, so
+    ``[502]`` fails every attempt and ``[502, 200]`` fails once then recovers.
+    """
+
+    def __init__(self, statuses):
+        self.statuses = list(statuses)
+        self.received: list[str] = []
+        probe = self
+
+        class _Handler(BaseHTTPRequestHandler):
+            # HTTP/1.0 closes after each response, so every retry arrives on a
+            # fresh connection and the count cannot be confused by keep-alive.
+            protocol_version = "HTTP/1.0"
+
+            def _reply(self):
+                probe.received.append(self.command)
+                length = int(self.headers.get("Content-Length") or 0)
+                if length:
+                    self.rfile.read(length)
+                index = min(len(probe.received), len(probe.statuses)) - 1
+                self.send_response(probe.statuses[index])
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+
+            do_GET = _reply
+            do_POST = _reply
+            do_PUT = _reply
+            do_PATCH = _reply
+
+            def log_message(self, *args):
+                """Silence the per-request stderr line."""
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        self.url = f"http://127.0.0.1:{self._server.server_port}/"
+
+    def __enter__(self):
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc_info):
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=5)
+        return False
+
+
+def test_a_lost_write_is_not_re_sent():
+    """A comment POST is never replayed, whatever the status.
+
+    502 stands in for every way a committed write can lose its response: the
+    comment is created, the 2xx dies in front of it, and a retry would create
+    the comment a second time on the PR.
+    """
+    session = _make_retry_session()
+    with _RetryProbe([502]) as probe:
+        resp = session.post(probe.url, json={"content": {"raw": "finding"}}, timeout=(5.0, 5.0))
+
+    assert probe.received == ["POST"]
+    assert resp.status_code == 502
+
+
+
+def test_a_lost_read_is_still_re_sent():
+    """Reads keep their retries: replaying a GET costs nothing but a request."""
+    session = _make_retry_session()
+    with _RetryProbe([502, 200]) as probe:
+        resp = session.get(probe.url, timeout=(5.0, 5.0))
+
+    assert probe.received == ["GET", "GET"]
+    assert resp.status_code == 200
+
+
+def test_only_read_verbs_are_retryable():
+    retry = _make_retry_session().get_adapter("https://api.bitbucket.org").max_retries
+
+    assert retry.allowed_methods == frozenset(["GET", "HEAD", "OPTIONS"])
+    assert retry.is_retry("GET", 502) is True
+    assert retry.is_retry("POST", 502) is False
+    # 429 is the one status a write could safely be replayed after — the server
+    # says it did not process the request — but urllib3 tests the method before
+    # it consults the status list, so holding a POST back on 502 holds it back
+    # on 429 too. That trade is deliberate; see the comment on the policy.
+    assert retry.is_retry("POST", 429) is False

--- a/tests/test_forge_bitbucket.py
+++ b/tests/test_forge_bitbucket.py
@@ -1,15 +1,343 @@
 """Tests for the Bitbucket Cloud forge adapter.
 
-URL parsing is covered across the cross-forge matrix in ``test_integration.py``;
-this module holds the adapter-level invariants that are cheaper to state
-directly against the adapter itself.
+The adapter had no test module at all before this one, which is how
+``post_summary`` shipped without ever looking for its own previous summary:
+nothing asserted that a second review updates the first one rather than
+posting beside it.
+
+URL parsing is also covered across the cross-forge matrix in
+``test_integration.py``; what lives here are the adapter-level invariants that
+are cheaper to state directly against the adapter itself.
 """
 from __future__ import annotations
 
+import json
+import logging
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from unittest.mock import MagicMock
 
-from prxref.forges.bitbucket import _make_retry_session
+import pytest
+import requests
+
+from prxref.forges import bitbucket
+from prxref.forges.base import FeedReadError, InlineComment, PRRef
+from prxref.forges.bitbucket import ForgeImpl, _make_retry_session
+
+MARKER = "<!-- prxref-summary -->"
+
+
+def _mock_response(status_code=200, json_data=None, text=""):
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status_code
+    resp.ok = 200 <= status_code < 300
+    if json_data is not None:
+        resp.json.return_value = json_data
+        resp.text = json.dumps(json_data)
+    else:
+        resp.text = text
+        resp.json.side_effect = ValueError("No JSON")
+    resp.raise_for_status.side_effect = (
+        None if resp.ok else requests.HTTPError(response=resp)
+    )
+    return resp
+
+
+def _ref(url="https://bitbucket.org/acme/api/pull-requests/42"):
+    ref = ForgeImpl.parse_pr_url(url)
+    assert ref is not None
+    return ref
+
+
+def _page(values, next_url=None):
+    body = {"values": values, "pagelen": 100, "size": len(values)}
+    if next_url:
+        body["next"] = next_url
+    return _mock_response(json_data=body)
+
+
+# --- URL parsing ------------------------------------------------------------
+
+
+def test_parse_pr_url_accepts_the_three_path_spellings():
+    for path in ("pull-requests", "pullrequests", "pullrequest"):
+        ref = ForgeImpl.parse_pr_url(f"https://bitbucket.org/acme/api/{path}/42")
+        assert ref is not None
+        assert ref.forge == "bitbucket"
+        assert ref.owner == "acme"
+        assert ref.repo == "api"
+        assert ref.number == 42
+        # every spelling normalizes to the canonical one
+        assert ref.url == "https://bitbucket.org/acme/api/pull-requests/42"
+
+
+def test_parse_pr_url_rejects_other_forges():
+    assert ForgeImpl.parse_pr_url("https://github.com/o/r/pull/1") is None
+    assert ForgeImpl.parse_pr_url("https://gitlab.com/g/r/-/merge_requests/1") is None
+    assert ForgeImpl.parse_pr_url(
+        "https://bitbucket.corp.example/projects/P/repos/r/pull-requests/1"
+    ) is None
+
+
+# --- summary dedup ----------------------------------------------------------
+
+
+def test_post_summary_creates_when_no_previous_summary_exists():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _page([])
+    session.post.return_value = _mock_response(201, json_data={"id": 5})
+
+    ForgeImpl(session=session).post_summary(_ref(), "review summary")
+
+    session.put.assert_not_called()
+    session.post.assert_called_once()
+    assert session.post.call_args[1]["json"] == {
+        "content": {"raw": f"{MARKER}\nreview summary"}
+    }
+
+
+def test_post_summary_stamps_the_marker_so_the_next_run_can_find_it():
+    # Nothing upstream of the adapter puts the marker in the body, so a summary
+    # posted without one is invisible to every later lookup.
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _page([])
+    session.post.return_value = _mock_response(201, json_data={"id": 5})
+
+    ForgeImpl(session=session).post_summary(_ref(), "no marker here")
+
+    posted = session.post.call_args[1]["json"]["content"]["raw"]
+    assert MARKER in posted
+
+
+def test_post_summary_leaves_a_body_that_already_carries_the_marker_alone():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _page([])
+    session.post.return_value = _mock_response(201, json_data={"id": 5})
+
+    ForgeImpl(session=session).post_summary(_ref(), f"{MARKER}\nalready stamped")
+
+    posted = session.post.call_args[1]["json"]["content"]["raw"]
+    assert posted == f"{MARKER}\nalready stamped"
+    assert posted.count(MARKER) == 1
+
+
+def test_post_summary_updates_the_existing_summary_instead_of_duplicating():
+    # The re-review case: a second run must land on the first run's comment.
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _page(
+        [
+            {"id": 1, "content": {"raw": "a human comment"}},
+            {"id": 77, "content": {"raw": f"{MARKER}\nold summary"}},
+        ]
+    )
+    session.put.return_value = _mock_response(200, json_data={"id": 77})
+
+    ForgeImpl(session=session).post_summary(_ref(), "new summary")
+
+    session.post.assert_not_called()
+    session.put.assert_called_once()
+    assert session.put.call_args[0][0].endswith("/pullrequests/42/comments/77")
+    assert session.put.call_args[1]["json"] == {
+        "content": {"raw": f"{MARKER}\nnew summary"}
+    }
+
+
+def test_post_summary_finds_a_summary_past_the_first_page():
+    session = MagicMock(spec=requests.Session)
+    next_url = "https://api.bitbucket.org/2.0/next-page"
+    session.get.side_effect = [
+        _page([{"id": i, "content": {"raw": f"chatter {i}"}} for i in range(100)], next_url),
+        _page([{"id": 77, "content": {"raw": f"{MARKER}\nold summary"}}]),
+    ]
+    session.put.return_value = _mock_response(200, json_data={"id": 77})
+
+    ForgeImpl(session=session).post_summary(_ref(), "new summary")
+
+    session.post.assert_not_called()
+    session.put.assert_called_once()
+    assert session.put.call_args[0][0].endswith("/comments/77")
+    assert session.get.call_args_list[1][0][0] == next_url
+
+
+def test_post_summary_stops_reading_as_soon_as_it_finds_the_marker():
+    session = MagicMock(spec=requests.Session)
+    session.get.side_effect = [
+        _page([{"id": 77, "content": {"raw": MARKER}}], "https://api.bitbucket.org/2.0/next"),
+        _page([]),
+    ]
+    session.put.return_value = _mock_response(200, json_data={"id": 77})
+
+    ForgeImpl(session=session).post_summary(_ref(), "new summary")
+
+    assert session.get.call_count == 1
+
+
+def test_post_summary_ignores_an_inline_comment_carrying_the_marker():
+    # A quoted marker inside a line comment is not the summary.
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _page(
+        [
+            {
+                "id": 9,
+                "content": {"raw": f"quoted {MARKER}"},
+                "inline": {"path": "a.py", "to": 3},
+            }
+        ]
+    )
+    session.post.return_value = _mock_response(201, json_data={"id": 10})
+
+    ForgeImpl(session=session).post_summary(_ref(), "body")
+
+    session.put.assert_not_called()
+    session.post.assert_called_once()
+
+
+def test_post_summary_ignores_a_deleted_comment_carrying_the_marker():
+    # Bitbucket keeps deleted comments in the feed with an empty body; updating
+    # one puts the summary somewhere nobody can read it.
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _page(
+        [{"id": 9, "content": {"raw": MARKER}, "deleted": True}]
+    )
+    session.post.return_value = _mock_response(201, json_data={"id": 10})
+
+    ForgeImpl(session=session).post_summary(_ref(), "body")
+
+    session.put.assert_not_called()
+    session.post.assert_called_once()
+
+
+# --- summary: an unreadable feed must not become a duplicate ----------------
+
+
+def test_post_summary_refuses_to_post_when_the_feed_read_fails():
+    session = MagicMock(spec=requests.Session)
+    session.get.side_effect = requests.ConnectionError("down")
+
+    with pytest.raises(FeedReadError, match="comment feed"):
+        ForgeImpl(session=session).post_summary(_ref(), "body")
+
+    session.post.assert_not_called()
+    session.put.assert_not_called()
+
+
+def test_post_summary_refuses_to_post_when_the_feed_returns_an_error_status():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(500, json_data={"error": "boom"})
+
+    with pytest.raises(FeedReadError, match="500"):
+        ForgeImpl(session=session).post_summary(_ref(), "body")
+
+    session.post.assert_not_called()
+
+
+def test_post_summary_refuses_to_post_when_the_feed_outruns_the_page_budget():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _page(
+        [{"id": 1, "content": {"raw": "chatter"}}],
+        "https://api.bitbucket.org/2.0/forever",
+    )
+
+    with pytest.raises(FeedReadError, match="page budget"):
+        ForgeImpl(session=session).post_summary(_ref(), "body")
+
+    assert session.get.call_count == bitbucket._MAX_PAGES
+    session.post.assert_not_called()
+
+
+# --- threads ----------------------------------------------------------------
+
+
+def test_list_threads_reads_inline_and_top_level_comments():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _page(
+        [
+            {
+                "id": 1,
+                "content": {"raw": "please fix"},
+                "inline": {"path": "src/app.py", "to": 12},
+                "user": {"nickname": "reviewer"},
+            },
+            {"id": 2, "content": {"raw": "looks fine"}, "user": {"nickname": "dev"}},
+        ]
+    )
+
+    threads = ForgeImpl(session=session).list_threads(_ref())
+
+    assert [t.path for t in threads] == ["src/app.py", None]
+    assert [t.line for t in threads] == [12, None]
+    assert [t.body_snippet for t in threads] == ["please fix", "looks fine"]
+
+
+def test_list_threads_pages_past_the_old_five_page_ceiling():
+    # The cap used to be five pages, so comment 501 was invisible to dedup.
+    session = MagicMock(spec=requests.Session)
+    pages = [
+        _page(
+            [{"id": n, "content": {"raw": f"page {n}"}}],
+            f"https://api.bitbucket.org/2.0/page/{n + 1}",
+        )
+        for n in range(8)
+    ]
+    pages.append(_page([{"id": 99, "content": {"raw": "last"}}]))
+    session.get.side_effect = pages
+
+    threads = ForgeImpl(session=session).list_threads(_ref())
+
+    assert len(threads) == 9
+    assert threads[-1].body_snippet == "last"
+
+
+def test_list_threads_keeps_what_it_read_and_warns_when_the_feed_read_fails(caplog):
+    # Dedup input is best-effort: a partial read still beats no read, but the
+    # shortfall has to be visible rather than silent.
+    session = MagicMock(spec=requests.Session)
+    session.get.side_effect = [
+        _page([{"id": 1, "content": {"raw": "one"}}], "https://api.bitbucket.org/2.0/two"),
+        requests.ConnectionError("down"),
+    ]
+
+    with caplog.at_level(logging.WARNING, logger="prxref.forges.bitbucket"):
+        threads = ForgeImpl(session=session).list_threads(_ref())
+
+    assert [t.body_snippet for t in threads] == ["one"]
+    assert "incomplete" in caplog.text.lower()
+
+
+def test_list_threads_returns_empty_on_an_immediate_transport_error(caplog):
+    session = MagicMock(spec=requests.Session)
+    session.get.side_effect = requests.ConnectionError("down")
+
+    with caplog.at_level(logging.WARNING, logger="prxref.forges.bitbucket"):
+        assert ForgeImpl(session=session).list_threads(_ref()) == []
+
+    assert caplog.records
+
+
+# --- inline comments (unchanged behavior, previously untested) --------------
+
+
+def test_post_inline_comments_skips_4xx_and_keeps_going():
+    session = MagicMock(spec=requests.Session)
+    session.post.side_effect = [
+        _mock_response(400),
+        _mock_response(201, json_data={"id": 2}),
+    ]
+    posted = ForgeImpl(session=session).post_inline_comments(
+        _ref(),
+        [
+            InlineComment(path="a.py", line=1, body="x"),
+            InlineComment(path="b.py", line=2, body="y"),
+        ],
+    )
+    assert posted == 1
+
+
+def test_ref_round_trips_through_the_protocol_dataclass():
+    ref = _ref()
+    assert isinstance(ref, PRRef)
+    assert ForgeImpl.parse_pr_url(ref.url) == ref
+
 
 # --- retry policy -----------------------------------------------------------
 
@@ -81,6 +409,22 @@ def test_a_lost_write_is_not_re_sent():
         resp = session.post(probe.url, json={"content": {"raw": "finding"}}, timeout=(5.0, 5.0))
 
     assert probe.received == ["POST"]
+    assert resp.status_code == 502
+
+
+def test_a_lost_summary_update_is_not_re_sent():
+    """The summary update is a write too, and PUT is not exempt.
+
+    Cloud only grew an update path when post_summary learned to find its own
+    previous summary; before that it always POSTed, so this verb had nothing
+    to test. It is dropped from the retry policy like every other write: one
+    policy shared by four adapters beats one exemption.
+    """
+    session = _make_retry_session()
+    with _RetryProbe([502]) as probe:
+        resp = session.put(probe.url, json={"content": {"raw": "summary"}}, timeout=(5.0, 5.0))
+
+    assert probe.received == ["PUT"]
     assert resp.status_code == 502
 
 

--- a/tests/test_forge_bitbucket.py
+++ b/tests/test_forge_bitbucket.py
@@ -1,0 +1,333 @@
+"""Tests for the Bitbucket Cloud forge adapter.
+
+The adapter had no test module at all before this one, which is how
+``post_summary`` shipped without ever looking for its own previous summary:
+nothing asserted that a second review updates the first one rather than
+posting beside it.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from prxref.forges import bitbucket
+from prxref.forges.base import FeedReadError, InlineComment, PRRef
+from prxref.forges.bitbucket import ForgeImpl
+
+MARKER = "<!-- prxref-summary -->"
+
+
+def _mock_response(status_code=200, json_data=None, text=""):
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status_code
+    resp.ok = 200 <= status_code < 300
+    if json_data is not None:
+        resp.json.return_value = json_data
+        resp.text = json.dumps(json_data)
+    else:
+        resp.text = text
+        resp.json.side_effect = ValueError("No JSON")
+    resp.raise_for_status.side_effect = (
+        None if resp.ok else requests.HTTPError(response=resp)
+    )
+    return resp
+
+
+def _ref(url="https://bitbucket.org/acme/api/pull-requests/42"):
+    ref = ForgeImpl.parse_pr_url(url)
+    assert ref is not None
+    return ref
+
+
+def _page(values, next_url=None):
+    body = {"values": values, "pagelen": 100, "size": len(values)}
+    if next_url:
+        body["next"] = next_url
+    return _mock_response(json_data=body)
+
+
+# --- URL parsing ------------------------------------------------------------
+
+
+def test_parse_pr_url_accepts_the_three_path_spellings():
+    for path in ("pull-requests", "pullrequests", "pullrequest"):
+        ref = ForgeImpl.parse_pr_url(f"https://bitbucket.org/acme/api/{path}/42")
+        assert ref is not None
+        assert ref.forge == "bitbucket"
+        assert ref.owner == "acme"
+        assert ref.repo == "api"
+        assert ref.number == 42
+        # every spelling normalizes to the canonical one
+        assert ref.url == "https://bitbucket.org/acme/api/pull-requests/42"
+
+
+def test_parse_pr_url_rejects_other_forges():
+    assert ForgeImpl.parse_pr_url("https://github.com/o/r/pull/1") is None
+    assert ForgeImpl.parse_pr_url("https://gitlab.com/g/r/-/merge_requests/1") is None
+    assert ForgeImpl.parse_pr_url(
+        "https://bitbucket.corp.example/projects/P/repos/r/pull-requests/1"
+    ) is None
+
+
+# --- summary dedup ----------------------------------------------------------
+
+
+def test_post_summary_creates_when_no_previous_summary_exists():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _page([])
+    session.post.return_value = _mock_response(201, json_data={"id": 5})
+
+    ForgeImpl(session=session).post_summary(_ref(), "review summary")
+
+    session.put.assert_not_called()
+    session.post.assert_called_once()
+    assert session.post.call_args[1]["json"] == {
+        "content": {"raw": f"{MARKER}\nreview summary"}
+    }
+
+
+def test_post_summary_stamps_the_marker_so_the_next_run_can_find_it():
+    # Nothing upstream of the adapter puts the marker in the body, so a summary
+    # posted without one is invisible to every later lookup.
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _page([])
+    session.post.return_value = _mock_response(201, json_data={"id": 5})
+
+    ForgeImpl(session=session).post_summary(_ref(), "no marker here")
+
+    posted = session.post.call_args[1]["json"]["content"]["raw"]
+    assert MARKER in posted
+
+
+def test_post_summary_leaves_a_body_that_already_carries_the_marker_alone():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _page([])
+    session.post.return_value = _mock_response(201, json_data={"id": 5})
+
+    ForgeImpl(session=session).post_summary(_ref(), f"{MARKER}\nalready stamped")
+
+    posted = session.post.call_args[1]["json"]["content"]["raw"]
+    assert posted == f"{MARKER}\nalready stamped"
+    assert posted.count(MARKER) == 1
+
+
+def test_post_summary_updates_the_existing_summary_instead_of_duplicating():
+    # The re-review case: a second run must land on the first run's comment.
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _page(
+        [
+            {"id": 1, "content": {"raw": "a human comment"}},
+            {"id": 77, "content": {"raw": f"{MARKER}\nold summary"}},
+        ]
+    )
+    session.put.return_value = _mock_response(200, json_data={"id": 77})
+
+    ForgeImpl(session=session).post_summary(_ref(), "new summary")
+
+    session.post.assert_not_called()
+    session.put.assert_called_once()
+    assert session.put.call_args[0][0].endswith("/pullrequests/42/comments/77")
+    assert session.put.call_args[1]["json"] == {
+        "content": {"raw": f"{MARKER}\nnew summary"}
+    }
+
+
+def test_post_summary_finds_a_summary_past_the_first_page():
+    session = MagicMock(spec=requests.Session)
+    next_url = "https://api.bitbucket.org/2.0/next-page"
+    session.get.side_effect = [
+        _page([{"id": i, "content": {"raw": f"chatter {i}"}} for i in range(100)], next_url),
+        _page([{"id": 77, "content": {"raw": f"{MARKER}\nold summary"}}]),
+    ]
+    session.put.return_value = _mock_response(200, json_data={"id": 77})
+
+    ForgeImpl(session=session).post_summary(_ref(), "new summary")
+
+    session.post.assert_not_called()
+    session.put.assert_called_once()
+    assert session.put.call_args[0][0].endswith("/comments/77")
+    assert session.get.call_args_list[1][0][0] == next_url
+
+
+def test_post_summary_stops_reading_as_soon_as_it_finds_the_marker():
+    session = MagicMock(spec=requests.Session)
+    session.get.side_effect = [
+        _page([{"id": 77, "content": {"raw": MARKER}}], "https://api.bitbucket.org/2.0/next"),
+        _page([]),
+    ]
+    session.put.return_value = _mock_response(200, json_data={"id": 77})
+
+    ForgeImpl(session=session).post_summary(_ref(), "new summary")
+
+    assert session.get.call_count == 1
+
+
+def test_post_summary_ignores_an_inline_comment_carrying_the_marker():
+    # A quoted marker inside a line comment is not the summary.
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _page(
+        [
+            {
+                "id": 9,
+                "content": {"raw": f"quoted {MARKER}"},
+                "inline": {"path": "a.py", "to": 3},
+            }
+        ]
+    )
+    session.post.return_value = _mock_response(201, json_data={"id": 10})
+
+    ForgeImpl(session=session).post_summary(_ref(), "body")
+
+    session.put.assert_not_called()
+    session.post.assert_called_once()
+
+
+def test_post_summary_ignores_a_deleted_comment_carrying_the_marker():
+    # Bitbucket keeps deleted comments in the feed with an empty body; updating
+    # one puts the summary somewhere nobody can read it.
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _page(
+        [{"id": 9, "content": {"raw": MARKER}, "deleted": True}]
+    )
+    session.post.return_value = _mock_response(201, json_data={"id": 10})
+
+    ForgeImpl(session=session).post_summary(_ref(), "body")
+
+    session.put.assert_not_called()
+    session.post.assert_called_once()
+
+
+# --- summary: an unreadable feed must not become a duplicate ----------------
+
+
+def test_post_summary_refuses_to_post_when_the_feed_read_fails():
+    session = MagicMock(spec=requests.Session)
+    session.get.side_effect = requests.ConnectionError("down")
+
+    with pytest.raises(FeedReadError, match="comment feed"):
+        ForgeImpl(session=session).post_summary(_ref(), "body")
+
+    session.post.assert_not_called()
+    session.put.assert_not_called()
+
+
+def test_post_summary_refuses_to_post_when_the_feed_returns_an_error_status():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(500, json_data={"error": "boom"})
+
+    with pytest.raises(FeedReadError, match="500"):
+        ForgeImpl(session=session).post_summary(_ref(), "body")
+
+    session.post.assert_not_called()
+
+
+def test_post_summary_refuses_to_post_when_the_feed_outruns_the_page_budget():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _page(
+        [{"id": 1, "content": {"raw": "chatter"}}],
+        "https://api.bitbucket.org/2.0/forever",
+    )
+
+    with pytest.raises(FeedReadError, match="page budget"):
+        ForgeImpl(session=session).post_summary(_ref(), "body")
+
+    assert session.get.call_count == bitbucket._MAX_PAGES
+    session.post.assert_not_called()
+
+
+# --- threads ----------------------------------------------------------------
+
+
+def test_list_threads_reads_inline_and_top_level_comments():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _page(
+        [
+            {
+                "id": 1,
+                "content": {"raw": "please fix"},
+                "inline": {"path": "src/app.py", "to": 12},
+                "user": {"nickname": "reviewer"},
+            },
+            {"id": 2, "content": {"raw": "looks fine"}, "user": {"nickname": "dev"}},
+        ]
+    )
+
+    threads = ForgeImpl(session=session).list_threads(_ref())
+
+    assert [t.path for t in threads] == ["src/app.py", None]
+    assert [t.line for t in threads] == [12, None]
+    assert [t.body_snippet for t in threads] == ["please fix", "looks fine"]
+
+
+def test_list_threads_pages_past_the_old_five_page_ceiling():
+    # The cap used to be five pages, so comment 501 was invisible to dedup.
+    session = MagicMock(spec=requests.Session)
+    pages = [
+        _page(
+            [{"id": n, "content": {"raw": f"page {n}"}}],
+            f"https://api.bitbucket.org/2.0/page/{n + 1}",
+        )
+        for n in range(8)
+    ]
+    pages.append(_page([{"id": 99, "content": {"raw": "last"}}]))
+    session.get.side_effect = pages
+
+    threads = ForgeImpl(session=session).list_threads(_ref())
+
+    assert len(threads) == 9
+    assert threads[-1].body_snippet == "last"
+
+
+def test_list_threads_keeps_what_it_read_and_warns_when_the_feed_read_fails(caplog):
+    # Dedup input is best-effort: a partial read still beats no read, but the
+    # shortfall has to be visible rather than silent.
+    session = MagicMock(spec=requests.Session)
+    session.get.side_effect = [
+        _page([{"id": 1, "content": {"raw": "one"}}], "https://api.bitbucket.org/2.0/two"),
+        requests.ConnectionError("down"),
+    ]
+
+    with caplog.at_level(logging.WARNING, logger="prxref.forges.bitbucket"):
+        threads = ForgeImpl(session=session).list_threads(_ref())
+
+    assert [t.body_snippet for t in threads] == ["one"]
+    assert "incomplete" in caplog.text.lower()
+
+
+def test_list_threads_returns_empty_on_an_immediate_transport_error(caplog):
+    session = MagicMock(spec=requests.Session)
+    session.get.side_effect = requests.ConnectionError("down")
+
+    with caplog.at_level(logging.WARNING, logger="prxref.forges.bitbucket"):
+        assert ForgeImpl(session=session).list_threads(_ref()) == []
+
+    assert caplog.records
+
+
+# --- inline comments (unchanged behavior, previously untested) --------------
+
+
+def test_post_inline_comments_skips_4xx_and_keeps_going():
+    session = MagicMock(spec=requests.Session)
+    session.post.side_effect = [
+        _mock_response(400),
+        _mock_response(201, json_data={"id": 2}),
+    ]
+    posted = ForgeImpl(session=session).post_inline_comments(
+        _ref(),
+        [
+            InlineComment(path="a.py", line=1, body="x"),
+            InlineComment(path="b.py", line=2, body="y"),
+        ],
+    )
+    assert posted == 1
+
+
+def test_ref_round_trips_through_the_protocol_dataclass():
+    ref = _ref()
+    assert isinstance(ref, PRRef)
+    assert ForgeImpl.parse_pr_url(ref.url) == ref

--- a/tests/test_forge_bitbucket_server.py
+++ b/tests/test_forge_bitbucket_server.py
@@ -2,13 +2,15 @@
 from __future__ import annotations
 
 import json
+import logging
 from unittest.mock import MagicMock
 
 import pytest
 import requests
 
 from prxref.config import make_forge
-from prxref.forges.base import InlineComment, PRRef, detect_forge
+from prxref.forges import bitbucket_server
+from prxref.forges.base import FeedReadError, InlineComment, PRRef, detect_forge
 from prxref.forges.bitbucket_server import ForgeImpl
 from prxref.triage import parse_unified_diff
 
@@ -468,7 +470,9 @@ def test_post_summary_creates_when_absent():
     session.post.return_value = _mock_response(status_code=201, json_data={"id": 5})
 
     ForgeImpl(session=session).post_summary(_ref(), "summary body")
-    assert session.post.call_args.kwargs["json"] == {"text": "summary body"}
+    assert session.post.call_args.kwargs["json"] == {
+        "text": "<!-- prxref-summary -->\nsummary body"
+    }
     session.put.assert_not_called()
 
 
@@ -495,7 +499,10 @@ def test_post_summary_updates_and_sends_the_version():
     ForgeImpl(session=session).post_summary(_ref(), "new body")
     session.post.assert_not_called()
     assert session.put.call_args[0][0].endswith("/comments/77")
-    assert session.put.call_args.kwargs["json"] == {"text": "new body", "version": 3}
+    assert session.put.call_args.kwargs["json"] == {
+        "text": "<!-- prxref-summary -->\nnew body",
+        "version": 3,
+    }
 
 
 def test_post_summary_ignores_an_inline_comment_carrying_the_marker():
@@ -619,3 +626,133 @@ def test_ref_round_trips_through_the_protocol_dataclass():
     ref = _ref()
     assert isinstance(ref, PRRef)
     assert ForgeImpl.parse_pr_url(ref.url) == ref
+
+
+# --- summary dedup: paging and unreadable feeds ------------------------------
+
+MARKER = "<!-- prxref-summary -->"
+
+
+def _activity_page(values, *, last=True, next_start=None):
+    body = {"values": values, "isLastPage": last}
+    if next_start is not None:
+        body["nextPageStart"] = next_start
+    return _mock_response(json_data=body)
+
+
+def _commented(text, **comment):
+    return {"action": "COMMENTED", "comment": {"text": text, **comment}}
+
+
+def test_post_summary_finds_a_summary_past_the_old_five_page_ceiling():
+    # The cap used to be five pages of 100, so a summary sitting at activity
+    # 501 was invisible and the run posted a second one beside it.
+    session = MagicMock()
+    pages = [
+        _activity_page([_commented(f"chatter {n}")], last=False, next_start=(n + 1) * 100)
+        for n in range(6)
+    ]
+    pages.append(_activity_page([_commented(MARKER, id=77, version=3)]))
+    session.get.side_effect = pages
+    session.put.return_value = _mock_response(json_data={"id": 77})
+
+    ForgeImpl(session=session).post_summary(_ref(), "new body")
+
+    session.post.assert_not_called()
+    assert session.put.call_args[0][0].endswith("/comments/77")
+    assert session.put.call_args.kwargs["json"] == {
+        "text": f"{MARKER}\nnew body",
+        "version": 3,
+    }
+
+
+def test_post_summary_stops_reading_as_soon_as_it_finds_the_marker():
+    session = MagicMock()
+    session.get.side_effect = [
+        _activity_page([_commented(MARKER, id=77, version=1)], last=False, next_start=100),
+        _activity_page([]),
+    ]
+    session.put.return_value = _mock_response(json_data={"id": 77})
+
+    ForgeImpl(session=session).post_summary(_ref(), "new body")
+
+    assert session.get.call_count == 1
+
+
+def test_post_summary_stamps_the_marker_when_the_body_lacks_one():
+    # Nothing upstream of the adapter puts the marker in the body, so a summary
+    # posted without one is invisible to every later lookup.
+    session = MagicMock()
+    session.get.return_value = _activity_page([])
+    session.post.return_value = _mock_response(status_code=201, json_data={"id": 5})
+
+    ForgeImpl(session=session).post_summary(_ref(), "no marker here")
+
+    assert session.post.call_args.kwargs["json"] == {"text": f"{MARKER}\nno marker here"}
+
+
+def test_post_summary_refuses_to_post_when_the_activity_read_fails():
+    # The old code caught the transport error, set `existing = None`, and fell
+    # through to the POST — a SECOND summary on a PR that already had one.
+    session = MagicMock()
+    session.get.side_effect = requests.ConnectionError("down")
+
+    with pytest.raises(FeedReadError, match="activity feed"):
+        ForgeImpl(session=session).post_summary(_ref(), "body")
+
+    session.post.assert_not_called()
+    session.put.assert_not_called()
+
+
+def test_post_summary_refuses_to_post_when_the_activity_read_errors_out():
+    session = MagicMock()
+    session.get.return_value = _mock_response(status_code=500, json_data={"errors": []})
+
+    with pytest.raises(FeedReadError, match="500"):
+        ForgeImpl(session=session).post_summary(_ref(), "body")
+
+    session.post.assert_not_called()
+
+
+def test_post_summary_refuses_to_post_when_the_feed_outruns_the_page_budget():
+    session = MagicMock()
+    session.get.return_value = _activity_page(
+        [_commented("chatter")], last=False, next_start=100
+    )
+
+    with pytest.raises(FeedReadError, match="page budget"):
+        ForgeImpl(session=session).post_summary(_ref(), "body")
+
+    assert session.get.call_count == bitbucket_server._MAX_PAGES
+    session.post.assert_not_called()
+
+
+def test_list_threads_pages_past_the_old_five_page_ceiling():
+    session = MagicMock()
+    pages = [
+        _activity_page([_commented(f"page {n}")], last=False, next_start=(n + 1) * 100)
+        for n in range(8)
+    ]
+    pages.append(_activity_page([_commented("last")]))
+    session.get.side_effect = pages
+
+    threads = ForgeImpl(session=session).list_threads(_ref())
+
+    assert len(threads) == 9
+    assert threads[-1].body_snippet == "last"
+
+
+def test_list_threads_keeps_what_it_read_and_warns_when_the_feed_read_fails(caplog):
+    # Dedup input is best-effort: a partial read beats no read, but the
+    # shortfall has to be visible rather than silent.
+    session = MagicMock()
+    session.get.side_effect = [
+        _activity_page([_commented("one")], last=False, next_start=100),
+        requests.ConnectionError("down"),
+    ]
+
+    with caplog.at_level(logging.WARNING, logger="prxref.forges.bitbucket_server"):
+        threads = ForgeImpl(session=session).list_threads(_ref())
+
+    assert [t.body_snippet for t in threads] == ["one"]
+    assert "incomplete" in caplog.text.lower()

--- a/tests/test_forge_bitbucket_server.py
+++ b/tests/test_forge_bitbucket_server.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from unittest.mock import MagicMock
 
 import pytest
@@ -9,7 +11,7 @@ import requests
 
 from prxref.config import make_forge
 from prxref.forges.base import InlineComment, PRRef, detect_forge
-from prxref.forges.bitbucket_server import ForgeImpl
+from prxref.forges.bitbucket_server import ForgeImpl, _make_retry_session
 from prxref.triage import parse_unified_diff
 
 
@@ -619,3 +621,116 @@ def test_ref_round_trips_through_the_protocol_dataclass():
     ref = _ref()
     assert isinstance(ref, PRRef)
     assert ForgeImpl.parse_pr_url(ref.url) == ref
+
+
+# --- retry policy -----------------------------------------------------------
+
+
+class _RetryProbe:
+    """A localhost server that counts arriving requests and replays statuses.
+
+    The retry policy lives in urllib3, underneath the ``requests`` adapter, so
+    a ``MagicMock`` session cannot exercise it — a mock never re-sends anything,
+    which is precisely the behaviour under test. This runs the real session
+    against a real socket and counts what actually arrives.
+
+    ``statuses`` is replayed one per request and its last entry repeats, so
+    ``[502]`` fails every attempt and ``[502, 200]`` fails once then recovers.
+    """
+
+    def __init__(self, statuses):
+        self.statuses = list(statuses)
+        self.received: list[str] = []
+        probe = self
+
+        class _Handler(BaseHTTPRequestHandler):
+            # HTTP/1.0 closes after each response, so every retry arrives on a
+            # fresh connection and the count cannot be confused by keep-alive.
+            protocol_version = "HTTP/1.0"
+
+            def _reply(self):
+                probe.received.append(self.command)
+                length = int(self.headers.get("Content-Length") or 0)
+                if length:
+                    self.rfile.read(length)
+                index = min(len(probe.received), len(probe.statuses)) - 1
+                self.send_response(probe.statuses[index])
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+
+            do_GET = _reply
+            do_POST = _reply
+            do_PUT = _reply
+            do_PATCH = _reply
+
+            def log_message(self, *args):
+                """Silence the per-request stderr line."""
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        self.url = f"http://127.0.0.1:{self._server.server_port}/"
+
+    def __enter__(self):
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc_info):
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=5)
+        return False
+
+
+def test_a_lost_write_is_not_re_sent():
+    """A comment POST is never replayed, whatever the status.
+
+    502 stands in for every way a committed write can lose its response: the
+    comment is created, the 2xx dies in front of it, and a retry would create
+    the comment a second time on the PR.
+    """
+    session = _make_retry_session()
+    with _RetryProbe([502]) as probe:
+        resp = session.post(probe.url, json={"text": "finding"}, timeout=(5.0, 5.0))
+
+    assert probe.received == ["POST"]
+    assert resp.status_code == 502
+
+
+def test_a_lost_summary_update_is_not_re_sent():
+    """The summary update is a write too, and PUT is not exempt.
+
+    PUT is idempotent by HTTP semantics, but Data Center's comment
+    update is version-checked: a replay of a PUT that already landed
+    carries the stale version and is answered 409, turning a silent
+    success into a raised error.
+    """
+    session = _make_retry_session()
+    with _RetryProbe([502]) as probe:
+        resp = session.put(probe.url, json={"text": "summary", "version": 3}, timeout=(5.0, 5.0))
+
+    assert probe.received == ["PUT"]
+    assert resp.status_code == 502
+
+
+
+def test_a_lost_read_is_still_re_sent():
+    """Reads keep their retries: replaying a GET costs nothing but a request."""
+    session = _make_retry_session()
+    with _RetryProbe([502, 200]) as probe:
+        resp = session.get(probe.url, timeout=(5.0, 5.0))
+
+    assert probe.received == ["GET", "GET"]
+    assert resp.status_code == 200
+
+
+def test_only_read_verbs_are_retryable():
+    retry = _make_retry_session().get_adapter("https://bitbucket.corp.example").max_retries
+
+    assert retry.allowed_methods == frozenset(["GET", "HEAD", "OPTIONS"])
+    assert retry.is_retry("GET", 502) is True
+    assert retry.is_retry("POST", 502) is False
+    # 429 is the one status a write could safely be replayed after — the server
+    # says it did not process the request — but urllib3 tests the method before
+    # it consults the status list, so holding a POST back on 502 holds it back
+    # on 429 too. That trade is deliberate; see the comment on the policy.
+    assert retry.is_retry("POST", 429) is False

--- a/tests/test_forge_bitbucket_server.py
+++ b/tests/test_forge_bitbucket_server.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from unittest.mock import MagicMock
@@ -10,7 +11,8 @@ import pytest
 import requests
 
 from prxref.config import make_forge
-from prxref.forges.base import InlineComment, PRRef, detect_forge
+from prxref.forges import bitbucket_server
+from prxref.forges.base import FeedReadError, InlineComment, PRRef, detect_forge
 from prxref.forges.bitbucket_server import ForgeImpl, _make_retry_session
 from prxref.triage import parse_unified_diff
 
@@ -470,7 +472,9 @@ def test_post_summary_creates_when_absent():
     session.post.return_value = _mock_response(status_code=201, json_data={"id": 5})
 
     ForgeImpl(session=session).post_summary(_ref(), "summary body")
-    assert session.post.call_args.kwargs["json"] == {"text": "summary body"}
+    assert session.post.call_args.kwargs["json"] == {
+        "text": "<!-- prxref-summary -->\nsummary body"
+    }
     session.put.assert_not_called()
 
 
@@ -497,7 +501,10 @@ def test_post_summary_updates_and_sends_the_version():
     ForgeImpl(session=session).post_summary(_ref(), "new body")
     session.post.assert_not_called()
     assert session.put.call_args[0][0].endswith("/comments/77")
-    assert session.put.call_args.kwargs["json"] == {"text": "new body", "version": 3}
+    assert session.put.call_args.kwargs["json"] == {
+        "text": "<!-- prxref-summary -->\nnew body",
+        "version": 3,
+    }
 
 
 def test_post_summary_ignores_an_inline_comment_carrying_the_marker():
@@ -621,6 +628,136 @@ def test_ref_round_trips_through_the_protocol_dataclass():
     ref = _ref()
     assert isinstance(ref, PRRef)
     assert ForgeImpl.parse_pr_url(ref.url) == ref
+
+
+# --- summary dedup: paging and unreadable feeds ------------------------------
+
+MARKER = "<!-- prxref-summary -->"
+
+
+def _activity_page(values, *, last=True, next_start=None):
+    body = {"values": values, "isLastPage": last}
+    if next_start is not None:
+        body["nextPageStart"] = next_start
+    return _mock_response(json_data=body)
+
+
+def _commented(text, **comment):
+    return {"action": "COMMENTED", "comment": {"text": text, **comment}}
+
+
+def test_post_summary_finds_a_summary_past_the_old_five_page_ceiling():
+    # The cap used to be five pages of 100, so a summary sitting at activity
+    # 501 was invisible and the run posted a second one beside it.
+    session = MagicMock()
+    pages = [
+        _activity_page([_commented(f"chatter {n}")], last=False, next_start=(n + 1) * 100)
+        for n in range(6)
+    ]
+    pages.append(_activity_page([_commented(MARKER, id=77, version=3)]))
+    session.get.side_effect = pages
+    session.put.return_value = _mock_response(json_data={"id": 77})
+
+    ForgeImpl(session=session).post_summary(_ref(), "new body")
+
+    session.post.assert_not_called()
+    assert session.put.call_args[0][0].endswith("/comments/77")
+    assert session.put.call_args.kwargs["json"] == {
+        "text": f"{MARKER}\nnew body",
+        "version": 3,
+    }
+
+
+def test_post_summary_stops_reading_as_soon_as_it_finds_the_marker():
+    session = MagicMock()
+    session.get.side_effect = [
+        _activity_page([_commented(MARKER, id=77, version=1)], last=False, next_start=100),
+        _activity_page([]),
+    ]
+    session.put.return_value = _mock_response(json_data={"id": 77})
+
+    ForgeImpl(session=session).post_summary(_ref(), "new body")
+
+    assert session.get.call_count == 1
+
+
+def test_post_summary_stamps_the_marker_when_the_body_lacks_one():
+    # Nothing upstream of the adapter puts the marker in the body, so a summary
+    # posted without one is invisible to every later lookup.
+    session = MagicMock()
+    session.get.return_value = _activity_page([])
+    session.post.return_value = _mock_response(status_code=201, json_data={"id": 5})
+
+    ForgeImpl(session=session).post_summary(_ref(), "no marker here")
+
+    assert session.post.call_args.kwargs["json"] == {"text": f"{MARKER}\nno marker here"}
+
+
+def test_post_summary_refuses_to_post_when_the_activity_read_fails():
+    # The old code caught the transport error, set `existing = None`, and fell
+    # through to the POST — a SECOND summary on a PR that already had one.
+    session = MagicMock()
+    session.get.side_effect = requests.ConnectionError("down")
+
+    with pytest.raises(FeedReadError, match="activity feed"):
+        ForgeImpl(session=session).post_summary(_ref(), "body")
+
+    session.post.assert_not_called()
+    session.put.assert_not_called()
+
+
+def test_post_summary_refuses_to_post_when_the_activity_read_errors_out():
+    session = MagicMock()
+    session.get.return_value = _mock_response(status_code=500, json_data={"errors": []})
+
+    with pytest.raises(FeedReadError, match="500"):
+        ForgeImpl(session=session).post_summary(_ref(), "body")
+
+    session.post.assert_not_called()
+
+
+def test_post_summary_refuses_to_post_when_the_feed_outruns_the_page_budget():
+    session = MagicMock()
+    session.get.return_value = _activity_page(
+        [_commented("chatter")], last=False, next_start=100
+    )
+
+    with pytest.raises(FeedReadError, match="page budget"):
+        ForgeImpl(session=session).post_summary(_ref(), "body")
+
+    assert session.get.call_count == bitbucket_server._MAX_PAGES
+    session.post.assert_not_called()
+
+
+def test_list_threads_pages_past_the_old_five_page_ceiling():
+    session = MagicMock()
+    pages = [
+        _activity_page([_commented(f"page {n}")], last=False, next_start=(n + 1) * 100)
+        for n in range(8)
+    ]
+    pages.append(_activity_page([_commented("last")]))
+    session.get.side_effect = pages
+
+    threads = ForgeImpl(session=session).list_threads(_ref())
+
+    assert len(threads) == 9
+    assert threads[-1].body_snippet == "last"
+
+
+def test_list_threads_keeps_what_it_read_and_warns_when_the_feed_read_fails(caplog):
+    # Dedup input is best-effort: a partial read beats no read, but the
+    # shortfall has to be visible rather than silent.
+    session = MagicMock()
+    session.get.side_effect = [
+        _activity_page([_commented("one")], last=False, next_start=100),
+        requests.ConnectionError("down"),
+    ]
+
+    with caplog.at_level(logging.WARNING, logger="prxref.forges.bitbucket_server"):
+        threads = ForgeImpl(session=session).list_threads(_ref())
+
+    assert [t.body_snippet for t in threads] == ["one"]
+    assert "incomplete" in caplog.text.lower()
 
 
 # --- retry policy -----------------------------------------------------------

--- a/tests/test_forge_github.py
+++ b/tests/test_forge_github.py
@@ -1,15 +1,281 @@
-"""Tests for the GitHub forge adapter.
+"""Tests for the GitHub / GitHub Enterprise Server forge adapter.
 
-URL parsing is covered across the cross-forge matrix in ``test_integration.py``;
-this module holds the adapter-level invariants that are cheaper to state
-directly against the adapter itself.
+The adapter had no test module before this one. Both comment reads went out
+unparameterised — one default page of 30 — so a summary or a thread past that
+window did not exist as far as the adapter was concerned.
+
+URL parsing is also covered across the cross-forge matrix in
+``test_integration.py``; what lives here are the adapter-level invariants that
+are cheaper to state directly against the adapter itself.
 """
 from __future__ import annotations
 
+import json
+import logging
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from unittest.mock import MagicMock
 
-from prxref.forges.github import _create_default_session
+import pytest
+import requests
+
+from prxref.forges import github
+from prxref.forges.base import FeedReadError, InlineComment, PRRef
+from prxref.forges.github import ForgeImpl, _create_default_session
+
+MARKER = "<!-- prxref-summary -->"
+# The page size the adapter is expected to ask for; pinned by its own test
+# below so every other test here reads as data rather than as a coupling.
+PAGE_SIZE = 100
+
+
+def _mock_response(status_code=200, json_data=None, text=""):
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status_code
+    resp.ok = 200 <= status_code < 300
+    if json_data is not None:
+        resp.json.return_value = json_data
+        resp.text = json.dumps(json_data)
+    else:
+        resp.text = text
+        resp.json.side_effect = ValueError("No JSON")
+    resp.raise_for_status.side_effect = (
+        None if resp.ok else requests.HTTPError(response=resp)
+    )
+    return resp
+
+
+def _ref(url="https://github.com/acme/api/pull/42"):
+    ref = ForgeImpl.parse_pr_url(url)
+    assert ref is not None
+    return ref
+
+
+def _full_page(prefix="chatter"):
+    """A page of exactly _PAGE_SIZE comments — the shape that means 'keep going'."""
+    return _mock_response(
+        json_data=[{"id": i, "body": f"{prefix} {i}"} for i in range(PAGE_SIZE)]
+    )
+
+
+# --- URL parsing ------------------------------------------------------------
+
+
+def test_parse_pr_url_cloud_and_enterprise():
+    cloud = ForgeImpl.parse_pr_url("https://github.com/acme/api/pull/42")
+    assert cloud is not None
+    assert (cloud.host, cloud.owner, cloud.repo, cloud.number) == (
+        "github.com", "acme", "api", 42,
+    )
+
+    ghes = ForgeImpl.parse_pr_url("https://git.corp.example/acme/api/pull/7")
+    assert ghes is not None
+    assert ghes.host == "git.corp.example"
+
+
+def test_parse_pr_url_rejects_other_forges():
+    assert ForgeImpl.parse_pr_url("https://gitlab.com/g/r/-/merge_requests/1") is None
+    assert ForgeImpl.parse_pr_url("https://bitbucket.org/o/r/pull-requests/1") is None
+
+
+# --- summary dedup ----------------------------------------------------------
+
+
+def test_post_summary_creates_when_no_previous_summary_exists():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(json_data=[])
+    session.post.return_value = _mock_response(201, json_data={"id": 5})
+
+    ForgeImpl(session=session).post_summary(_ref(), "review summary")
+
+    session.patch.assert_not_called()
+    session.post.assert_called_once()
+    assert session.post.call_args[1]["json"] == {"body": f"{MARKER}\nreview summary"}
+
+
+def test_post_summary_asks_for_a_full_page_rather_than_the_default_thirty():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(json_data=[])
+    session.post.return_value = _mock_response(201, json_data={"id": 5})
+
+    ForgeImpl(session=session).post_summary(_ref(), "body")
+
+    params = session.get.call_args[1]["params"]
+    assert params["per_page"] == PAGE_SIZE == github._PAGE_SIZE
+    assert params["page"] == 1
+
+
+def test_post_summary_updates_the_existing_summary_instead_of_duplicating():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(
+        json_data=[
+            {"id": 1, "body": "a human comment"},
+            {"id": 77, "body": f"{MARKER}\nold summary"},
+        ]
+    )
+    session.patch.return_value = _mock_response(200, json_data={"id": 77})
+
+    ForgeImpl(session=session).post_summary(_ref(), "new summary")
+
+    session.post.assert_not_called()
+    session.patch.assert_called_once()
+    assert session.patch.call_args[0][0].endswith("/issues/comments/77")
+    assert session.patch.call_args[1]["json"] == {"body": f"{MARKER}\nnew summary"}
+
+
+def test_post_summary_finds_a_summary_past_the_first_page():
+    session = MagicMock(spec=requests.Session)
+    session.get.side_effect = [
+        _full_page(),
+        _mock_response(json_data=[{"id": 77, "body": f"{MARKER}\nold summary"}]),
+    ]
+    session.patch.return_value = _mock_response(200, json_data={"id": 77})
+
+    ForgeImpl(session=session).post_summary(_ref(), "new summary")
+
+    session.post.assert_not_called()
+    session.patch.assert_called_once()
+    assert session.patch.call_args[0][0].endswith("/issues/comments/77")
+    assert session.get.call_args_list[1][1]["params"]["page"] == 2
+
+
+def test_post_summary_stops_reading_as_soon_as_it_finds_the_marker():
+    session = MagicMock(spec=requests.Session)
+    hit = [{"id": i, "body": "chatter"} for i in range(PAGE_SIZE - 1)]
+    hit.append({"id": 77, "body": MARKER})
+    session.get.return_value = _mock_response(json_data=hit)
+    session.patch.return_value = _mock_response(200, json_data={"id": 77})
+
+    ForgeImpl(session=session).post_summary(_ref(), "new summary")
+
+    # A full page normally means "fetch the next one"; finding the marker wins.
+    assert session.get.call_count == 1
+
+
+# --- summary: an unreadable feed must not become a duplicate ----------------
+
+
+def test_post_summary_refuses_to_post_when_the_feed_returns_an_error_status():
+    # This is the fall-through the old code had: `if list_resp.ok:` was false,
+    # so the lookup was skipped and the POST ran as if no summary existed.
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(403, json_data={"message": "rate limited"})
+
+    with pytest.raises(FeedReadError, match="403"):
+        ForgeImpl(session=session).post_summary(_ref(), "body")
+
+    session.post.assert_not_called()
+    session.patch.assert_not_called()
+
+
+def test_post_summary_refuses_to_post_when_the_feed_read_raises():
+    session = MagicMock(spec=requests.Session)
+    session.get.side_effect = requests.ConnectionError("down")
+
+    with pytest.raises(FeedReadError, match="comment feed"):
+        ForgeImpl(session=session).post_summary(_ref(), "body")
+
+    session.post.assert_not_called()
+
+
+def test_post_summary_refuses_to_post_when_the_feed_outruns_the_page_budget():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _full_page()
+
+    with pytest.raises(FeedReadError, match="page budget"):
+        ForgeImpl(session=session).post_summary(_ref(), "body")
+
+    assert session.get.call_count == github._MAX_PAGES
+    session.post.assert_not_called()
+
+
+def test_post_summary_refuses_to_post_when_the_feed_is_not_a_list():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(json_data={"message": "Not Found"})
+
+    with pytest.raises(FeedReadError):
+        ForgeImpl(session=session).post_summary(_ref(), "body")
+
+    session.post.assert_not_called()
+
+
+# --- threads ----------------------------------------------------------------
+
+
+def test_list_threads_reads_review_comments():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(
+        json_data=[
+            {
+                "id": 1,
+                "path": "src/app.py",
+                "line": 12,
+                "user": {"login": "reviewer"},
+                "body": "please fix",
+            }
+        ]
+    )
+
+    threads = ForgeImpl(session=session).list_threads(_ref())
+
+    assert len(threads) == 1
+    assert threads[0].path == "src/app.py"
+    assert threads[0].line == 12
+    assert threads[0].author == "reviewer"
+    assert threads[0].body_snippet == "please fix"
+
+
+def test_list_threads_pages_past_the_first_page():
+    session = MagicMock(spec=requests.Session)
+    session.get.side_effect = [
+        _full_page("early"),
+        _mock_response(json_data=[{"id": 999, "body": "late", "path": "b.py", "line": 3}]),
+    ]
+
+    threads = ForgeImpl(session=session).list_threads(_ref())
+
+    assert len(threads) == PAGE_SIZE + 1
+    assert threads[-1].body_snippet == "late"
+
+
+def test_list_threads_keeps_what_it_read_and_warns_when_the_feed_read_fails(caplog):
+    session = MagicMock(spec=requests.Session)
+    session.get.side_effect = [
+        _full_page("early"),
+        requests.ConnectionError("down"),
+    ]
+
+    with caplog.at_level(logging.WARNING, logger="prxref.forges.github"):
+        threads = ForgeImpl(session=session).list_threads(_ref())
+
+    assert len(threads) == PAGE_SIZE
+    assert "incomplete" in caplog.text.lower()
+
+
+# --- inline comments (unchanged behavior, previously untested) --------------
+
+
+def test_post_inline_comments_skips_422_and_keeps_going():
+    session = MagicMock(spec=requests.Session)
+    session.post.side_effect = [
+        _mock_response(422),
+        _mock_response(201, json_data={"id": 2}),
+    ]
+    posted = ForgeImpl(session=session).post_inline_comments(
+        _ref(),
+        [
+            InlineComment(path="a.py", line=1, body="x"),
+            InlineComment(path="b.py", line=2, body="y"),
+        ],
+    )
+    assert posted == 1
+
+
+def test_ref_round_trips_through_the_protocol_dataclass():
+    ref = _ref()
+    assert isinstance(ref, PRRef)
+    assert ForgeImpl.parse_pr_url(ref.url) == ref
+
 
 # --- retry policy -----------------------------------------------------------
 

--- a/tests/test_forge_github.py
+++ b/tests/test_forge_github.py
@@ -1,0 +1,271 @@
+"""Tests for the GitHub / GitHub Enterprise Server forge adapter.
+
+The adapter had no test module before this one. Both comment reads went out
+unparameterised — one default page of 30 — so a summary or a thread past that
+window did not exist as far as the adapter was concerned.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from prxref.forges import github
+from prxref.forges.base import FeedReadError, InlineComment, PRRef
+from prxref.forges.github import ForgeImpl
+
+MARKER = "<!-- prxref-summary -->"
+# The page size the adapter is expected to ask for; pinned by its own test
+# below so every other test here reads as data rather than as a coupling.
+PAGE_SIZE = 100
+
+
+def _mock_response(status_code=200, json_data=None, text=""):
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status_code
+    resp.ok = 200 <= status_code < 300
+    if json_data is not None:
+        resp.json.return_value = json_data
+        resp.text = json.dumps(json_data)
+    else:
+        resp.text = text
+        resp.json.side_effect = ValueError("No JSON")
+    resp.raise_for_status.side_effect = (
+        None if resp.ok else requests.HTTPError(response=resp)
+    )
+    return resp
+
+
+def _ref(url="https://github.com/acme/api/pull/42"):
+    ref = ForgeImpl.parse_pr_url(url)
+    assert ref is not None
+    return ref
+
+
+def _full_page(prefix="chatter"):
+    """A page of exactly _PAGE_SIZE comments — the shape that means 'keep going'."""
+    return _mock_response(
+        json_data=[{"id": i, "body": f"{prefix} {i}"} for i in range(PAGE_SIZE)]
+    )
+
+
+# --- URL parsing ------------------------------------------------------------
+
+
+def test_parse_pr_url_cloud_and_enterprise():
+    cloud = ForgeImpl.parse_pr_url("https://github.com/acme/api/pull/42")
+    assert cloud is not None
+    assert (cloud.host, cloud.owner, cloud.repo, cloud.number) == (
+        "github.com", "acme", "api", 42,
+    )
+
+    ghes = ForgeImpl.parse_pr_url("https://git.corp.example/acme/api/pull/7")
+    assert ghes is not None
+    assert ghes.host == "git.corp.example"
+
+
+def test_parse_pr_url_rejects_other_forges():
+    assert ForgeImpl.parse_pr_url("https://gitlab.com/g/r/-/merge_requests/1") is None
+    assert ForgeImpl.parse_pr_url("https://bitbucket.org/o/r/pull-requests/1") is None
+
+
+# --- summary dedup ----------------------------------------------------------
+
+
+def test_post_summary_creates_when_no_previous_summary_exists():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(json_data=[])
+    session.post.return_value = _mock_response(201, json_data={"id": 5})
+
+    ForgeImpl(session=session).post_summary(_ref(), "review summary")
+
+    session.patch.assert_not_called()
+    session.post.assert_called_once()
+    assert session.post.call_args[1]["json"] == {"body": f"{MARKER}\nreview summary"}
+
+
+def test_post_summary_asks_for_a_full_page_rather_than_the_default_thirty():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(json_data=[])
+    session.post.return_value = _mock_response(201, json_data={"id": 5})
+
+    ForgeImpl(session=session).post_summary(_ref(), "body")
+
+    params = session.get.call_args[1]["params"]
+    assert params["per_page"] == PAGE_SIZE == github._PAGE_SIZE
+    assert params["page"] == 1
+
+
+def test_post_summary_updates_the_existing_summary_instead_of_duplicating():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(
+        json_data=[
+            {"id": 1, "body": "a human comment"},
+            {"id": 77, "body": f"{MARKER}\nold summary"},
+        ]
+    )
+    session.patch.return_value = _mock_response(200, json_data={"id": 77})
+
+    ForgeImpl(session=session).post_summary(_ref(), "new summary")
+
+    session.post.assert_not_called()
+    session.patch.assert_called_once()
+    assert session.patch.call_args[0][0].endswith("/issues/comments/77")
+    assert session.patch.call_args[1]["json"] == {"body": f"{MARKER}\nnew summary"}
+
+
+def test_post_summary_finds_a_summary_past_the_first_page():
+    session = MagicMock(spec=requests.Session)
+    session.get.side_effect = [
+        _full_page(),
+        _mock_response(json_data=[{"id": 77, "body": f"{MARKER}\nold summary"}]),
+    ]
+    session.patch.return_value = _mock_response(200, json_data={"id": 77})
+
+    ForgeImpl(session=session).post_summary(_ref(), "new summary")
+
+    session.post.assert_not_called()
+    session.patch.assert_called_once()
+    assert session.patch.call_args[0][0].endswith("/issues/comments/77")
+    assert session.get.call_args_list[1][1]["params"]["page"] == 2
+
+
+def test_post_summary_stops_reading_as_soon_as_it_finds_the_marker():
+    session = MagicMock(spec=requests.Session)
+    hit = [{"id": i, "body": "chatter"} for i in range(PAGE_SIZE - 1)]
+    hit.append({"id": 77, "body": MARKER})
+    session.get.return_value = _mock_response(json_data=hit)
+    session.patch.return_value = _mock_response(200, json_data={"id": 77})
+
+    ForgeImpl(session=session).post_summary(_ref(), "new summary")
+
+    # A full page normally means "fetch the next one"; finding the marker wins.
+    assert session.get.call_count == 1
+
+
+# --- summary: an unreadable feed must not become a duplicate ----------------
+
+
+def test_post_summary_refuses_to_post_when_the_feed_returns_an_error_status():
+    # This is the fall-through the old code had: `if list_resp.ok:` was false,
+    # so the lookup was skipped and the POST ran as if no summary existed.
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(403, json_data={"message": "rate limited"})
+
+    with pytest.raises(FeedReadError, match="403"):
+        ForgeImpl(session=session).post_summary(_ref(), "body")
+
+    session.post.assert_not_called()
+    session.patch.assert_not_called()
+
+
+def test_post_summary_refuses_to_post_when_the_feed_read_raises():
+    session = MagicMock(spec=requests.Session)
+    session.get.side_effect = requests.ConnectionError("down")
+
+    with pytest.raises(FeedReadError, match="comment feed"):
+        ForgeImpl(session=session).post_summary(_ref(), "body")
+
+    session.post.assert_not_called()
+
+
+def test_post_summary_refuses_to_post_when_the_feed_outruns_the_page_budget():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _full_page()
+
+    with pytest.raises(FeedReadError, match="page budget"):
+        ForgeImpl(session=session).post_summary(_ref(), "body")
+
+    assert session.get.call_count == github._MAX_PAGES
+    session.post.assert_not_called()
+
+
+def test_post_summary_refuses_to_post_when_the_feed_is_not_a_list():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(json_data={"message": "Not Found"})
+
+    with pytest.raises(FeedReadError):
+        ForgeImpl(session=session).post_summary(_ref(), "body")
+
+    session.post.assert_not_called()
+
+
+# --- threads ----------------------------------------------------------------
+
+
+def test_list_threads_reads_review_comments():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(
+        json_data=[
+            {
+                "id": 1,
+                "path": "src/app.py",
+                "line": 12,
+                "user": {"login": "reviewer"},
+                "body": "please fix",
+            }
+        ]
+    )
+
+    threads = ForgeImpl(session=session).list_threads(_ref())
+
+    assert len(threads) == 1
+    assert threads[0].path == "src/app.py"
+    assert threads[0].line == 12
+    assert threads[0].author == "reviewer"
+    assert threads[0].body_snippet == "please fix"
+
+
+def test_list_threads_pages_past_the_first_page():
+    session = MagicMock(spec=requests.Session)
+    session.get.side_effect = [
+        _full_page("early"),
+        _mock_response(json_data=[{"id": 999, "body": "late", "path": "b.py", "line": 3}]),
+    ]
+
+    threads = ForgeImpl(session=session).list_threads(_ref())
+
+    assert len(threads) == PAGE_SIZE + 1
+    assert threads[-1].body_snippet == "late"
+
+
+def test_list_threads_keeps_what_it_read_and_warns_when_the_feed_read_fails(caplog):
+    session = MagicMock(spec=requests.Session)
+    session.get.side_effect = [
+        _full_page("early"),
+        requests.ConnectionError("down"),
+    ]
+
+    with caplog.at_level(logging.WARNING, logger="prxref.forges.github"):
+        threads = ForgeImpl(session=session).list_threads(_ref())
+
+    assert len(threads) == PAGE_SIZE
+    assert "incomplete" in caplog.text.lower()
+
+
+# --- inline comments (unchanged behavior, previously untested) --------------
+
+
+def test_post_inline_comments_skips_422_and_keeps_going():
+    session = MagicMock(spec=requests.Session)
+    session.post.side_effect = [
+        _mock_response(422),
+        _mock_response(201, json_data={"id": 2}),
+    ]
+    posted = ForgeImpl(session=session).post_inline_comments(
+        _ref(),
+        [
+            InlineComment(path="a.py", line=1, body="x"),
+            InlineComment(path="b.py", line=2, body="y"),
+        ],
+    )
+    assert posted == 1
+
+
+def test_ref_round_trips_through_the_protocol_dataclass():
+    ref = _ref()
+    assert isinstance(ref, PRRef)
+    assert ForgeImpl.parse_pr_url(ref.url) == ref

--- a/tests/test_forge_github.py
+++ b/tests/test_forge_github.py
@@ -1,0 +1,123 @@
+"""Tests for the GitHub forge adapter.
+
+URL parsing is covered across the cross-forge matrix in ``test_integration.py``;
+this module holds the adapter-level invariants that are cheaper to state
+directly against the adapter itself.
+"""
+from __future__ import annotations
+
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from prxref.forges.github import _create_default_session
+
+# --- retry policy -----------------------------------------------------------
+
+
+class _RetryProbe:
+    """A localhost server that counts arriving requests and replays statuses.
+
+    The retry policy lives in urllib3, underneath the ``requests`` adapter, so
+    a ``MagicMock`` session cannot exercise it — a mock never re-sends anything,
+    which is precisely the behaviour under test. This runs the real session
+    against a real socket and counts what actually arrives.
+
+    ``statuses`` is replayed one per request and its last entry repeats, so
+    ``[502]`` fails every attempt and ``[502, 200]`` fails once then recovers.
+    """
+
+    def __init__(self, statuses):
+        self.statuses = list(statuses)
+        self.received: list[str] = []
+        probe = self
+
+        class _Handler(BaseHTTPRequestHandler):
+            # HTTP/1.0 closes after each response, so every retry arrives on a
+            # fresh connection and the count cannot be confused by keep-alive.
+            protocol_version = "HTTP/1.0"
+
+            def _reply(self):
+                probe.received.append(self.command)
+                length = int(self.headers.get("Content-Length") or 0)
+                if length:
+                    self.rfile.read(length)
+                index = min(len(probe.received), len(probe.statuses)) - 1
+                self.send_response(probe.statuses[index])
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+
+            do_GET = _reply
+            do_POST = _reply
+            do_PUT = _reply
+            do_PATCH = _reply
+
+            def log_message(self, *args):
+                """Silence the per-request stderr line."""
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        self.url = f"http://127.0.0.1:{self._server.server_port}/"
+
+    def __enter__(self):
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc_info):
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=5)
+        return False
+
+
+def test_a_lost_write_is_not_re_sent():
+    """A comment POST is never replayed, whatever the status.
+
+    502 stands in for every way a committed write can lose its response: the
+    comment is created, the 2xx dies in front of it, and a retry would create
+    the comment a second time on the PR.
+    """
+    session = _create_default_session()
+    with _RetryProbe([502]) as probe:
+        resp = session.post(probe.url, json={"body": "finding"}, timeout=(5.0, 5.0))
+
+    assert probe.received == ["POST"]
+    assert resp.status_code == 502
+
+
+def test_a_lost_summary_update_is_not_re_sent():
+    """The summary update is a write too, and PATCH is not exempt.
+
+    PATCH is not idempotent by HTTP semantics at all, and this one
+    edits an existing comment — exactly the request that must not be
+    replayed blind.
+    """
+    session = _create_default_session()
+    with _RetryProbe([502]) as probe:
+        resp = session.patch(probe.url, json={"body": "summary"}, timeout=(5.0, 5.0))
+
+    assert probe.received == ["PATCH"]
+    assert resp.status_code == 502
+
+
+
+def test_a_lost_read_is_still_re_sent():
+    """Reads keep their retries: replaying a GET costs nothing but a request."""
+    session = _create_default_session()
+    with _RetryProbe([502, 200]) as probe:
+        resp = session.get(probe.url, timeout=(5.0, 5.0))
+
+    assert probe.received == ["GET", "GET"]
+    assert resp.status_code == 200
+
+
+def test_only_read_verbs_are_retryable():
+    retry = _create_default_session().get_adapter("https://api.github.com").max_retries
+
+    assert retry.allowed_methods == frozenset(["GET", "HEAD", "OPTIONS"])
+    assert retry.is_retry("GET", 502) is True
+    assert retry.is_retry("POST", 502) is False
+    # 429 is the one status a write could safely be replayed after — the server
+    # says it did not process the request — but urllib3 tests the method before
+    # it consults the status list, so holding a POST back on 502 holds it back
+    # on 429 too. That trade is deliberate; see the comment on the policy.
+    assert retry.is_retry("POST", 429) is False

--- a/tests/test_forge_gitlab.py
+++ b/tests/test_forge_gitlab.py
@@ -2,12 +2,14 @@
 from __future__ import annotations
 
 import json
+import logging
 from unittest.mock import MagicMock
 
 import pytest
 import requests
 
-from prxref.forges.base import InlineComment, PRRef
+from prxref.forges import gitlab
+from prxref.forges.base import FeedReadError, InlineComment, PRRef
 from prxref.forges.gitlab import ForgeImpl
 from prxref.triage import parse_unified_diff
 
@@ -360,3 +362,156 @@ def test_list_threads_flatten():
     assert threads[2].line is None
     assert threads[2].author == "reviewer2"
     assert threads[2].resolved is True
+
+
+# --- summary dedup: paging and unreadable feeds ------------------------------
+
+# The note page size the adapter is expected to ask for, pinned by its own test
+# below so the rest of these read as data rather than as a coupling.
+NOTE_PAGE_SIZE = 100
+MARKER = "<!-- prxref-summary -->"
+
+
+def _gl_ref():
+    return PRRef(
+        "gitlab", "gitlab.com", "group", "repo", 7,
+        "https://gitlab.com/group/repo/-/merge_requests/7",
+    )
+
+
+def _full_note_page(prefix="chatter"):
+    """A page of exactly per_page notes — the shape that means 'keep going'."""
+    return _mock_response(
+        200, json_data=[{"id": i, "body": f"{prefix} {i}"} for i in range(NOTE_PAGE_SIZE)]
+    )
+
+
+def test_post_summary_asks_for_a_full_page_of_notes():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(200, json_data=[])
+    session.post.return_value = _mock_response(201, json_data={"id": 1})
+
+    ForgeImpl(session=session).post_summary(_gl_ref(), "body")
+
+    params = session.get.call_args[1]["params"]
+    assert params["per_page"] == NOTE_PAGE_SIZE == gitlab._PAGE_SIZE
+    assert params["page"] == 1
+    # Oldest-first, so a note created during the walk lands at the END and
+    # cannot shift a later page's window back over a note already passed.
+    assert params["sort"] == "asc"
+    assert params["order_by"] == "created_at"
+
+
+def test_post_summary_finds_a_summary_past_the_first_page():
+    session = MagicMock(spec=requests.Session)
+    session.get.side_effect = [
+        _full_note_page(),
+        _mock_response(200, json_data=[{"id": 88, "body": f"{MARKER}\nold summary"}]),
+    ]
+    session.put.return_value = _mock_response(200, json_data={"id": 88})
+
+    ForgeImpl(session=session).post_summary(_gl_ref(), "new summary")
+
+    session.post.assert_not_called()
+    session.put.assert_called_once()
+    assert session.put.call_args[0][0].endswith("/notes/88")
+    assert session.get.call_args_list[1][1]["params"]["page"] == 2
+
+
+def test_post_summary_stamps_the_marker_when_the_body_lacks_one():
+    # Nothing upstream of the adapter puts the marker in the body, so a summary
+    # posted without one is invisible to every later lookup.
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(200, json_data=[])
+    session.post.return_value = _mock_response(201, json_data={"id": 1})
+
+    ForgeImpl(session=session).post_summary(_gl_ref(), "no marker here")
+
+    assert session.post.call_args[1]["json"] == {"body": f"{MARKER}\nno marker here"}
+
+
+def test_post_summary_refuses_to_post_when_the_note_read_fails():
+    # The old code swallowed the transport error and fell through to the POST,
+    # which is a SECOND summary on a PR that already had one.
+    session = MagicMock(spec=requests.Session)
+    session.get.side_effect = requests.ConnectionError("down")
+
+    with pytest.raises(FeedReadError, match="note feed"):
+        ForgeImpl(session=session).post_summary(_gl_ref(), "body")
+
+    session.post.assert_not_called()
+    session.put.assert_not_called()
+
+
+def test_post_summary_refuses_to_post_when_the_note_read_returns_an_error_status():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(500, json_data={"message": "boom"})
+
+    with pytest.raises(FeedReadError, match="500"):
+        ForgeImpl(session=session).post_summary(_gl_ref(), "body")
+
+    session.post.assert_not_called()
+
+
+def test_post_summary_refuses_to_post_when_the_notes_outrun_the_page_budget():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _full_note_page()
+
+    with pytest.raises(FeedReadError, match="page budget"):
+        ForgeImpl(session=session).post_summary(_gl_ref(), "body")
+
+    assert session.get.call_count == gitlab._MAX_PAGES
+    session.post.assert_not_called()
+
+
+def test_post_summary_stops_reading_as_soon_as_it_finds_the_marker():
+    session = MagicMock(spec=requests.Session)
+    hit = [{"id": i, "body": "chatter"} for i in range(NOTE_PAGE_SIZE - 1)]
+    hit.append({"id": 88, "body": MARKER})
+    session.get.return_value = _mock_response(200, json_data=hit)
+    session.put.return_value = _mock_response(200, json_data={"id": 88})
+
+    ForgeImpl(session=session).post_summary(_gl_ref(), "new summary")
+
+    assert session.get.call_count == 1
+
+
+def test_list_threads_pages_past_the_first_page():
+    session = MagicMock(spec=requests.Session)
+    session.get.side_effect = [
+        _mock_response(
+            200,
+            json_data=[
+                {"id": f"d{i}", "notes": [{"id": i, "body": f"early {i}"}]}
+                for i in range(NOTE_PAGE_SIZE)
+            ],
+        ),
+        _mock_response(200, json_data=[{"id": "last", "notes": [{"id": 9, "body": "late"}]}]),
+    ]
+
+    threads = ForgeImpl(session=session).list_threads(_gl_ref())
+
+    assert len(threads) == NOTE_PAGE_SIZE + 1
+    assert threads[-1].body_snippet == "late"
+
+
+def test_list_threads_keeps_what_it_read_and_warns_when_the_feed_read_fails(caplog):
+    # Dedup input is best-effort: a partial read beats no read, but the
+    # shortfall has to be visible rather than silent.
+    session = MagicMock(spec=requests.Session)
+    session.get.side_effect = [
+        _mock_response(
+            200,
+            json_data=[
+                {"id": f"d{i}", "notes": [{"id": i, "body": f"early {i}"}]}
+                for i in range(NOTE_PAGE_SIZE)
+            ],
+        ),
+        requests.ConnectionError("down"),
+    ]
+
+    with caplog.at_level(logging.WARNING, logger="prxref.forges.gitlab"):
+        threads = ForgeImpl(session=session).list_threads(_gl_ref())
+
+    assert len(threads) == NOTE_PAGE_SIZE
+    assert "incomplete" in caplog.text.lower()

--- a/tests/test_forge_gitlab.py
+++ b/tests/test_forge_gitlab.py
@@ -2,13 +2,15 @@
 from __future__ import annotations
 
 import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from unittest.mock import MagicMock
 
 import pytest
 import requests
 
 from prxref.forges.base import InlineComment, PRRef
-from prxref.forges.gitlab import ForgeImpl
+from prxref.forges.gitlab import ForgeImpl, _make_retry_session
 from prxref.triage import parse_unified_diff
 
 
@@ -360,3 +362,115 @@ def test_list_threads_flatten():
     assert threads[2].line is None
     assert threads[2].author == "reviewer2"
     assert threads[2].resolved is True
+
+
+# --- retry policy -----------------------------------------------------------
+
+
+class _RetryProbe:
+    """A localhost server that counts arriving requests and replays statuses.
+
+    The retry policy lives in urllib3, underneath the ``requests`` adapter, so
+    a ``MagicMock`` session cannot exercise it — a mock never re-sends anything,
+    which is precisely the behaviour under test. This runs the real session
+    against a real socket and counts what actually arrives.
+
+    ``statuses`` is replayed one per request and its last entry repeats, so
+    ``[502]`` fails every attempt and ``[502, 200]`` fails once then recovers.
+    """
+
+    def __init__(self, statuses):
+        self.statuses = list(statuses)
+        self.received: list[str] = []
+        probe = self
+
+        class _Handler(BaseHTTPRequestHandler):
+            # HTTP/1.0 closes after each response, so every retry arrives on a
+            # fresh connection and the count cannot be confused by keep-alive.
+            protocol_version = "HTTP/1.0"
+
+            def _reply(self):
+                probe.received.append(self.command)
+                length = int(self.headers.get("Content-Length") or 0)
+                if length:
+                    self.rfile.read(length)
+                index = min(len(probe.received), len(probe.statuses)) - 1
+                self.send_response(probe.statuses[index])
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+
+            do_GET = _reply
+            do_POST = _reply
+            do_PUT = _reply
+            do_PATCH = _reply
+
+            def log_message(self, *args):
+                """Silence the per-request stderr line."""
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        self.url = f"http://127.0.0.1:{self._server.server_port}/"
+
+    def __enter__(self):
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc_info):
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=5)
+        return False
+
+
+def test_a_lost_write_is_not_re_sent():
+    """A comment POST is never replayed, whatever the status.
+
+    502 stands in for every way a committed write can lose its response: the
+    comment is created, the 2xx dies in front of it, and a retry would create
+    the comment a second time on the PR.
+    """
+    session = _make_retry_session()
+    with _RetryProbe([502]) as probe:
+        resp = session.post(probe.url, json={"body": "finding"}, timeout=(5.0, 5.0))
+
+    assert probe.received == ["POST"]
+    assert resp.status_code == 502
+
+
+def test_a_lost_summary_update_is_not_re_sent():
+    """The summary update is a write too, and PUT is not exempt.
+
+    The note update overwrites the body, so a replay would write the
+    same text twice and settle. It is dropped anyway: one policy
+    shared by four adapters is worth more than one exemption.
+    """
+    session = _make_retry_session()
+    with _RetryProbe([502]) as probe:
+        resp = session.put(probe.url, json={"body": "summary"}, timeout=(5.0, 5.0))
+
+    assert probe.received == ["PUT"]
+    assert resp.status_code == 502
+
+
+
+def test_a_lost_read_is_still_re_sent():
+    """Reads keep their retries: replaying a GET costs nothing but a request."""
+    session = _make_retry_session()
+    with _RetryProbe([502, 200]) as probe:
+        resp = session.get(probe.url, timeout=(5.0, 5.0))
+
+    assert probe.received == ["GET", "GET"]
+    assert resp.status_code == 200
+
+
+def test_only_read_verbs_are_retryable():
+    retry = _make_retry_session().get_adapter("https://gitlab.com").max_retries
+
+    assert retry.allowed_methods == frozenset(["GET", "HEAD", "OPTIONS"])
+    assert retry.is_retry("GET", 502) is True
+    assert retry.is_retry("POST", 502) is False
+    # 429 is the one status a write could safely be replayed after — the server
+    # says it did not process the request — but urllib3 tests the method before
+    # it consults the status list, so holding a POST back on 502 holds it back
+    # on 429 too. That trade is deliberate; see the comment on the policy.
+    assert retry.is_retry("POST", 429) is False

--- a/tests/test_forge_gitlab.py
+++ b/tests/test_forge_gitlab.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from unittest.mock import MagicMock
@@ -9,7 +10,8 @@ from unittest.mock import MagicMock
 import pytest
 import requests
 
-from prxref.forges.base import InlineComment, PRRef
+from prxref.forges import gitlab
+from prxref.forges.base import FeedReadError, InlineComment, PRRef
 from prxref.forges.gitlab import ForgeImpl, _make_retry_session
 from prxref.triage import parse_unified_diff
 
@@ -362,6 +364,159 @@ def test_list_threads_flatten():
     assert threads[2].line is None
     assert threads[2].author == "reviewer2"
     assert threads[2].resolved is True
+
+
+# --- summary dedup: paging and unreadable feeds ------------------------------
+
+# The note page size the adapter is expected to ask for, pinned by its own test
+# below so the rest of these read as data rather than as a coupling.
+NOTE_PAGE_SIZE = 100
+MARKER = "<!-- prxref-summary -->"
+
+
+def _gl_ref():
+    return PRRef(
+        "gitlab", "gitlab.com", "group", "repo", 7,
+        "https://gitlab.com/group/repo/-/merge_requests/7",
+    )
+
+
+def _full_note_page(prefix="chatter"):
+    """A page of exactly per_page notes — the shape that means 'keep going'."""
+    return _mock_response(
+        200, json_data=[{"id": i, "body": f"{prefix} {i}"} for i in range(NOTE_PAGE_SIZE)]
+    )
+
+
+def test_post_summary_asks_for_a_full_page_of_notes():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(200, json_data=[])
+    session.post.return_value = _mock_response(201, json_data={"id": 1})
+
+    ForgeImpl(session=session).post_summary(_gl_ref(), "body")
+
+    params = session.get.call_args[1]["params"]
+    assert params["per_page"] == NOTE_PAGE_SIZE == gitlab._PAGE_SIZE
+    assert params["page"] == 1
+    # Oldest-first, so a note created during the walk lands at the END and
+    # cannot shift a later page's window back over a note already passed.
+    assert params["sort"] == "asc"
+    assert params["order_by"] == "created_at"
+
+
+def test_post_summary_finds_a_summary_past_the_first_page():
+    session = MagicMock(spec=requests.Session)
+    session.get.side_effect = [
+        _full_note_page(),
+        _mock_response(200, json_data=[{"id": 88, "body": f"{MARKER}\nold summary"}]),
+    ]
+    session.put.return_value = _mock_response(200, json_data={"id": 88})
+
+    ForgeImpl(session=session).post_summary(_gl_ref(), "new summary")
+
+    session.post.assert_not_called()
+    session.put.assert_called_once()
+    assert session.put.call_args[0][0].endswith("/notes/88")
+    assert session.get.call_args_list[1][1]["params"]["page"] == 2
+
+
+def test_post_summary_stamps_the_marker_when_the_body_lacks_one():
+    # Nothing upstream of the adapter puts the marker in the body, so a summary
+    # posted without one is invisible to every later lookup.
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(200, json_data=[])
+    session.post.return_value = _mock_response(201, json_data={"id": 1})
+
+    ForgeImpl(session=session).post_summary(_gl_ref(), "no marker here")
+
+    assert session.post.call_args[1]["json"] == {"body": f"{MARKER}\nno marker here"}
+
+
+def test_post_summary_refuses_to_post_when_the_note_read_fails():
+    # The old code swallowed the transport error and fell through to the POST,
+    # which is a SECOND summary on a PR that already had one.
+    session = MagicMock(spec=requests.Session)
+    session.get.side_effect = requests.ConnectionError("down")
+
+    with pytest.raises(FeedReadError, match="note feed"):
+        ForgeImpl(session=session).post_summary(_gl_ref(), "body")
+
+    session.post.assert_not_called()
+    session.put.assert_not_called()
+
+
+def test_post_summary_refuses_to_post_when_the_note_read_returns_an_error_status():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(500, json_data={"message": "boom"})
+
+    with pytest.raises(FeedReadError, match="500"):
+        ForgeImpl(session=session).post_summary(_gl_ref(), "body")
+
+    session.post.assert_not_called()
+
+
+def test_post_summary_refuses_to_post_when_the_notes_outrun_the_page_budget():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _full_note_page()
+
+    with pytest.raises(FeedReadError, match="page budget"):
+        ForgeImpl(session=session).post_summary(_gl_ref(), "body")
+
+    assert session.get.call_count == gitlab._MAX_PAGES
+    session.post.assert_not_called()
+
+
+def test_post_summary_stops_reading_as_soon_as_it_finds_the_marker():
+    session = MagicMock(spec=requests.Session)
+    hit = [{"id": i, "body": "chatter"} for i in range(NOTE_PAGE_SIZE - 1)]
+    hit.append({"id": 88, "body": MARKER})
+    session.get.return_value = _mock_response(200, json_data=hit)
+    session.put.return_value = _mock_response(200, json_data={"id": 88})
+
+    ForgeImpl(session=session).post_summary(_gl_ref(), "new summary")
+
+    assert session.get.call_count == 1
+
+
+def test_list_threads_pages_past_the_first_page():
+    session = MagicMock(spec=requests.Session)
+    session.get.side_effect = [
+        _mock_response(
+            200,
+            json_data=[
+                {"id": f"d{i}", "notes": [{"id": i, "body": f"early {i}"}]}
+                for i in range(NOTE_PAGE_SIZE)
+            ],
+        ),
+        _mock_response(200, json_data=[{"id": "last", "notes": [{"id": 9, "body": "late"}]}]),
+    ]
+
+    threads = ForgeImpl(session=session).list_threads(_gl_ref())
+
+    assert len(threads) == NOTE_PAGE_SIZE + 1
+    assert threads[-1].body_snippet == "late"
+
+
+def test_list_threads_keeps_what_it_read_and_warns_when_the_feed_read_fails(caplog):
+    # Dedup input is best-effort: a partial read beats no read, but the
+    # shortfall has to be visible rather than silent.
+    session = MagicMock(spec=requests.Session)
+    session.get.side_effect = [
+        _mock_response(
+            200,
+            json_data=[
+                {"id": f"d{i}", "notes": [{"id": i, "body": f"early {i}"}]}
+                for i in range(NOTE_PAGE_SIZE)
+            ],
+        ),
+        requests.ConnectionError("down"),
+    ]
+
+    with caplog.at_level(logging.WARNING, logger="prxref.forges.gitlab"):
+        threads = ForgeImpl(session=session).list_threads(_gl_ref())
+
+    assert len(threads) == NOTE_PAGE_SIZE
+    assert "incomplete" in caplog.text.lower()
 
 
 # --- retry policy -----------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -1153,7 +1153,7 @@ wheels = [
 
 [[package]]
 name = "prxref"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },

--- a/uv.lock
+++ b/uv.lock
@@ -1160,24 +1160,30 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+litellm = [
+    { name = "litellm" },
+]
+
+[package.dev-dependencies]
 dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
-litellm = [
-    { name = "litellm" },
-]
 
 [package.metadata]
 requires-dist = [
     { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.40" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "requests", specifier = ">=2.31" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
 ]
-provides-extras = ["dev", "litellm"]
+provides-extras = ["litellm"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-cov", specifier = ">=5.0" },
+    { name = "ruff", specifier = ">=0.6" },
+]
 
 [[package]]
 name = "pydantic"


### PR DESCRIPTION
**The duplicate-comment release.** Three independent ways prxref could post the same thing twice — plus the test command this repo documented but could not run.

### The summary dedup was dead on all four forges

Three adapters defined a `_SUMMARY_MARKER` and scanned the comment feed for it, so `post_summary` could update its previous summary instead of adding another. **Nothing upstream ever wrote the marker into the body.** `_render_summary`, `_FALLBACK_SUMMARY_TEMPLATE`, `prompts/summary.md` and `formatter.format_summary` all render verdict, findings and attribution — and no marker. The lookup searched for a string that was never emitted, so it never matched, so every re-review appended another summary.

Proven by simulating two reviews against the orchestrator's real rendered body: before, all four forges post twice and end with two summary comments; after, all four post once, update once, and end with one.

Four more things independently able to cause the same duplicate, all fixed: truncated paging (GitLab read **one** page of 50, GitHub **one** unparameterised page of 30, neither with a loop); an unreadable feed being read as "no summary exists"; `list_threads` silently under-reporting; and Bitbucket Cloud having no lookup **at all** — an unconditional POST that duplicated on every re-review.

`list_threads` takes the opposite trade from `post_summary`, deliberately: it returns the pages it did read and warns, because the orchestrator substitutes `threads = []` for any exception and raising would throw away good pages. The bug there was the silence, not the partial result.

### A lost write was re-sent up to three times

All four adapters listed the write verbs in `allowed_methods` against a `status_forcelist` of `[429, 500, 502, 503, 504]`. A comment POST the forge had already committed, whose `2xx` was lost on the way back, was sent again. **One `session.post()` put four POSTs on the wire** against a permanent 502 — reproduced on a real localhost server, since a mock never re-sends.

Now `GET`/`HEAD`/`OPTIONS` on all four. 429 is the one case where replaying a write would genuinely have been safe, but `Retry.is_retry` tests the method *before* it consults `status_forcelist`, so no single policy can retry a POST on 429 while holding it back on 502. Connection errors still retry for every verb — urllib3 gates only its read-error path on the method, and a connection never established carried no write.

### `uv run pytest` could not work

pytest and ruff lived in `[project.optional-dependencies]`, and `uv run` never installs a project *extra*. On a cold checkout the documented command exited 2 with `Failed to spawn: pytest`, printed right after a cheerful `Installed N packages`. It survived because CI always spelled `--extra dev` and because the venv is sticky. Now a PEP 735 dependency group, so the bare command is correct.

⚠️ **`pip install prxref[dev]` no longer works**, and it fails *silently* — stock pip exits 0 with no warning and installs the package without the tools. Contributors run `uv sync`; with pip, install the tools directly. The `litellm` runtime extra is untouched.

### CI reviews were truncating

`prxref-review.yml` set no `PRXREF_LLM_MAX_TOKENS`, so it ran on the 4096 default. The configured model is a reasoning model, and reasoning tokens draw from the same completion budget — the response hit `finish_reason=length` before the findings JSON began. On a real PR it reviewed 2 of 4 chunks. Now 32000, the value observed completing 4/4 on that same PR.

### Verification

```
924 passed          uv run pytest        (871 on one branch, 908 on the other; union verified lossless)
All checks passed!  uv run ruff check src tests
0.6.0               uv run prxref --version
```

Both new test modules — `test_forge_bitbucket.py` and `test_forge_github.py` — did not exist before. That absence is how the Cloud dedup gap shipped.

🤖 Authored with Claude Code — Opus 5 (session `1722c3bc`)
