### PR TITLE
feat: rename the third severity note -> outofscope (0.8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.8.0] — 2026-08-31
+
+The severity-rename release. The blue bucket is now called `outofscope`.
+
+### Changed
+
+- **The third severity is renamed `note` -> `outofscope`** (owner decision). The
+  class contents are unchanged — minor findings: misleading naming, TODOs
+  without context, dead code the diff adds — as are the marker (🟦), the
+  ordering (error-first, outofscope last) and the unknown-severity fallback.
+  Every surface moved together: the worker prompt vocabulary, the quality-gate
+  `SEVERITIES` set, the summary template placeholder (`{outofscope_count}`),
+  both renderers, and the tests. Posted comments now read
+  `🟥 N error · 🟧 N warning · 🟦 N outofscope`.
+
 ## [0.7.0] — 2026-08-31
 
 The severity-marker release. Every posted comment now carries the severity

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prxref"
-version = "0.7.0"
+version = "0.8.0"
 description = "Fast automated AI code review for Bitbucket, GitLab, and GitHub"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/prxref/__init__.py
+++ b/src/prxref/__init__.py
@@ -1,3 +1,3 @@
 """prxref — fast automated AI code review for Bitbucket, GitLab, and GitHub."""
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"

--- a/src/prxref/formatter.py
+++ b/src/prxref/formatter.py
@@ -20,14 +20,14 @@ except ImportError:  # reviewer seat not landed yet; inline default applies
 _SEVERITY_MARKERS: dict[str, str] = {
     "error": "🟥",
     "warning": "🟧",
-    "note": "🟦",
+    "outofscope": "🟦",
 }
-_SEVERITY_ORDER: dict[str, int] = {"error": 0, "warning": 1, "note": 2}
+_SEVERITY_ORDER: dict[str, int] = {"error": 0, "warning": 1, "outofscope": 2}
 
 _DEFAULT_SUMMARY_TEMPLATE = """\
 ## {verdict_banner}
 
-**Findings:** 🟥 {error_count} error · 🟧 {warning_count} warning · 🟦 {note_count} note
+**Findings:** 🟥 {error_count} error · 🟧 {warning_count} warning · 🟦 {outofscope_count} outofscope
 
 {active_count} active of {total_count} raw
 
@@ -42,11 +42,11 @@ _DEFAULT_SUMMARY_TEMPLATE = """\
 
 
 def _norm_severity(severity: str) -> str:
-    """Normalize a severity for lookup; unknown values read as ``note``."""
+    """Normalize a severity for lookup; unknown values read as ``outofscope``."""
     norm = (severity or "").strip().lower()
     if norm in _SEVERITY_MARKERS:
         return norm
-    return "note"
+    return "outofscope"
 
 
 def _fmt_seconds(elapsed_ms: int) -> str:
@@ -121,7 +121,7 @@ def _load_summary_template() -> str:
     """Load ``prompts/summary.md`` via the shared loader, else inline default.
 
     Placeholder contract for the template owner: ``verdict_banner``,
-    ``error_count``, ``warning_count``, ``note_count``, ``active_count``,
+    ``error_count``, ``warning_count``, ``outofscope_count``, ``active_count``,
     ``total_count``, ``findings_table``, ``dropped_section``,
     ``chunk_count``, ``input_tokens``, ``output_tokens``, ``elapsed_s``,
     ``model``, ``attribution``.
@@ -175,8 +175,8 @@ def format_summary(
         "warning_count": sum(
             1 for f in findings_active if _norm_severity(f.severity) == "warning"
         ),
-        "note_count": sum(
-            1 for f in findings_active if _norm_severity(f.severity) == "note"
+        "outofscope_count": sum(
+            1 for f in findings_active if _norm_severity(f.severity) == "outofscope"
         ),
         "active_count": len(findings_active),
         "total_count": len(findings_active) + len(findings_dropped),

--- a/src/prxref/orchestrator.py
+++ b/src/prxref/orchestrator.py
@@ -27,7 +27,7 @@ Stage order (v1 — no Jira, no graph, no learnings, no investigator):
    successful one, so a reason left only in the logs reaches nobody.
 6. Post: summary rendered from ``reviewer.load_prompt("summary")`` with
    placeholders ``{verdict} {title} {file_count} {error_count}
-   {warning_count} {note_count} {findings} {attribution}`` filled, plus
+   {warning_count} {outofscope_count} {findings} {attribution}`` filled, plus
    inline comments for up to ``max_inline_comments`` active findings.
    ``post_mode`` narrows what is written: ``"summary+inline"`` (default) is
    that full behaviour, ``"summary"`` skips the inline batch, ``"inline"``
@@ -88,7 +88,7 @@ POST_INLINE_MODES = frozenset({"summary+inline", "inline"})
 # findings under its own diagnostics.
 MAX_REPORTED_REASONS = 3
 
-_SEVERITY_MARKERS = {"error": "🟥", "warning": "🟧", "note": "🟦"}
+_SEVERITY_MARKERS = {"error": "🟥", "warning": "🟧", "outofscope": "🟦"}
 
 _REDACTED = "[redacted]"
 
@@ -200,7 +200,7 @@ _FALLBACK_SUMMARY_TEMPLATE = (
     "🤖 **prxref review — {verdict}**\n\n"
     "PR: {title}\n\n"
     "Files reviewed: {file_count} · 🟥 {error_count} error · "
-    "🟧 {warning_count} warning · 🟦 {note_count} note\n\n"
+    "🟧 {warning_count} warning · 🟦 {outofscope_count} outofscope\n\n"
     "{findings}\n\n{attribution}"
 )
 
@@ -652,7 +652,7 @@ def _render_summary(
     if not include_verdict:
         template = _strip_verdict_stamp(template)
 
-    counts = {"error": 0, "warning": 0, "note": 0}
+    counts = {"error": 0, "warning": 0, "outofscope": 0}
     for f in findings_active:
         counts[f.severity] = counts.get(f.severity, 0) + 1
 
@@ -675,7 +675,7 @@ def _render_summary(
         .replace("{file_count}", str(len(files)))
         .replace("{error_count}", str(counts["error"]))
         .replace("{warning_count}", str(counts["warning"]))
-        .replace("{note_count}", str(counts["note"]))
+        .replace("{outofscope_count}", str(counts["outofscope"]))
         .replace("{findings}", bullets)
         .replace("{attribution}", attribution)
     )

--- a/src/prxref/prompts/summary.md
+++ b/src/prxref/prompts/summary.md
@@ -2,7 +2,7 @@
 
 PR: {title} · files reviewed: {file_count}
 
-🟥 {error_count} error · 🟧 {warning_count} warning · 🟦 {note_count} note
+🟥 {error_count} error · 🟧 {warning_count} warning · 🟦 {outofscope_count} outofscope
 
 {findings}
 

--- a/src/prxref/prompts/worker.md
+++ b/src/prxref/prompts/worker.md
@@ -8,7 +8,7 @@ Verify every claim against the diff itself. Every finding must cite a file and l
 
 - `error` — the change will break at runtime or is a real bug: crash, wrong result, data loss, security hole, broken contract.
 - `warning` — risk or smell the diff introduces or worsens: race-prone pattern, resource leak, missing error handling, load-bearing duplication.
-- `note` — minor: misleading naming, a TODO without context, dead code the diff adds.
+- `outofscope` — minor: misleading naming, a TODO without context, dead code the diff adds.
 
 ## Confidence
 

--- a/src/prxref/quality.py
+++ b/src/prxref/quality.py
@@ -22,7 +22,7 @@ from dataclasses import replace
 from .forges.base import Thread
 from .triage import Finding
 
-SEVERITIES: frozenset[str] = frozenset({"error", "warning", "note"})
+SEVERITIES: frozenset[str] = frozenset({"error", "warning", "outofscope"})
 
 DEFAULT_CONFIDENCE_FLOOR: float = 0.6
 DEFAULT_MAX_ERRORS: int = 10

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -735,7 +735,7 @@ class TestFailOnExitPolicy:
         self, fake_runtime, monkeypatch, capsys
     ):
         monkeypatch.setenv("PRXREF_FAIL_ON", "error")
-        self._install_result(fake_runtime, ["error", "note"])
+        self._install_result(fake_runtime, ["error", "outofscope"])
         code = self._review()
         assert code == 1
         out, err = capsys.readouterr()
@@ -747,7 +747,7 @@ class TestFailOnExitPolicy:
         self, fake_runtime, monkeypatch
     ):
         monkeypatch.setenv("PRXREF_FAIL_ON", "error")
-        self._install_result(fake_runtime, ["warning", "note"])
+        self._install_result(fake_runtime, ["warning", "outofscope"])
         assert self._review() == 0
 
     def test_error_policy_matches_severity_exactly(

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -68,7 +68,7 @@ class TestFormatInlineComment:
 
     def test_warning_and_note_markers(self):
         assert format_inline_comment(_f(severity="warning"), "a").startswith("🟧 **")
-        assert format_inline_comment(_f(severity="note"), "a").startswith("🟦 **")
+        assert format_inline_comment(_f(severity="outofscope"), "a").startswith("🟦 **")
 
     def test_unknown_severity_defaults_to_note(self):
         assert format_inline_comment(_f(severity=""), "a").startswith("🟦 **")
@@ -95,12 +95,12 @@ class TestFormatSummaryCounts:
             findings_active=[
                 _f(severity="error", file="a.py"),
                 _f(severity="error", file="b.py"),
-                _f(severity="note"),
+                _f(severity="outofscope"),
             ]
         )
         assert "🟥 2 error" in text
         assert "🟧 0 warning" in text
-        assert "🟦 1 note" in text
+        assert "🟦 1 outofscope" in text
 
     def test_active_of_total_counts(self):
         assert "1 active of 2 raw" in _summary()
@@ -112,7 +112,7 @@ class TestFormatSummaryCounts:
             findings_dropped=[],
         )
         assert "✅ Approved" in text
-        assert "🟥 0 error · 🟧 0 warning · 🟦 0 note" in text
+        assert "🟥 0 error · 🟧 0 warning · 🟦 0 outofscope" in text
         assert "0 active of 0 raw" in text
         assert "No findings survived the quality passes." in text
 
@@ -121,7 +121,7 @@ class TestFormatSummaryTables:
     def test_table_rows_sorted_error_first(self):
         text = _summary(
             findings_active=[
-                _f(severity="note", file="z.py", line=1),
+                _f(severity="outofscope", file="z.py", line=1),
                 _f(severity="error", file="z.py", line=2, title="Boom"),
             ]
         )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -310,7 +310,7 @@ class TestScenario2ModelFallback:
                 {
                     "file": "src/auth.py",
                     "line": 2,
-                    "severity": "note",
+                    "severity": "outofscope",
                     "confidence": 0.8,
                     "title": "Token validation note",
                     "body": "Token check is standard.",

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -27,7 +27,7 @@ SUMMARY_TEMPLATE = (
     "🤖 **prxref review — {verdict}**\n\n"
     "PR: {title}\n\n"
     "Files reviewed: {file_count} · 🟥 {error_count} error · "
-    "🟧 {warning_count} warning · 🟦 {note_count} note\n\n"
+    "🟧 {warning_count} warning · 🟦 {outofscope_count} note\n\n"
     "{findings}\n\n{attribution}"
 )
 
@@ -236,7 +236,7 @@ HAPPY_FINDINGS = {
     "src/app.py": [
         {"file": "src/app.py", "line": 3, "severity": "error", "confidence": 0.9,
          "title": "Null deref", "body": "x may be None when config is missing."},
-        {"file": "src/app.py", "line": 7, "severity": "note", "confidence": 0.8,
+        {"file": "src/app.py", "line": 7, "severity": "outofscope", "confidence": 0.8,
          "title": "Typo", "body": "recieve -> receive."},
     ],
 }
@@ -974,7 +974,7 @@ def _review_chunk_failing(errors_by_path: dict[str, str], *, tokens: int = 0):
         error = errors_by_path.get(files[0].path, "")
         findings = [] if error else [
             Finding(
-                file=files[0].path, line=1, severity="note", confidence=0.9,
+                file=files[0].path, line=1, severity="outofscope", confidence=0.9,
                 title="ok", body="b",
             )
         ]

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -196,7 +196,7 @@ class TestQualityGate:
     def test_enforces_severity_vocabulary(self):
         f_invalid = _f(severity="concern", confidence=0.95)
         f_blueprint = _f(severity="blueprint", confidence=0.95)
-        f_note = _f(severity="note", confidence=0.95)
+        f_note = _f(severity="outofscope", confidence=0.95)
 
         result = apply_quality_gate([f_invalid, f_blueprint, f_note])
         assert result[0].drop_reason == "invalid severity: 'concern'"

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -257,8 +257,8 @@ class TestReviewChunk:
     def test_skips_finding_entries_without_file(self):
         payload = json.dumps({
             "findings": [
-                {"line": 1, "severity": "note", "title": "Missing file", "body": "no file key"},
-                {"file": "src/app.py", "line": 2, "severity": "note", "title": "OK", "body": "has file"},
+                {"line": 1, "severity": "outofscope", "title": "Missing file", "body": "no file key"},
+                {"file": "src/app.py", "line": 2, "severity": "outofscope", "title": "OK", "body": "has file"},
             ],
             "escalations": [],
         })

--- a/uv.lock
+++ b/uv.lock
@@ -1153,7 +1153,7 @@ wheels = [
 
 [[package]]
 name = "prxref"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
## What

The blue severity bucket is renamed `note` -> `outofscope` (owner decision). The class contents are unchanged — minor findings: misleading naming, TODOs without context, dead code the diff adds. Marker stays 🟦; error-first ordering and the unknown-severity fallback are unchanged.

## Surfaces moved together

- `prompts/worker.md` severity vocabulary
- `quality.SEVERITIES` (the gate that validates the vocabulary)
- `prompts/summary.md` placeholder `{outofscope_count}` + rendered word
- `orchestrator.py` counts/template/markers, `formatter.py` (both renderers)
- all test fixtures and pins

## Verification

- `uv run pytest` — 993 passed
- `uv run ruff check src tests` — clean
- includes version bump to 0.8.0 + CHANGELOG