### PR TITLE
fix: a truncated completion advances the fallback chain instead of returning as success

### DIFF
--- a/src/prxref/llm_backends.py
+++ b/src/prxref/llm_backends.py
@@ -6,10 +6,16 @@ model chain: ``PRXREF_LLM_BASE_URL`` and ``PRXREF_LLM_MODELS`` are required,
 and an unset one raises ``ConfigError`` rather than guessing a host.
 
 Fallback is a caller-side loop over the model chain: a model that answers
-with HTTP >= 500, HTTP 429, a connection error, or a timeout is advanced
+with HTTP >= 500, HTTP 429, a connection error, a timeout, a malformed
+body, or a truncated completion (``finish_reason`` ``length``) is advanced
 past immediately — no same-model retry, fast failover is the product
-promise. The optional ``litellm`` extra wraps the in-process SDK and
-delegates the chain to its native ``fallbacks=`` mechanism.
+promise. A truncated answer arrives as HTTP 200, so it has to be caught
+here or the chain never advances; if every model truncates, the last
+truncated answer is returned rather than raised and the reviewer names the
+token budget as the cause. The optional ``litellm`` extra wraps the
+in-process SDK and delegates the chain to its native ``fallbacks=``
+mechanism (which advances on errors only — a truncated litellm answer
+still returns as success).
 
 Tenet: no provider credential is ever read and no env name is
 provider-specific — provider keys live behind the configured endpoint,
@@ -37,6 +43,11 @@ logger = logging.getLogger(__name__)
 # it. Clamped to the deadline itself when that is smaller.
 _CONNECT_TIMEOUT = 10.0
 _READ_CHUNK_BYTES = 8192
+# The truncation vocabulary, mirrored from reviewer.py's
+# _TRUNCATION_FINISH_REASONS: gateways disagree on casing and spelling, and a
+# truncated answer is a 200, so it must be caught HERE for the chain to
+# advance — the reviewer only sees what survives the chain.
+_TRUNCATION_FINISH_REASONS = frozenset({"length", "max_tokens"})
 
 
 class LLMError(Exception):
@@ -48,8 +59,13 @@ class OpenAICompatClient(LLMClient):
 
     Tries each model in ``models`` order (cheap first for speed). A model
     fails on HTTP >= 500, HTTP 429, any other HTTP error, a connection
-    error, a timeout, or a malformed body — the next model is tried at once,
-    and exhausting the chain raises :class:`LLMError` with per-model reasons.
+    error, a timeout, a malformed body, or a truncated completion
+    (``finish_reason`` ``length``/``max_tokens``) — the next model is tried
+    at once, and exhausting the chain raises :class:`LLMError` with
+    per-model reasons. The one exception is exhaustion by truncation: a
+    truncated answer is a real completion, so the last truncated result is
+    returned instead of raised and the reviewer downstream names the token
+    budget as the cause.
     ``temperature`` is omitted from the payload entirely when unset (like
     ``reasoning_effort``), never sent as a numeric default: some endpoints
     reject it alongside reasoning parameters. The choice's ``finish_reason``
@@ -134,7 +150,7 @@ class OpenAICompatClient(LLMClient):
         json_mode: bool = False,
         timeout_s: float | None = None,
     ) -> InvokeResult:
-        """POST /chat/completions per model until one answers; fast-fail the rest."""
+        """POST /chat/completions per model until one answers untruncated; fast-fail the rest."""
         request_timeout = self.default_timeout if timeout_s is None else timeout_s
         payload: dict = {
             "messages": [
@@ -152,6 +168,7 @@ class OpenAICompatClient(LLMClient):
         headers = {"Authorization": f"Bearer {self.api_key}"}
 
         failures: list[str] = []
+        last_truncated: InvokeResult | None = None
         for attempt, model in enumerate(self.models, start=1):
             t0 = time.perf_counter()
             logger.info(
@@ -215,10 +232,25 @@ class OpenAICompatClient(LLMClient):
                 )
                 failures.append(f"{model}: malformed response ({exc.__class__.__name__})")
                 continue
-            # finish_reason is logged on the SUCCESS path deliberately: a
-            # "length" stop is a 200 carrying a truncated body, so it never
-            # reaches any of the failure branches above, and without this line
-            # the only place it surfaces is the posted summary.
+            if finish_reason.strip().lower() in _TRUNCATION_FINISH_REASONS:
+                # A truncated completion is HTTP 200, so without this branch
+                # it returned as success and PRXREF_LLM_MODELS never advanced.
+                logger.warning(
+                    "llm attempt %d/%d truncated: model=%s finish_reason=%s after %dms out=%s",
+                    attempt, len(self.models), resp_model, finish_reason, elapsed_ms,
+                    usage.get("completion_tokens") or 0,
+                )
+                failures.append(f"{model}: truncated (finish_reason={finish_reason})")
+                last_truncated = InvokeResult(
+                    text=text,
+                    input_tokens=usage.get("prompt_tokens") or 0,
+                    output_tokens=usage.get("completion_tokens") or 0,
+                    model=resp_model,
+                    backend="openai-compat",
+                    elapsed_ms=elapsed_ms,
+                    finish_reason=finish_reason,
+                )
+                continue
             logger.info(
                 "llm attempt %d/%d ok: model=%s %dms in=%s out=%s finish=%s",
                 attempt, len(self.models), resp_model, elapsed_ms,
@@ -234,6 +266,11 @@ class OpenAICompatClient(LLMClient):
                 elapsed_ms=elapsed_ms,
                 finish_reason=finish_reason,
             )
+        # Exhausting the chain on truncation alone is a last resort, not a
+        # failure: the best answer anyone managed is still handed back, with
+        # finish_reason intact so the reviewer blames the token budget.
+        if last_truncated is not None:
+            return last_truncated
         raise LLMError("all models failed: " + "; ".join(failures))
 
 

--- a/tests/test_llm_backends.py
+++ b/tests/test_llm_backends.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import inspect
 import json as json_module
+import logging
 import pathlib
 import sys
 import time
@@ -523,7 +524,7 @@ class TestLiteLLMClient:
 _ABSENT = object()
 
 
-def _resp_with_finish(finish_reason, text="ok", status_code=200):
+def _resp_with_finish(finish_reason, text="ok", status_code=200, model="m1-resolved"):
     """A well-formed success body whose choice carries ``finish_reason``.
 
     ``_resp`` puts its ``**extra`` at the top level of the body; the stop
@@ -534,7 +535,7 @@ def _resp_with_finish(finish_reason, text="ok", status_code=200):
         choice["finish_reason"] = finish_reason
     payload = {
         "choices": [choice],
-        "model": "m1-resolved",
+        "model": model,
         "usage": {"prompt_tokens": 3, "completion_tokens": 2},
     }
     return SimpleNamespace(status_code=status_code, payload=payload, json=lambda: payload)
@@ -548,8 +549,11 @@ class TestFinishReasonOpenAICompat:
     """
 
     def test_length_is_carried_through(self):
+        """A lone model that truncates exhausts the chain into the last-resort
+        return, which is exactly where the carried-through reason is asserted."""
         s = _ScriptedSession(_resp_with_finish("length"))
-        assert _client(s).invoke("sys", "usr").finish_reason == "length"
+        r = _client(s, models=("m1",)).invoke("sys", "usr")
+        assert r.finish_reason == "length"
 
     def test_stop_is_carried_through_not_normalised_away(self):
         """Control for the test above: a clean stop must NOT read as 'length'."""
@@ -581,6 +585,82 @@ class TestFinishReasonOpenAICompat:
         """``_resp`` has no finish_reason; the field must default, not guess."""
         s = _ScriptedSession(_resp())
         assert _client(s).invoke("sys", "usr").finish_reason == ""
+
+
+class TestTruncationAdvancesTheChain:
+    """A truncated completion is HTTP 200, so it used to return as success and
+    PRXREF_LLM_MODELS never advanced (issue #10). The reviewer's truncation
+    handling only engages AFTER the chain has run, so the chain itself has to
+    refuse a ``length`` stop as a final answer.
+    """
+
+    def test_a_truncated_model_advances_to_the_next_model(self, caplog):
+        s = _ScriptedSession(
+            _resp_with_finish("length", text='{"findings": [{"ti'),
+            _resp_with_finish("stop", text="ok", model="m2-resolved"),
+        )
+        with caplog.at_level(logging.WARNING, logger="prxref.llm_backends"):
+            r = _client(s).invoke("sys", "usr")
+        assert r.text == "ok"
+        assert r.model == "m2-resolved"
+        assert r.finish_reason == "stop"
+        assert len(s.calls) == 2
+        assert s.calls[0]["json"]["model"] == "m1"
+        assert s.calls[1]["json"]["model"] == "m2"
+        messages = [rec.getMessage() for rec in caplog.records]
+        assert any("truncated" in m and "m1" in m for m in messages)
+
+    def test_all_models_truncated_returns_the_last_truncated_result(self):
+        """Last resort: exhaustion by truncation hands back the truncated
+        answer with its reason intact — never an exception — so the reviewer
+        downstream can still name the token budget as the cause."""
+        s = _ScriptedSession(
+            _resp_with_finish("length", text='{"a"'),
+            _resp_with_finish("length", text='{"b"', model="m2-resolved"),
+        )
+        r = _client(s).invoke("sys", "usr")
+        assert r.text == '{"b"'
+        assert r.model == "m2-resolved"
+        assert r.finish_reason == "length"
+        assert len(s.calls) == 2
+
+    def test_a_truncation_is_returned_even_when_a_later_model_hard_fails(self):
+        s = _ScriptedSession(_resp_with_finish("length", text='{"a"'), _resp(status_code=503))
+        r = _client(s).invoke("sys", "usr")
+        assert r.text == '{"a"'
+        assert r.finish_reason == "length"
+
+    def test_truncation_then_a_hard_failure_still_reaches_the_healthy_model(self):
+        s = _ScriptedSession(
+            _resp_with_finish("length"),
+            _resp(status_code=500),
+            _resp(model="m3-resolved"),
+        )
+        r = _client(s, models=("a", "b", "c")).invoke("sys", "usr")
+        assert r.text == "ok"
+        assert r.model == "m3-resolved"
+
+    @pytest.mark.parametrize("raw", ["length", "LENGTH", "max_tokens", "MAX_TOKENS", " Length "])
+    def test_every_truncation_spelling_the_reviewer_knows_advances(self, raw):
+        """Same casefolded vocabulary as reviewer._budget_stop_reason: a
+        gateway that logs MAX_TOKENS must fail over exactly like ``length``."""
+        s = _ScriptedSession(_resp_with_finish(raw), _resp(model="m2-resolved"))
+        assert _client(s).invoke("sys", "usr").model == "m2-resolved"
+
+    def test_a_clean_stop_still_returns_on_the_first_model(self):
+        """Control: a healthy answer must not be pushed off its model."""
+        s = _ScriptedSession(_resp_with_finish("stop", model="only-resolved"))
+        r = _client(s, models=("only",)).invoke("sys", "usr")
+        assert r.text == "ok"
+        assert len(s.calls) == 1
+
+    def test_a_non_truncation_stop_reason_still_returns_as_success(self):
+        """Control: not every unusual stop is a budget stop; unknown reasons
+        keep today's behaviour."""
+        s = _ScriptedSession(_resp_with_finish("content_filter", model="only-resolved"))
+        r = _client(s, models=("only",)).invoke("sys", "usr")
+        assert r.finish_reason == "content_filter"
+        assert len(s.calls) == 1
 
 
 class TestMalformedBodiesAdvanceTheChain:


### PR DESCRIPTION
Fixes #10.

## Mechanism

A truncated completion arrives as HTTP 200 with `finish_reason: "length"`, so inside `OpenAICompatClient.invoke`'s attempt loop it hit the success return and `PRXREF_LLM_MODELS` never advanced — the chain only failed over on HTTP errors, timeouts, connection errors, and malformed bodies.

Now a `finish_reason` in `{length, max_tokens}` (casefolded — the same vocabulary `reviewer.py`'s `_budget_stop_reason` already uses, so a gateway logging `MAX_TOKENS` behaves identically) is treated as a per-model failure inside the loop: warning logged, recorded in the failures list, next model tried.

## Exhaustion is a last resort

If every model truncates, the **last truncated result** is returned instead of raising `LLMError`, with `finish_reason` intact — `reviewer.py`'s existing truncation path (`_truncation_reason` / the parseable-truncation branch) then names the token budget and `PRXREF_LLM_MAX_TOKENS` on the posted summary. The single-model end-to-end integration tests pass unchanged.

## Not changed

The litellm backend shares no response-parsing helper — its chain is litellm's native `fallbacks=`, which advance on errors only — so per the issue's conditional it is untouched; a truncated litellm answer still returns as success (documented in the module docstring).

## Tests

11 new tests in `TestTruncationAdvancesTheChain`: advance-on-truncation (result + warning), all-truncated last-resort return, truncation-then-hard-failure mixes, the reviewer's full truncation-spelling set, and `stop`/`content_filter` no-regression controls. Suite: 1004 → 1015 passed; `ruff check src tests` clean.