### PR TITLE
release: 0.7.0 — severity markers in every posted comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.7.0] — 2026-08-31
+
+The severity-marker release. Every posted comment now carries the severity
+class at a glance: 🟥 error, 🟧 warning, 🟦 note.
+
+### Changed
+
+- **Severity markers in every posted comment.** The squares existed only in
+  `formatter.py`, which nothing imports — the live renderer posted 🚨/⚠️/📝 on
+  inline comments and a plain `0 error · 0 warning · 0 note` counts line on
+  summaries. `_SEVERITY_EMOJI` is now `_SEVERITY_MARKERS` mapping to
+  🟥/🟧/🟦 (unknown severities read as 🟦 note), and both the shipped
+  `prompts/summary.md` counts line and the fallback template carry the same
+  markers. Summary counts lines read `🟥 N error · 🟧 N warning · 🟦 N note`,
+  findings bullets are prefixed with their square, and each inline comment
+  body is prefixed `🤖 🟥 **[ERROR] …` / `🟧 **[WARNING] …` / `🟦 **[NOTE] …`.
+
 ## [0.6.0] — 2026-08-28
 
 The duplicate-comment release. Three ways prxref could post the same thing twice,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prxref"
-version = "0.6.0"
+version = "0.7.0"
 description = "Fast automated AI code review for Bitbucket, GitLab, and GitHub"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/prxref/__init__.py
+++ b/src/prxref/__init__.py
@@ -1,3 +1,3 @@
 """prxref — fast automated AI code review for Bitbucket, GitLab, and GitHub."""
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1153,7 +1153,7 @@ wheels = [
 
 [[package]]
 name = "prxref"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
Version bump to 0.7.0 for #13: pyproject, __init__, uv.lock, CHANGELOG. 993 tests pass, ruff clean. Merging this and tagging v0.7.0 triggers the release workflow (sdist + wheel + PyPI via OIDC).