### PR TITLE
fix: the GitHub prune pass deleted nothing — wrong route (0.9.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- **The GitHub prune pass deleted nothing (0.9.0).** The delete route was
+  built from the listing URL, which carries the pull number
+  (`/pulls/N/comments/{id}`); the delete route lives outside that namespace
+  (`/pulls/comments/{id}`), so every DELETE 404'd while the run reported
+  partial success. Found live against a real PR; the mocked-session test
+  now pins the endpoint's shape.
+
 ## [0.9.0] — 2026-08-31
 
 The honesty release. What stands on a PR after a re-review now equals the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prxref"
-version = "0.9.0"
+version = "0.9.1"
 description = "Fast automated AI code review for Bitbucket, GitLab, and GitHub"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/prxref/__init__.py
+++ b/src/prxref/__init__.py
@@ -1,3 +1,3 @@
 """prxref — fast automated AI code review for Bitbucket, GitLab, and GitHub."""
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"

--- a/src/prxref/forges/github.py
+++ b/src/prxref/forges/github.py
@@ -362,9 +362,16 @@ class ForgeImpl:
                     comment_id = comment.get("id")
                     if comment_id is None:
                         continue
-                    resp = self.session.delete(
-                        f"{list_url}/{comment_id}", headers=headers
+                    # The delete route lives outside the pull-number
+                    # namespace — /pulls/comments/{id}, not /pulls/N/
+                    # comments/{id} — so the listing URL and the delete URL
+                    # differ in shape, and the listing-shaped one 404s for
+                    # every comment.
+                    delete_url = (
+                        f"{self._api_base(ref)}/repos/{ref.owner}/{ref.repo}"
+                        f"/pulls/comments/{comment_id}"
                     )
+                    resp = self.session.delete(delete_url, headers=headers)
                     if resp.ok:
                         removed += 1
                     else:

--- a/tests/test_forge_github.py
+++ b/tests/test_forge_github.py
@@ -357,7 +357,13 @@ def test_prune_deletes_only_attributed_comments():
     removed = ForgeImpl(session=session).prune_inline_comments(_ref())
 
     assert removed == 2
-    deleted_ids = {c.args[0].rsplit("/", 1)[-1] for c in session.delete.call_args_list}
+    deleted_urls = [c.args[0] for c in session.delete.call_args_list]
+    # The delete route carries NO pull number: /pulls/comments/{id}. The
+    # listing URL does, and reusing it 404s every delete.
+    for url in deleted_urls:
+        assert "/repos/acme/api/pulls/comments/" in url
+        assert "/pulls/42/" not in url
+    deleted_ids = {url.rsplit("/", 1)[-1] for url in deleted_urls}
     assert deleted_ids == {"11", "13"}
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1153,7 +1153,7 @@ wheels = [
 
 [[package]]
 name = "prxref"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
Follow-up to #20. Found in live verification, not in review: the prune DELETE was built from the listing URL and kept the pull number (`/pulls/N/comments/{id}`); GitHub's delete route is `/pulls/comments/{id}` — no pull number — so all 12 DELETEs on a real PR 404'd while the run logged only partial-sounding warnings and pruned zero. The test now asserts the route shape (no `/pulls/42/` segment). 1004 passed, ruff clean.