### PR TITLE
feat: stale-inline pruning and honest inline accounting (0.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.9.0] — 2026-08-31
+
+The honesty release. What stands on a PR after a re-review now equals the
+latest review, and the summary keeps the promises its findings list makes.
+
+### Added
+
+- **Stale-inline pruning (#17).** A re-review updates the summary in place,
+  but the previous run's inline comments stayed standing — an Approved
+  summary could sit above stale ERROR comments from an earlier,
+  nondeterministic run. Forges may now implement
+  `prune_inline_comments(ref) -> int` (GitHub does; the others follow): the
+  orchestrator calls it before reading threads, so the dedup cannot suppress
+  this run's findings against comments that are about to disappear. Only
+  comments carrying the attribution marker (`Reviewed by prxref`) are ever
+  deleted — a human's comment is not a candidate — and the whole pass is
+  best-effort: a 403 from a different identity's comment, or an unreadable
+  feed, logs and continues rather than aborting the review.
+
+- **Inline accounting in the summary (#16).** The summary itemizes every
+  active finding, but the inline pass could silently post fewer — the
+  `PRXREF_MAX_INLINE_COMMENTS` cap, a forge that rejected the anchor (a 422
+  on a line outside the diff), or a failed batch — with nothing on the PR
+  saying so. When fewer inline comments land than findings are itemized, the
+  summary is re-posted (update-in-place) with a line naming the shortfall and
+  its reasons, e.g. `Inline comments: 13 of 21 findings (6 over the
+  15-comment cap · 2 anchors rejected by the forge).` A failed batch is
+  disclosed the same way.
+
+### Changed
+
+- **The inline slice is severity-ordered.** Findings previously became
+  comments in chunk order, so the cap and rejected anchors cost the run
+  whatever sat at the tail — including error-severity findings. The slice is
+  now error-first, then warning, then outofscope, confidence-descending
+  within each.
+
+- `post_inline_comments`'s return value — the number actually posted — was
+  computed by the forges and discarded by the orchestrator; it now drives
+  the accounting line and the posted-count trace event.
+
 ## [0.8.0] — 2026-08-31
 
 The severity-rename release. The blue bucket is now called `outofscope`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prxref"
-version = "0.8.0"
+version = "0.9.0"
 description = "Fast automated AI code review for Bitbucket, GitLab, and GitHub"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/prxref/__init__.py
+++ b/src/prxref/__init__.py
@@ -1,3 +1,3 @@
 """prxref — fast automated AI code review for Bitbucket, GitLab, and GitHub."""
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"

--- a/src/prxref/forges/base.py
+++ b/src/prxref/forges/base.py
@@ -64,6 +64,13 @@ class PRData:
 
 SUMMARY_MARKER = "<!-- prxref-summary -->"
 
+# The attribution prefix every posted comment carries (the full line is
+# ``Reviewed by prxref · model=… · N tok · Xs``). The prune pass matches on
+# this prefix to recognise its own comments, so the constant lives beside the
+# summary marker it keeps company with: both are the tool's own fingerprints
+# on a forge's comment feed.
+ATTRIBUTION_MARKER = "Reviewed by prxref"
+
 
 class FeedReadError(RuntimeError):
     """A PR's comment/activity feed could not be read all the way to the end.

--- a/src/prxref/forges/github.py
+++ b/src/prxref/forges/github.py
@@ -13,6 +13,7 @@ from requests.adapters import HTTPAdapter
 from prxref.retry_logging import LoggingRetry
 
 from .base import (
+    ATTRIBUTION_MARKER,
     SUMMARY_MARKER,
     FeedReadError,
     InlineComment,
@@ -333,3 +334,50 @@ class ForgeImpl:
             )
 
         return threads
+
+    def prune_inline_comments(self, ref: PRRef) -> int:
+        """Delete prxref-attributed inline comments; returns the count removed.
+
+        A re-review updates the summary in place, but the previous run's
+        inline comments stayed standing — so a PR could carry an Approved
+        summary above stale ERROR-severity comments from an earlier,
+        nondeterministic run. Deleting our own comments first keeps what
+        stands on the PR equal to the latest review.
+
+        Only comments whose body carries the attribution marker are
+        candidates, so a human's comment is never touched. A delete the token
+        is not allowed to perform (403 from a different identity's comment)
+        is logged and skipped, and a feed that cannot be read ends the prune
+        with what it already removed: best-effort, because a cleanup must
+        never abort the review that follows it.
+        """
+        list_url = f"{self._api_base(ref)}/repos/{ref.owner}/{ref.repo}/pulls/{ref.number}/comments"
+        headers = self._headers(ref.host)
+        removed = 0
+        try:
+            for comments in self._iter_comment_pages(ref, list_url, headers):
+                for comment in comments:
+                    if ATTRIBUTION_MARKER not in (comment.get("body") or ""):
+                        continue
+                    comment_id = comment.get("id")
+                    if comment_id is None:
+                        continue
+                    resp = self.session.delete(
+                        f"{list_url}/{comment_id}", headers=headers
+                    )
+                    if resp.ok:
+                        removed += 1
+                    else:
+                        logger.warning(
+                            "could not prune inline comment %s on %s/%s#%s "
+                            "(HTTP %s): %s",
+                            comment_id, ref.owner, ref.repo, ref.number,
+                            resp.status_code, _response_detail(resp),
+                        )
+        except FeedReadError as e:
+            logger.warning(
+                "prune of review comments on %s/%s#%s ended early after %d "
+                "removals (best-effort): %s",
+                ref.owner, ref.repo, ref.number, removed, e,
+            )
+        return removed

--- a/src/prxref/orchestrator.py
+++ b/src/prxref/orchestrator.py
@@ -56,7 +56,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 from . import reviewer
-from .forges.base import Forge, InlineComment, PRData, PRRef
+from .forges.base import ATTRIBUTION_MARKER, Forge, InlineComment, PRData, PRRef
 from .llm import LLMClient
 from .quality import active, apply_line_align, apply_quality_gate, apply_thread_dedup
 from .trace import Tracer, get_tracer
@@ -89,6 +89,11 @@ POST_INLINE_MODES = frozenset({"summary+inline", "inline"})
 MAX_REPORTED_REASONS = 3
 
 _SEVERITY_MARKERS = {"error": "🟥", "warning": "🟧", "outofscope": "🟦"}
+
+# Inline-comment priority: the most severe findings get the anchor first, so
+# a cap or a rejected anchor costs the run its least-important comments
+# rather than whatever happened to sit at the tail of chunk order.
+_SEVERITY_RANK = {"error": 0, "warning": 1, "outofscope": 2}
 
 _REDACTED = "[redacted]"
 
@@ -363,6 +368,9 @@ def orchestrate_review(
 
     findings = [f for r in results if not r["error"] for f in r["findings"]]
 
+    if post and post_mode in POST_INLINE_MODES:
+        _prune_stale_inline_comments(forge, ref)
+
     try:
         threads = forge.list_threads(ref)
     except Exception as e:  # noqa: BLE001
@@ -416,21 +424,53 @@ def orchestrate_review(
             logger.error("post_summary failed: %s", e)
     # A summary-mode run still requires the summary to have landed before the
     # inline batch rides on it; an inline-mode run has no summary to gate on.
+    inline_attempted = 0
+    inline_failed = False
     if post_inline_wanted and findings_active and (posted or not post_summary_wanted):
+        ordered = sorted(
+            findings_active,
+            key=lambda f: (_SEVERITY_RANK.get(f.severity, 3), -f.confidence),
+        )
         comments = [
             InlineComment(
                 path=f.file,
                 line=f.line,
                 body=_format_finding(f, model),
             )
-            for f in findings_active[:max_inline_comments]
+            for f in ordered[:max_inline_comments]
         ]
+        inline_attempted = len(comments)
         try:
-            forge.post_inline_comments(ref, comments)
+            inline_posted = forge.post_inline_comments(ref, comments)
             posted = True
-            inline_posted = len(comments)
         except Exception as e:  # noqa: BLE001
             logger.error("post_inline_comments failed: %s", e)
+            inline_failed = True
+
+    # The summary itemizes every active finding, so when the inline pass left
+    # some of them without an anchor the summary has to say so — otherwise it
+    # promises a per-finding comment the PR never received. The counts only
+    # exist after posting, so the disclosure rides a second post_summary call,
+    # which the forges already implement as an update-in-place.
+    if (
+        post_summary_wanted and posted and post_inline_wanted
+        and len(findings_active) > inline_posted
+    ):
+        refreshed = _render_summary(
+            pr, files, verdict, findings_active, model,
+            input_tokens, output_tokens, elapsed_ms,
+            chunks_reviewed=chunks_reviewed, chunks_failed=chunks_failed,
+            failure_reasons=[r["error"] for r in results if r["error"]],
+            include_verdict=post_verdict,
+            inline_accounting=_inline_accounting(
+                len(findings_active), inline_attempted, inline_posted,
+                failed=inline_failed, cap=max_inline_comments,
+            ),
+        )
+        try:
+            forge.post_summary(ref, refreshed)
+        except Exception as e:  # noqa: BLE001
+            logger.error("summary re-post with inline accounting failed: %s", e)
 
     if post and (post_summary_wanted or post_inline_wanted):
         tracer.event(
@@ -462,7 +502,56 @@ def _elapsed_ms(t0: float) -> int:
 
 
 def _attribution(model: str, tokens: int, elapsed_ms: int) -> str:
-    return f"Reviewed by prxref · model={model} · {tokens} tok · {elapsed_ms / 1000:.1f}s"
+    return f"{ATTRIBUTION_MARKER} · model={model} · {tokens} tok · {elapsed_ms / 1000:.1f}s"
+
+
+def _prune_stale_inline_comments(forge: Forge, ref: PRRef) -> None:
+    """Call the forge's optional stale-inline cleanup, before dedup reads threads.
+
+    The order is load-bearing: pruning after ``list_threads`` would let the
+    thread dedup suppress this run's findings as already-discussed and then
+    delete the very comments it suppressed them against, removing the finding
+    from the PR entirely. The capability is optional — forges without it and
+    the duck-typed test fakes are skipped via getattr — and best-effort: a
+    prune failure is logged, never raised, because cleanup must not abort the
+    review that follows it.
+    """
+    prune = getattr(forge, "prune_inline_comments", None)
+    if not callable(prune):
+        return
+    try:
+        removed = prune(ref)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("prune_inline_comments failed (best-effort): %s", e)
+        return
+    if removed:
+        logger.info("pruned %d stale inline comment(s) before posting", removed)
+
+
+def _inline_accounting(
+    active: int, attempted: int, posted: int, *, failed: bool, cap: int
+) -> str:
+    """Render the claimed-vs-posted inline reconciliation line.
+
+    The summary itemizes every active finding; when the inline pass leaves
+    some of them without an anchor — the cap, a forge that rejected the
+    position, or a failed batch — this line keeps the summary's promise
+    honest instead of silently itemizing comments that never landed.
+    """
+    if failed:
+        return (
+            f"Inline comments: posting failed — 0 of {active} findings have one."
+        )
+    reasons: list[str] = []
+    capped = max(0, active - attempted)
+    rejected = max(0, attempted - posted)
+    if capped:
+        reasons.append(f"{capped} over the {cap}-comment cap")
+    if rejected:
+        plural = "s" if rejected != 1 else ""
+        reasons.append(f"{rejected} anchor{plural} rejected by the forge")
+    detail = " · ".join(reasons) if reasons else "unposted"
+    return f"Inline comments: {posted} of {active} findings ({detail})."
 
 
 HEARTBEAT_SECONDS = 30.0
@@ -643,6 +732,7 @@ def _render_summary(
     chunks_failed: int = 0,
     failure_reasons: Sequence[str] = (),
     include_verdict: bool = True,
+    inline_accounting: str | None = None,
 ) -> str:
     try:
         template = reviewer.load_prompt("summary")
@@ -664,6 +754,8 @@ def _render_summary(
         )
     else:
         bullets = "No findings — nice work."
+    if inline_accounting:
+        bullets = f"{bullets}\n\n{inline_accounting}"
 
     attribution = _attribution(
         model, input_tokens + output_tokens, elapsed_ms,

--- a/tests/test_forge_github.py
+++ b/tests/test_forge_github.py
@@ -333,6 +333,61 @@ def test_ref_round_trips_through_the_protocol_dataclass():
     assert ForgeImpl.parse_pr_url(ref.url) == ref
 
 
+# --- pruning stale inline comments -------------------------------------------
+
+
+ATTRIBUTION_BODY = (
+    "🤖 🟥 **[ERROR] x** (`a.py:1`)\n\nbody\n\n---\n"
+    "*Reviewed by prxref · model=m*"
+)
+
+
+def test_prune_deletes_only_attributed_comments():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(
+        200,
+        json_data=[
+            {"id": 11, "body": ATTRIBUTION_BODY},
+            {"id": 12, "body": "a human's comment, never a candidate"},
+            {"id": 13, "body": "*Reviewed by prxref · model=other*"},
+        ],
+    )
+    session.delete.return_value = _mock_response(204)
+
+    removed = ForgeImpl(session=session).prune_inline_comments(_ref())
+
+    assert removed == 2
+    deleted_ids = {c.args[0].rsplit("/", 1)[-1] for c in session.delete.call_args_list}
+    assert deleted_ids == {"11", "13"}
+
+
+def test_prune_counts_past_a_delete_the_token_cannot_perform():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(
+        200,
+        json_data=[
+            {"id": 21, "body": ATTRIBUTION_BODY},
+            {"id": 22, "body": ATTRIBUTION_BODY},
+        ],
+    )
+    session.delete.side_effect = [_mock_response(204), _mock_response(403)]
+
+    removed = ForgeImpl(session=session).prune_inline_comments(_ref())
+
+    assert removed == 1
+    assert session.delete.call_count == 2
+
+
+def test_prune_survives_an_unreadable_feed():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(500)
+
+    removed = ForgeImpl(session=session).prune_inline_comments(_ref())
+
+    assert removed == 0
+    session.delete.assert_not_called()
+
+
 # --- retry policy -----------------------------------------------------------
 
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -27,7 +27,7 @@ SUMMARY_TEMPLATE = (
     "🤖 **prxref review — {verdict}**\n\n"
     "PR: {title}\n\n"
     "Files reviewed: {file_count} · 🟥 {error_count} error · "
-    "🟧 {warning_count} warning · 🟦 {outofscope_count} note\n\n"
+    "🟧 {warning_count} warning · 🟦 {outofscope_count} outofscope\n\n"
     "{findings}\n\n{attribution}"
 )
 
@@ -300,6 +300,82 @@ class TestHappyPath:
         assert len(forge.inline_batches) == 1
         assert len(forge.inline_batches[0]) == 15
         assert res["posted"] is True
+
+    def test_inline_batch_is_severity_ordered(self):
+        findings = {
+            "src/app.py": [
+                {"file": "src/app.py", "line": 3, "severity": "warning",
+                 "confidence": 0.9, "title": "warn high", "body": "b"},
+                {"file": "src/app.py", "line": 5, "severity": "warning",
+                 "confidence": 0.8, "title": "warn low", "body": "b"},
+                {"file": "src/app.py", "line": 7, "severity": "error",
+                 "confidence": 0.7, "title": "the error", "body": "b"},
+            ],
+        }
+        forge = FakeForge(diff=_added_file_diff("src/app.py", 20))
+        orchestrate_review(forge, REF, FakeLLM(findings_by_path=findings))
+
+        bodies = [c.body for c in forge.inline_batches[0]]
+        error_positions = [i for i, b in enumerate(bodies) if "[ERROR] the error" in b]
+        assert error_positions == [0]
+
+    def test_cap_shortfall_is_disclosed_in_the_summary(self):
+        findings = {
+            "src/app.py": [
+                {"file": "src/app.py", "line": 3, "severity": "error",
+                 "confidence": 0.9, "title": "kept", "body": "b"},
+                {"file": "src/app.py", "line": 5, "severity": "warning",
+                 "confidence": 0.9, "title": "capped out", "body": "b"},
+            ],
+        }
+        forge = FakeForge(diff=_added_file_diff("src/app.py", 20))
+        orchestrate_review(
+            forge, REF, FakeLLM(findings_by_path=findings),
+            max_inline_comments=1,
+        )
+
+        assert len(forge.summaries) == 2
+        assert "Inline comments:" not in forge.summaries[0]
+        assert "Inline comments: 1 of 2 findings (1 over the 1-comment cap)." in (
+            forge.summaries[1]
+        )
+
+    def test_rejected_anchors_are_disclosed_in_the_summary(self):
+        class RejectingForge(FakeForge):
+            def post_inline_comments(self, ref, comments) -> int:
+                self.inline_batches.append(list(comments))
+                return max(0, len(comments) - 1)
+
+        findings = {
+            "src/app.py": [
+                {"file": "src/app.py", "line": 3, "severity": "error",
+                 "confidence": 0.9, "title": "posted", "body": "b"},
+                {"file": "src/app.py", "line": 5, "severity": "warning",
+                 "confidence": 0.9, "title": "rejected", "body": "b"},
+            ],
+        }
+        forge = RejectingForge(diff=_added_file_diff("src/app.py", 20))
+        orchestrate_review(forge, REF, FakeLLM(findings_by_path=findings))
+
+        assert "Inline comments: 1 of 2 findings (1 anchor rejected by the forge)." in (
+            forge.summaries[-1]
+        )
+
+    def test_failed_inline_batch_is_disclosed_in_the_summary(self):
+        findings = {
+            "src/app.py": [
+                {"file": "src/app.py", "line": 3, "severity": "error",
+                 "confidence": 0.9, "title": "lost", "body": "b"},
+            ],
+        }
+        forge = FakeForge(diff=_added_file_diff("src/app.py", 20))
+        forge.fail.add("post_inline")
+        orchestrate_review(forge, REF, FakeLLM(findings_by_path=findings))
+
+        assert (
+            "Inline comments: posting failed — 0 of 1 findings have one."
+            in forge.summaries[-1]
+        )
 
 
 class TestParallelFanOut:
@@ -1407,6 +1483,61 @@ class TestMultiLineReasonsStayInTheBlockquote:
     def test_the_continuation_text_is_still_reported(self, monkeypatch):
         forge, _res = self._run(monkeypatch, self.MULTILINE)
         assert "second line of the reason" in forge.summaries[0]
+
+
+class TestStaleInlinePrune:
+    """A re-review clears its own prior inline comments before it reads threads.
+
+    Order is the whole point: prune must precede ``list_threads`` or the dedup
+    would suppress this run's findings as already-discussed and then delete the
+    comments it suppressed them against. And a clean re-review (zero findings)
+    still prunes, so an Approved summary cannot keep standing above the stale
+    ERROR comments of an earlier, nondeterministic run.
+    """
+
+    class PruningForge(FakeForge):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.calls: list[str] = []
+            self.pruned = 0
+
+        def prune_inline_comments(self, ref) -> int:
+            self.calls.append("prune")
+            self.pruned += 3
+            return 3
+
+        def list_threads(self, ref):
+            self.calls.append("list_threads")
+            return super().list_threads(ref)
+
+    def test_prune_precedes_thread_listing(self):
+        forge = self.PruningForge(diff=_added_file_diff("src/app.py", 20))
+        orchestrate_review(forge, REF, FakeLLM(findings_by_path=HAPPY_FINDINGS))
+        assert forge.calls.index("prune") < forge.calls.index("list_threads")
+
+    def test_a_clean_rerun_still_prunes(self):
+        forge = self.PruningForge(diff=_added_file_diff("src/app.py", 20))
+        res = orchestrate_review(forge, REF, FakeLLM(findings_by_path={}))
+        assert res["verdict"] == "Approved"
+        assert forge.calls[0] == "prune"
+        assert forge.inline_batches == []
+
+    def test_a_prune_failure_never_aborts_the_review(self):
+        class ExplodingPrune(self.PruningForge):
+            def prune_inline_comments(self, ref) -> int:
+                self.calls.append("prune")
+                raise RuntimeError("boom prune")
+
+        forge = ExplodingPrune(diff=_added_file_diff("src/app.py", 20))
+        res = orchestrate_review(forge, REF, FakeLLM(findings_by_path=HAPPY_FINDINGS))
+        assert res["posted"] is True
+        assert len(forge.inline_batches) == 1
+
+    def test_forges_without_the_capability_are_skipped(self):
+        forge = FakeForge(diff=_added_file_diff("src/app.py", 20))
+        res = orchestrate_review(forge, REF, FakeLLM(findings_by_path=HAPPY_FINDINGS))
+        assert res["posted"] is True
+        assert len(forge.summaries) == 1
 
 
 class TestPostModeKnobs:

--- a/uv.lock
+++ b/uv.lock
@@ -1153,7 +1153,7 @@ wheels = [
 
 [[package]]
 name = "prxref"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
Fixes #16, fixes #17. Found by the review-the-reviews audit (2026-08-31).

## What

**Pruning (#17):** re-reviews left prior runs' inline comments standing — an Approved summary could sit above stale ERROR comments. `prune_inline_comments(ref) -> int` (implemented for GitHub; other forges follow) is called before `list_threads` so thread-dedup can't suppress findings against comments about to be deleted. Only attribution-carrying comments are ever touched; 403s and unreadable feeds log and continue.

**Accounting (#16):** the summary itemized 21 findings while 13 inline comments posted (cap 15 + 2 rejected anchors), silently. The forge's return value — previously discarded — now drives a shortfall line re-posted into the summary: `Inline comments: 13 of 21 findings (6 over the 15-comment cap · 2 anchors rejected by the forge).` Failed batches disclosed too.

**Severity-ordered slice:** the cap previously cost the run whatever sat at the tail of chunk order, including errors.

## Verification

- `uv run pytest` — 1004 passed (11 new: ordering, cap/rejected/failed disclosure, prune order, clean-rerun prune, prune failure, capability-absent, 3 adapter-level prune tests)
- `uv run ruff check src tests` — clean

Also fixes a leftover from #15: the test restatement of the fallback template rendered `🟦 N note` after the placeholder rename.