### PR TITLE
fix: GitHub inline comments never posted, and Bitbucket Server diff path prefixes

### DIFF
--- a/src/prxref/forges/github.py
+++ b/src/prxref/forges/github.py
@@ -34,6 +34,22 @@ _PR_URL_RE = re.compile(
 # a refusal to post rather than an invisible short read.
 _PAGE_SIZE = 100
 _MAX_PAGES = 50
+# A rejection body is operator-only diagnostics, never posted to the forge, but
+# it is still bounded: GitHub's validation errors enumerate every unmatched
+# subschema and run long enough to bury the log line that carries them.
+_ERROR_DETAIL_CHARS = 400
+
+
+def _response_detail(resp: requests.Response) -> str:
+    """Return a bounded, single-line rendering of an error response body."""
+    try:
+        body = resp.text or ""
+    except Exception:  # noqa: BLE001 - a body that will not decode is not a failure
+        return "<unreadable body>"
+    collapsed = " ".join(body.split())
+    if len(collapsed) > _ERROR_DETAIL_CHARS:
+        return collapsed[:_ERROR_DETAIL_CHARS] + "…"
+    return collapsed or "<empty body>"
 
 
 def _create_default_session() -> requests.Session:
@@ -236,9 +252,20 @@ class ForgeImpl:
             resp.raise_for_status()
 
     def post_inline_comments(self, ref: PRRef, comments: Sequence[InlineComment]) -> int:
-        """Post inline comments; returns the number actually posted."""
+        """Post inline comments; returns the number actually posted.
+
+        ``commit_id`` is required: without it GitHub rejects the whole payload
+        as matching no subschema, and reports ``line`` itself as an
+        unpermitted key, so every comment 422s rather than only the ones whose
+        line falls outside the diff. The head SHA is read from ``get_pr`` the
+        way the GitLab adapter reads its own position SHAs.
+        """
+        if not comments:
+            return 0
+
         url = f"{self._api_base(ref)}/repos/{ref.owner}/{ref.repo}/pulls/{ref.number}/comments"
         headers = self._headers(ref.host)
+        commit_id = self.get_pr(ref).source_sha
         posted = 0
 
         for comment in comments:
@@ -247,9 +274,18 @@ class ForgeImpl:
                 "path": comment.path,
                 "line": comment.line,
                 "side": comment.side or "RIGHT",
+                "commit_id": commit_id,
             }
             resp = self.session.post(url, json=payload, headers=headers)
             if resp.status_code == 422:
+                # A line outside the diff is the expected 422 and skipping it
+                # is correct, but the same status covers a malformed payload
+                # that would skip every comment. Log the body so the two are
+                # distinguishable instead of both reading as "0 posted".
+                logger.warning(
+                    "GitHub rejected an inline comment on %s:%s (422): %s",
+                    comment.path, comment.line, _response_detail(resp),
+                )
                 continue
             resp.raise_for_status()
             posted += 1

--- a/src/prxref/triage.py
+++ b/src/prxref/triage.py
@@ -98,22 +98,41 @@ class FileDiff:
         }
 
 
-_DIFF_GIT_RE = re.compile(r'^diff --git a/(.*?) b/(.*)$')
+# Bitbucket Server / Data Center spells its diff prefixes ``src://`` and
+# ``dst://`` where git uses ``a/`` and ``b/``. Both spellings have to be
+# understood in two places -- the ``diff --git`` header and the ``---``/``+++``
+# operands -- or Server paths keep the prefix and every reported location reads
+# ``dst://pkg/mod.py`` instead of ``pkg/mod.py``.
+_DIFF_GIT_RES = (
+    re.compile(r'^diff --git a/(.*?) b/(.*)$'),
+    re.compile(r'^diff --git src://(.*?) dst://(.*)$'),
+)
+_PATH_PREFIXES = ("a/", "b/", "src://", "dst://")
 _HUNK_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
 _RENAME_FROM_RE = re.compile(r"^rename from (.+)$")
 _RENAME_TO_RE = re.compile(r"^rename to (.+)$")
 
 
+def _match_diff_git(line: str) -> re.Match | None:
+    """Match a ``diff --git`` header in either the git or Bitbucket Server form."""
+    for pattern in _DIFF_GIT_RES:
+        m = pattern.match(line)
+        if m:
+            return m
+    return None
+
+
 def _clean_path(raw: str) -> str | None:
     """Normalize a ``---``/``+++`` path operand: strip quotes, timestamps,
-    and the a//b/ prefix; map /dev/null to None."""
+    and the a//b/ or src:////dst:// prefix; map /dev/null to None."""
     rest = raw.split("\t")[0].rstrip("\r")
     if len(rest) >= 2 and rest.startswith('"') and rest.endswith('"'):
         rest = rest[1:-1]
     if rest == "/dev/null":
         return None
-    if rest.startswith(("a/", "b/")):
-        rest = rest[2:]
+    for prefix in _PATH_PREFIXES:
+        if rest.startswith(prefix):
+            return rest[len(prefix):]
     return rest
 
 
@@ -203,7 +222,7 @@ def parse_unified_diff(diff: str) -> list[FileDiff]:
 
         if line.startswith("diff --git "):
             close_current()
-            m = _DIFF_GIT_RE.match(line)
+            m = _match_diff_git(line)
             old = m.group(1) if m else None
             new = m.group(2) if m else None
             cur = FileDiff(path=new or old or "", old_path=old, new_path=new)

--- a/tests/test_forge_github.py
+++ b/tests/test_forge_github.py
@@ -255,12 +255,30 @@ def test_list_threads_keeps_what_it_read_and_warns_when_the_feed_read_fails(capl
 # --- inline comments (unchanged behavior, previously untested) --------------
 
 
-def test_post_inline_comments_skips_422_and_keeps_going():
+def _session_for_inline(post_responses, head_sha="deadbeef"):
+    """A session whose get() answers get_pr and whose post() replays statuses.
+
+    post_inline_comments reads the head SHA through get_pr, so an inline-comment
+    test has to satisfy that GET as well as the comment POSTs.
+    """
     session = MagicMock(spec=requests.Session)
-    session.post.side_effect = [
+    session.get.return_value = _mock_response(
+        200,
+        json_data={
+            "title": "t", "body": "", "user": {"login": "u"},
+            "head": {"ref": "feature", "sha": head_sha},
+            "base": {"ref": "main", "sha": "cafe"},
+        },
+    )
+    session.post.side_effect = post_responses
+    return session
+
+
+def test_post_inline_comments_skips_422_and_keeps_going():
+    session = _session_for_inline([
         _mock_response(422),
         _mock_response(201, json_data={"id": 2}),
-    ]
+    ])
     posted = ForgeImpl(session=session).post_inline_comments(
         _ref(),
         [
@@ -269,6 +287,44 @@ def test_post_inline_comments_skips_422_and_keeps_going():
         ],
     )
     assert posted == 1
+
+
+def test_post_inline_comments_sends_commit_id():
+    """GitHub rejects the whole payload without commit_id, reporting `line`
+    itself as an unpermitted key, so every comment 422s rather than only the
+    out-of-diff ones. Assert on the payload: a call-count assertion passes
+    against a body GitHub refuses."""
+    session = _session_for_inline([_mock_response(201, json_data={"id": 1})], head_sha="abc123")
+    posted = ForgeImpl(session=session).post_inline_comments(
+        _ref(), [InlineComment(path="a.py", line=7, body="x")]
+    )
+    assert posted == 1
+    payload = session.post.call_args.kwargs["json"]
+    assert payload["commit_id"] == "abc123"
+    assert payload["path"] == "a.py"
+    assert payload["line"] == 7
+    assert payload["side"] == "RIGHT"
+
+
+def test_post_inline_comments_no_comments_makes_no_requests():
+    """An empty list must not cost a get_pr round trip."""
+    session = MagicMock(spec=requests.Session)
+    assert ForgeImpl(session=session).post_inline_comments(_ref(), []) == 0
+    session.get.assert_not_called()
+    session.post.assert_not_called()
+
+
+def test_post_inline_comments_logs_the_422_body(caplog):
+    """A swallowed 422 used to leave nothing behind, so a payload-level
+    rejection and a legitimately skipped line both read as \"0 posted\"."""
+    session = _session_for_inline([_mock_response(422, text='{"message":"No subschema matched"}')])
+    with caplog.at_level(logging.WARNING, logger="prxref.forges.github"):
+        posted = ForgeImpl(session=session).post_inline_comments(
+            _ref(), [InlineComment(path="a.py", line=1, body="x")]
+        )
+    assert posted == 0
+    assert "No subschema matched" in caplog.text
+    assert "a.py" in caplog.text
 
 
 def test_ref_round_trips_through_the_protocol_dataclass():

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -14,6 +14,67 @@ from prxref.triage import (
 )
 
 
+class TestBitbucketServerDiffPrefixes:
+    """Bitbucket Server / Data Center emits ``src://``/``dst://`` where git
+    emits ``a/``/``b/``.
+
+    The header and operand shapes below are copied verbatim from a real
+    Bitbucket Data Center 10.4.2 pull-request diff. The hand-written Server
+    fixtures elsewhere in the suite all use git-style prefixes, which is
+    exactly why an unstripped ``dst://`` survived into every reported location
+    without a test noticing.
+    """
+
+    SERVER_DIFF = (
+        "diff --git src://cache.py dst://cache.py\n"
+        "index 3cc2d49..4a62838 100644\n"
+        "--- src://cache.py\n"
+        "+++ dst://cache.py\n"
+        "@@ -17,3 +17,4 @@ class TTLCache:\n"
+        " context1\n"
+        " context2\n"
+        " context3\n"
+        "+added_line\n"
+    )
+
+    GIT_DIFF = (
+        SERVER_DIFF
+        .replace("src://", "a/")
+        .replace("dst://", "b/")
+    )
+
+    def test_server_prefixes_are_stripped(self):
+        files = parse_unified_diff(self.SERVER_DIFF)
+        assert len(files) == 1
+        assert files[0].path == "cache.py"
+        assert files[0].old_path == "cache.py"
+        assert files[0].new_path == "cache.py"
+
+    def test_server_form_parses_identically_to_the_git_form(self):
+        """The control: the same diff in git spelling must come out the same."""
+        server = parse_unified_diff(self.SERVER_DIFF)
+        git = parse_unified_diff(self.GIT_DIFF)
+        assert [f.path for f in server] == [f.path for f in git] == ["cache.py"]
+        assert server[0].added_lines == git[0].added_lines
+
+    def test_server_header_is_matched_not_just_the_operands(self):
+        """Without the header pattern the file is still recovered from
+        ``---``/``+++``, so assert the header itself parses -- otherwise a
+        header-only regression stays invisible."""
+        header_only = (
+            "diff --git src://pkg/mod.py dst://pkg/mod.py\n"
+            "@@ -1,2 +1,3 @@\n"
+            " context\n"
+            "+added\n"
+        )
+        files = parse_unified_diff(header_only)
+        assert len(files) == 1
+        assert files[0].path == "pkg/mod.py"
+
+    def test_git_prefixes_still_work(self):
+        assert parse_unified_diff(self.GIT_DIFF)[0].path == "cache.py"
+
+
 class TestUnifiedDiffParsing:
     def test_parses_single_modified_file(self):
         diff = (


### PR DESCRIPTION
Two forge-adapter bugs found by running prxref against a **real** Bitbucket Data Center instance and a real GitHub PR, rather than against the hand-written fixtures. Both were invisible to the existing suite for the same reason: a fixture invented from an adapter's own assumptions cannot contradict them.

## 1. GitHub inline comments never posted (#7)

`post_inline_comments` omitted `commit_id`. GitHub rejected the whole payload as matching no subschema — reporting `line` itself as an unpermitted key — so **every** inline comment 422'd, not just the out-of-diff ones. The bare `continue` on 422 then discarded the reason, leaving a review that completed with zero inline comments and nothing in the log to explain why.

Measured against a real PR, same payload otherwise:

| | posted |
|---|---|
| without `commit_id` | 0/3 (all 422) |
| with `commit_id` | 3/3 (all 201) |

No new plumbing was needed: `PRData.source_sha` is already populated from `head.sha`, and `gitlab.py:373` sets the precedent of reading position SHAs from `get_pr` inside `post_inline_comments`.

The 422 branch stays — a line outside the diff is a legitimate skip — but now logs the bounded response body, so a skipped comment and a rejected payload stop reading identically. The detail is operator-only and never reaches a posted comment.

## 2. Bitbucket Server `src://` / `dst://` prefixes not stripped (#6)

Server spells its diff prefixes `src://` and `dst://` where git uses `a/` and `b/`:

```
diff --git src://cache.py dst://cache.py
--- src://cache.py
+++ dst://cache.py
```

`_clean_path` stripped only the git pair and `_DIFF_GIT_RE` matched only the git header, so every Server path kept its prefix and each location read `dst://cache.py:45` instead of `cache.py:45` — in the visible comment text *and* the inline anchor. Bitbucket accepted those anchors, because its own diff uses the same identifiers, so nothing failed loudly; what a reviewer read was simply wrong.

## Verification

- Both fixes have regression tests that were confirmed **RED on the pre-change tree** and green after — 2 of the GitHub tests and 3 of the Server tests. The Server test carries the git-spelled form of the same diff as a control.
- The Server test's header and operand shapes are copied verbatim from a real Bitbucket Data Center 10.4.2 pull-request diff.
- The GitHub fix was verified through the actual adapter against the live GitHub API (1/1 posted, probe comment deleted), not only against mocks. The previous test asserted on call counts and passed against a body GitHub refuses.
- Full suite: 931 passed. `ruff check src tests`: clean.

Closes #6
Closes #7

---

🤖 Authored with Claude Code

— Claude Opus 5 via Claude Code

Claude-Session-Id: 974bbdda-6362-4426-9971-fec77fabc1d9
