### PR TITLE
feat: blue/red/yellow severity markers in every posted comment

### DIFF
--- a/src/prxref/orchestrator.py
+++ b/src/prxref/orchestrator.py
@@ -88,7 +88,7 @@ POST_INLINE_MODES = frozenset({"summary+inline", "inline"})
 # findings under its own diagnostics.
 MAX_REPORTED_REASONS = 3
 
-_SEVERITY_EMOJI = {"error": "🚨", "warning": "⚠️", "note": "📝"}
+_SEVERITY_MARKERS = {"error": "🟥", "warning": "🟧", "note": "🟦"}
 
 _REDACTED = "[redacted]"
 
@@ -199,8 +199,8 @@ def redact_for_post(reason: str) -> str:
 _FALLBACK_SUMMARY_TEMPLATE = (
     "🤖 **prxref review — {verdict}**\n\n"
     "PR: {title}\n\n"
-    "Files reviewed: {file_count} · errors: {error_count} · "
-    "warnings: {warning_count} · notes: {note_count}\n\n"
+    "Files reviewed: {file_count} · 🟥 {error_count} error · "
+    "🟧 {warning_count} warning · 🟦 {note_count} note\n\n"
     "{findings}\n\n{attribution}"
 )
 
@@ -658,7 +658,7 @@ def _render_summary(
 
     if findings_active:
         bullets = "\n".join(
-            f"- {_SEVERITY_EMOJI.get(f.severity, '📝')} "
+            f"- {_SEVERITY_MARKERS.get(f.severity, '🟦')} "
             f"`{f.file}:{f.line if f.line > 0 else '—'}` — {f.title}"
             for f in findings_active
         )
@@ -730,10 +730,10 @@ def _failure_reason_lines(reasons: Sequence[str]) -> list[str]:
 
 
 def _format_finding(f: Finding, model: str) -> str:
-    emoji = _SEVERITY_EMOJI.get(f.severity, "📝")
+    marker = _SEVERITY_MARKERS.get(f.severity, "🟦")
     loc = f"{f.file}:{f.line}" if f.line > 0 else f.file
     return (
-        f"🤖 {emoji} **[{f.severity.upper()}] {f.title}** (`{loc}`)\n\n"
+        f"🤖 {marker} **[{f.severity.upper()}] {f.title}** (`{loc}`)\n\n"
         f"{f.body}\n\n"
         f"---\n*Reviewed by prxref · model={model}*"
     )

--- a/src/prxref/prompts/summary.md
+++ b/src/prxref/prompts/summary.md
@@ -2,7 +2,7 @@
 
 PR: {title} · files reviewed: {file_count}
 
-{error_count} error · {warning_count} warning · {note_count} note
+🟥 {error_count} error · 🟧 {warning_count} warning · 🟦 {note_count} note
 
 {findings}
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -26,8 +26,8 @@ from prxref.triage import DEFAULT_TOKEN_BUDGET, Finding, build_chunks, parse_uni
 SUMMARY_TEMPLATE = (
     "🤖 **prxref review — {verdict}**\n\n"
     "PR: {title}\n\n"
-    "Files reviewed: {file_count} · errors: {error_count} · "
-    "warnings: {warning_count} · notes: {note_count}\n\n"
+    "Files reviewed: {file_count} · 🟥 {error_count} error · "
+    "🟧 {warning_count} warning · 🟦 {note_count} note\n\n"
     "{findings}\n\n{attribution}"
 )
 
@@ -268,7 +268,7 @@ class TestHappyPath:
         assert "Request-Changes" in summary
         assert "Add widget" in summary
         assert "Files reviewed: 1" in summary
-        assert "errors: 1" in summary
+        assert "🟥 1 error" in summary
         assert "Null deref" in summary
         assert "Reviewed by prxref · model=test-model-1 · 150 tok" in summary
 
@@ -278,11 +278,11 @@ class TestHappyPath:
         by_line = {c.line: c for c in comments}
         assert set(by_line) == {3, 7}
         assert by_line[3].path == "src/app.py"
-        assert "🚨" in by_line[3].body
+        assert "🟥" in by_line[3].body
         assert "[ERROR] Null deref" in by_line[3].body
         assert "x may be None" in by_line[3].body
         assert "Reviewed by prxref · model=test-model-1" in by_line[3].body
-        assert "📝" in by_line[7].body
+        assert "🟦" in by_line[7].body
 
     def test_inline_comments_capped_at_fifteen(self):
         findings = {
@@ -1587,7 +1587,7 @@ class TestPostVerdictKnobs:
         assert "**prxref review**" in summary
         assert "Add widget" in summary
         assert "Files reviewed: 1" in summary
-        assert "errors: 1" in summary
+        assert "🟥 1 error" in summary
         assert "Null deref" in summary
         assert "Reviewed by prxref · model=test-model-1 · 150 tok" in summary
 


### PR DESCRIPTION
## What

The severity squares (🟥 error / 🟧 warning / 🟦 note) existed only in `formatter.py`, which nothing imports — the live renderer in `orchestrator.py` posted 🚨/⚠️/📝 on inline comments and a plain `0 error · 0 warning · 0 note` counts line on summaries.

## Change

- `_SEVERITY_MARKERS` (was `_SEVERITY_EMOJI`) now maps to 🟥/🟧/🟦; unknown severities read as 🟦 note, matching `formatter._norm_severity`
- The shipped `prompts/summary.md` counts line and the fallback template both carry the markers
- Test restatements updated to the new strings

## Verification

- `uv run pytest` — 993 passed
- `uv run ruff check src tests` — clean

Posted output after this lands: summary counts line reads `🟥 N error · 🟧 N warning · 🟦 N note`, each findings bullet and inline comment body is prefixed with its severity square.