### PR TITLE
Deterministic severity-consistency pass before the quality gate (fixes #18)

### DIFF
--- a/src/prxref/orchestrator.py
+++ b/src/prxref/orchestrator.py
@@ -16,6 +16,8 @@ Stage order (v1 — no Jira, no graph, no learnings, no investigator):
    accepted for test doubles.
 4. Quality passes in order: ``apply_line_align`` → thread dedup
    (existing threads fetched best-effort; failure means no threads) →
+   severity consistency (findings sharing a normalized title are raised
+   to the group's max severity) →
    ``apply_quality_gate(confidence_floor=, max_errors=)``. Dropped findings
    are retained in the result with ``drop_reason`` set, never silently
    discarded.
@@ -58,7 +60,13 @@ from typing import Any
 from . import reviewer
 from .forges.base import ATTRIBUTION_MARKER, Forge, InlineComment, PRData, PRRef
 from .llm import LLMClient
-from .quality import active, apply_line_align, apply_quality_gate, apply_thread_dedup
+from .quality import (
+    active,
+    apply_line_align,
+    apply_quality_gate,
+    apply_severity_consistency,
+    apply_thread_dedup,
+)
 from .trace import Tracer, get_tracer
 from .triage import (
     DEFAULT_CONTEXT_LINES,
@@ -379,6 +387,18 @@ def orchestrate_review(
 
     findings = apply_line_align(findings, added_lines_by_file(files))
     findings = apply_thread_dedup(findings, threads)
+    consistent = apply_severity_consistency(findings)
+    rewrites = sum(
+        1
+        for before, after in zip(findings, consistent, strict=True)
+        if before.severity != after.severity
+    )
+    if rewrites:
+        logger.info(
+            "severity consistency: raised %d finding(s) to their title group's max severity",
+            rewrites,
+        )
+    findings = consistent
     findings = apply_quality_gate(
         findings, confidence_floor=confidence_floor, max_errors=max_errors,
     )

--- a/src/prxref/quality.py
+++ b/src/prxref/quality.py
@@ -1,12 +1,17 @@
 """Deterministic quality passes over worker findings.
 
-Three passes run before posting:
+Four passes run before posting:
 1. ``apply_line_align``: snap each finding's cited line to the nearest
    actual ``+`` line in that file's diff (within tolerance, else line=0).
 2. ``apply_thread_dedup``: drop findings that duplicate an already-open
    or existing thread on the PR (path + line-window + shared distinctive tokens).
-3. ``apply_quality_gate``: drop findings below the confidence floor, cap
-   errors per review, and enforce the {error, warning, note} severity vocabulary.
+3. ``apply_severity_consistency``: findings sharing one normalized title —
+   within a file or across sibling files — are all raised to the group's
+   maximum severity, so per-chunk workers cannot disagree about how
+   serious the same pattern is.
+4. ``apply_quality_gate``: drop findings below the confidence floor, cap
+   errors per review, and enforce the {error, warning, outofscope} severity
+   vocabulary.
 
 Every dropped finding retains its identity with ``drop_reason`` populated,
 so review runstores and logs can explain every filter decision. Use
@@ -172,6 +177,61 @@ def apply_thread_dedup(
             result.append(replace(f, drop_reason="duplicate of existing thread"))
         else:
             result.append(f)
+    return result
+
+
+_SEVERITY_RANK: dict[str, int] = {"error": 0, "warning": 1, "outofscope": 2}
+
+_TITLE_PUNCT_RE = re.compile(r"[`*\"'\u2018\u2019\u201c\u201d]")
+
+
+def normalize_title(title: str) -> str:
+    """Canonical form used to group findings that restate the same pattern.
+
+    Lowercase; backticks, quotes, and emphasis marks removed; edge
+    punctuation trimmed; whitespace runs collapsed to one space. Grouping
+    is exact-match on this form, so a title that merely mentions another's
+    words stays its own pattern.
+    """
+    lowered = _TITLE_PUNCT_RE.sub("", title.lower())
+    trimmed = lowered.strip(" .:;,!?-")
+    return " ".join(trimmed.split())
+
+
+def apply_severity_consistency(findings: Sequence[Finding]) -> list[Finding]:
+    """Raise every finding in a normalized-title group to the group's max severity.
+
+    Per-chunk workers decide severity in isolation, so the same pattern can
+    surface as an error in one file and a warning in a sibling, or as a
+    warning at one anchor and a note at another in the same file. Findings
+    sharing one :func:`normalize_title` form — within a file or across
+    files — are all rewritten to the group's highest severity
+    (error > warning > outofscope). A rewritten finding keeps its own file,
+    line, body, and confidence; only severity changes. Findings carrying a
+    ``drop_reason`` or a severity outside the vocabulary pass through
+    untouched.
+    """
+    group_max: dict[str, str] = {}
+    for f in findings:
+        if f.drop_reason is not None:
+            continue
+        severity = (f.severity or "").strip().lower()
+        if severity not in _SEVERITY_RANK:
+            continue
+        key = normalize_title(f.title)
+        current = group_max.get(key)
+        if current is None or _SEVERITY_RANK[severity] < _SEVERITY_RANK[current]:
+            group_max[key] = severity
+
+    result: list[Finding] = []
+    for f in findings:
+        severity = (f.severity or "").strip().lower()
+        if f.drop_reason is None and severity in _SEVERITY_RANK:
+            target = group_max.get(normalize_title(f.title), severity)
+            if severity != target:
+                result.append(replace(f, severity=target))
+                continue
+        result.append(f)
     return result
 
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -441,6 +441,43 @@ class TestDedup:
         assert len(forge.inline_batches) == 1
 
 
+class TestSeverityConsistency:
+    def test_normalized_title_raises_warning_to_error_before_the_error_cap(self, monkeypatch):
+        # Issue #18: identical pattern, sibling files, split severities. The
+        # consistency pass must run BEFORE apply_quality_gate so the cap
+        # counts the normalized error: with PRXREF_MAX_ERROR_FINDINGS=1 the
+        # now-two errors cap to one. If the pass ran after the gate, the
+        # warning would sail past the cap uncapped and both would survive.
+        monkeypatch.setenv("PRXREF_MAX_ERROR_FINDINGS", "1")
+        diff = _added_file_diff("functions/a.ts", 10) + _added_file_diff("functions/b.ts", 10)
+        findings = {
+            "functions/a.ts": [
+                {"file": "functions/a.ts", "line": 3, "severity": "error",
+                 "confidence": 0.9, "title": "Hardcoded secret in serverless handler",
+                 "body": "VITE_ key committed."},
+            ],
+            "functions/b.ts": [
+                {"file": "functions/b.ts", "line": 3, "severity": "warning",
+                 "confidence": 0.8, "title": "hardcoded secret in serverless handler",
+                 "body": "Same VITE_ pattern."},
+            ],
+        }
+        forge = FakeForge(diff=diff)
+        res = orchestrate_review(forge, REF, FakeLLM(findings_by_path=findings), post=False)
+
+        assert len(res["findings_active"]) == 1
+        kept = res["findings_active"][0]
+        assert kept.title == "Hardcoded secret in serverless handler"
+        assert kept.severity == "error"
+        assert kept.file == "functions/a.ts"
+        assert len(res["findings_dropped"]) == 1
+        dropped = res["findings_dropped"][0]
+        assert dropped.file == "functions/b.ts"
+        assert dropped.severity == "error"
+        assert dropped.drop_reason == "error cap exceeded (max 1)"
+        assert res["verdict"] == "Request-Changes"
+
+
 class TestErrorPaths:
     def test_total_llm_failure_error_verdict_and_notice_posted(self):
         forge = FakeForge(diff=_added_file_diff("src/app.py", 20))

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -7,8 +7,10 @@ from prxref.quality import (
     active,
     apply_line_align,
     apply_quality_gate,
+    apply_severity_consistency,
     apply_thread_dedup,
     is_duplicate_of_existing,
+    normalize_title,
     snap_line,
 )
 from prxref.triage import Finding
@@ -170,6 +172,80 @@ class TestThreadDedup:
         assert result[0].drop_reason == "duplicate of existing thread"
         assert result[1].drop_reason is None
         assert active(result) == [f2]
+
+
+class TestSeverityConsistency:
+    def test_same_file_same_title_warning_and_note_both_raise_to_warning(self):
+        # The live issue #18 case: per-chunk workers flagged the same
+        # read-modify-write pattern warning at one anchor, note at another.
+        warning = _f(
+            file="src/supabase.ts", line=42, severity="warning", confidence=0.8,
+            title="Race when updating config",
+            body="Read-modify-write is not atomic.",
+        )
+        note = _f(
+            file="src/supabase.ts", line=88, severity="outofscope", confidence=0.7,
+            title="`race` when updating config.",
+            body="Same pattern, softer call.",
+        )
+        result = apply_severity_consistency([warning, note])
+        assert result[0].severity == "warning"
+        assert result[1].severity == "warning"
+
+    def test_rewritten_finding_keeps_its_own_identity(self):
+        warning = _f(
+            file="src/supabase.ts", line=42, severity="warning", confidence=0.8,
+            title="Race when updating config", body="Own body.",
+        )
+        note = _f(
+            file="src/supabase.ts", line=88, severity="outofscope", confidence=0.7,
+            title="`race` when updating config.", body="Other body.",
+        )
+        result = apply_severity_consistency([warning, note])
+        assert (result[1].file, result[1].line) == ("src/supabase.ts", 88)
+        assert result[1].body == "Other body."
+        assert result[1].confidence == 0.7
+        assert result[1].drop_reason is None
+        # Unmodified finding keeps object identity, matching the other passes
+        assert result[0] is warning
+
+    def test_cross_file_same_title_error_and_warning_both_error(self):
+        error = _f(
+            file="functions/a.ts", line=10, severity="error", confidence=0.9,
+            title="Hardcoded secret in serverless handler", body="",
+        )
+        warning = _f(
+            file="functions/b.ts", line=10, severity="warning", confidence=0.8,
+            title="hardcoded secret in serverless handler", body="",
+        )
+        result = apply_severity_consistency([error, warning])
+        assert result[0].severity == "error"
+        assert result[1].severity == "error"
+
+    def test_different_titles_never_merge(self):
+        # One title mentioning the other's words is still a different pattern
+        short = _f(severity="warning", confidence=0.8, title="Null deref")
+        long = _f(
+            severity="outofscope", confidence=0.7,
+            title="Null deref in the config loader fallback path",
+        )
+        result = apply_severity_consistency([short, long])
+        assert result[0].severity == "warning"
+        assert result[1].severity == "outofscope"
+
+    def test_dropped_findings_neither_join_nor_get_rewritten(self):
+        dropped = _f(severity="error", confidence=0.9, title="Shared title",
+                     drop_reason="duplicate of existing thread")
+        note = _f(severity="outofscope", confidence=0.7, title="Shared title")
+        result = apply_severity_consistency([dropped, note])
+        assert result[0] is dropped
+        assert result[0].severity == "error"
+        assert result[1].severity == "outofscope"
+
+    def test_backtick_and_punctuation_variants_normalize_together(self):
+        assert normalize_title("`foo` bar") == normalize_title("foo bar")
+        assert normalize_title('"Quoted" title!') == normalize_title("quoted title")
+        assert normalize_title("  Mixed   CASE  ") == "mixed case"
 
 
 class TestQualityGate:


### PR DESCRIPTION
## Problem

Live evidence from issue #18: per-chunk LLM workers decide severity in isolation, so the same VITE_-prefixed-secret-in-serverless pattern was flagged **error** in one file and **warning** in two siblings, and the same read-modify-write race in one file got **warning** at one anchor and **note** at another. Identical pattern, inconsistent severity — the reader can't tell whether the disagreement is meaningful.

## Fix

A new deterministic post-pass, `apply_severity_consistency(findings)` in `src/prxref/quality.py`, run in the orchestrator's quality chain **before** `apply_quality_gate`:

```
line_align -> thread_dedup -> severity_consistency -> quality_gate
```

- **Normalization** (`normalize_title`): lowercase, remove backticks/quotes/emphasis marks, strip edge punctuation `.:;,!?-`, collapse whitespace runs. Kept in one documented helper.
- **Grouping**: exact-match on the normalized title, across all files and within one file alike. Every member of a group is raised to the group's max severity by rank `error > warning > outofscope`. Rewritten findings keep their own file/line/body/confidence — only severity changes. Dropped or out-of-vocabulary findings neither join nor get rewritten.
- Running **before** the gate means the error cap (`PRXREF_MAX_ERROR_FINDINGS`) sees normalized severities: a warning normalized up to error correctly counts against the cap (pinned by the orchestrator-level test).
- One summary log line when rewrites happen, silent otherwise. No worker-prompt change — this is the repo's deterministic-and-cheap doctrine, not a prompt tweak.

## Tests

- 6 unit tests in `test_quality.py` (`TestSeverityConsistency`): the live same-file warning+note case, identity preservation on rewrite, the sibling-file error+warning case, different-titles-never-merge, dropped findings don't participate, and backtick/punctuation variants normalizing together.
- 1 orchestrator-level test (`test_orchestrator.py`): normalization raises a warning to error, then `PRXREF_MAX_ERROR_FINDINGS=1` caps the now-two errors — pinning the pass ordering with the quality gate.
- Full suite: **1011 passed**, `ruff check src tests` clean.

Fixes #18