### PR TITLE
fix: inline anchors are re-resolved against the diff before posting (fixes #19)

### DIFF
--- a/src/prxref/orchestrator.py
+++ b/src/prxref/orchestrator.py
@@ -377,7 +377,7 @@ def orchestrate_review(
         logger.warning("list_threads failed (best-effort): %s", e)
         threads = []
 
-    findings = apply_line_align(findings, added_lines_by_file(files))
+    findings = apply_line_align(findings, added_lines_by_file(files), files=files)
     findings = apply_thread_dedup(findings, threads)
     findings = apply_quality_gate(
         findings, confidence_floor=confidence_floor, max_errors=max_errors,

--- a/src/prxref/prompts/worker.md
+++ b/src/prxref/prompts/worker.md
@@ -59,4 +59,4 @@ Return exactly one JSON object, no prose, no fences:
 }
 ```
 
-`file` is a path from the diff headers. `line` is the 1-based line number in the NEW file. Emit `"findings": []` when the chunk is clean.
+`file` is a path from the diff headers. `line` is the 1-based line number in the NEW file: take it from the `@@` header of the hunk containing the cited code — that header's `+` start counted forward past context and `+` lines only — never from another hunk's header. Emit `"findings": []` when the chunk is clean.

--- a/src/prxref/quality.py
+++ b/src/prxref/quality.py
@@ -2,7 +2,11 @@
 
 Three passes run before posting:
 1. ``apply_line_align``: snap each finding's cited line to the nearest
-   actual ``+`` line in that file's diff (within tolerance, else line=0).
+   actual ``+`` line in that file's diff (within tolerance, else line=0),
+   then corroborate exact ``+``-line members against the file's hunks by
+   content, so an anchor that is a valid added line of the WRONG hunk
+   (issue #19's drift shape) is re-resolved or demoted to file-level
+   instead of posting at a wrong position.
 2. ``apply_thread_dedup``: drop findings that duplicate an already-open
    or existing thread on the PR (path + line-window + shared distinctive tokens).
 3. ``apply_quality_gate``: drop findings below the confidence floor, cap
@@ -20,12 +24,19 @@ from collections.abc import Sequence
 from dataclasses import replace
 
 from .forges.base import Thread
-from .triage import Finding
+from .triage import FileDiff, Finding, Hunk
 
 SEVERITIES: frozenset[str] = frozenset({"error", "warning", "outofscope"})
 
 DEFAULT_CONFIDENCE_FLOOR: float = 0.6
 DEFAULT_MAX_ERRORS: int = 10
+
+# Positional snap radius for cited lines. Inline comment cards render only a
+# handful of surrounding lines, so a nudge of up to 5 keeps the cited code
+# visible in the posted comment; past that the comment separates from its
+# evidence. 5 also sits below the smallest drift the issue #19 audit measured
+# on real reviews (10 lines), so no observed-failure distance survives.
+DEFAULT_LINE_TOLERANCE: int = 5
 
 
 def active(findings: Sequence[Finding]) -> list[Finding]:
@@ -33,11 +44,17 @@ def active(findings: Sequence[Finding]) -> list[Finding]:
     return [f for f in findings if f.drop_reason is None]
 
 
-def snap_line(line: int, added: set[int], tolerance: int = 3) -> int:
+def snap_line(
+    line: int, added: set[int], tolerance: int = DEFAULT_LINE_TOLERANCE
+) -> int:
     """Snap a cited line to the nearest ``+`` line within tolerance, else 0.
 
-    A returned 0 denotes a file-level anchor (no ``+`` line close enough).
+    A returned 0 denotes a file-level anchor (no ``+`` line close enough,
+    or the citation was already file-level: ``line <= 0`` never snatches a
+    file-level finding onto an inline line).
     """
+    if line <= 0:
+        return 0
     if line in added:
         return line
     if not added:
@@ -48,21 +65,103 @@ def snap_line(line: int, added: set[int], tolerance: int = 3) -> int:
     return 0
 
 
+def _hunk_text(hunk: Hunk) -> str:
+    return "\n".join(ln.text for ln in hunk.lines)
+
+
+def _hunk_containing(hunks: Sequence[Hunk], line: int) -> Hunk | None:
+    """The hunk whose new-file span holds ``line``, or None."""
+    for h in hunks:
+        if h.new_start <= line < h.new_start + h.new_count:
+            return h
+    return None
+
+
+def _realign_member(finding: Finding, hunks: Sequence[Hunk]) -> int:
+    """Re-resolve an exact ``+``-line member anchor by content, or keep it.
+
+    Membership alone cannot catch issue #19's drift: a model that adds the
+    wrong hunk's ``@@`` start to an in-hunk offset emits a number that IS a
+    valid added line, of the wrong hunk. The one checkable property left is
+    content correspondence — the finding's own evidence tokens (title +
+    body, minus stopwords) must occur in the anchor hunk's text. Zero
+    overlap refutes the anchor: it re-anchors to the best token-matching
+    added line elsewhere in the file (context lines score too; the target
+    is the nearest ``+`` line to the best match), or drops to file-level 0
+    when no line matches anywhere. Non-empty overlap corroborates the
+    anchor and the citation stands.
+    """
+    ftoks = _tokens(f"{finding.title} {finding.body}")
+    if not ftoks:
+        return finding.line
+    anchor = _hunk_containing(hunks, finding.line)
+    if anchor is not None and ftoks & _tokens(_hunk_text(anchor)):
+        return finding.line
+    best_line, best_key = 0, (0, 0)
+    for h in hunks:
+        if h is anchor:
+            continue
+        scored = [
+            (len(ftoks & _tokens(ln.text)), -abs((ln.new_line or 0) - finding.line), ln)
+            for ln in h.lines
+            if ln.kind != "-" and ln.new_line is not None
+        ]
+        scored = [s for s in scored if s[0] > 0]
+        if not scored:
+            continue
+        _, _, best = max(scored, key=lambda s: (s[0], s[1]))
+        if best.kind == "+":
+            target = best
+        else:
+            adds = [
+                ln for ln in h.lines
+                if ln.kind == "+" and ln.new_line is not None
+            ]
+            if not adds:
+                continue
+            target = min(
+                adds, key=lambda a: abs((a.new_line or 0) - (best.new_line or 0))
+            )
+        key = (
+            len(ftoks & _tokens(best.text)),
+            -abs((target.new_line or 0) - finding.line),
+        )
+        if key > best_key:
+            best_key, best_line = key, target.new_line or 0
+    return best_line
+
+
 def apply_line_align(
     findings: Sequence[Finding],
     added_lines_by_file: dict[str, set[int]] | None = None,
-    tolerance: int = 3,
+    tolerance: int = DEFAULT_LINE_TOLERANCE,
+    files: Sequence[FileDiff] | None = None,
 ) -> list[Finding]:
-    """Snap each finding's line number to the nearest ``+`` line in that file.
+    """Snap each finding's line to a defensible anchor in that file's diff.
+
+    Positional pass: within ``tolerance`` of the nearest ``+`` line the
+    citation snaps there; beyond it the citation is not trusted and drops
+    to file-level (0) — the summary still carries the finding, at an
+    honest location. Content pass: an exact ``+``-line member is
+    corroborated against the file's hunks when ``files`` is supplied
+    (see :func:`_realign_member`) — that is the only way a wrong-hunk
+    citation becomes visible, and it is corrected or demoted instead of
+    posted at a wrong position.
 
     When ``added_lines_by_file`` is omitted or has no entry for a file,
-    the finding's line is dropped to 0 (file-level).
+    the finding's line is dropped to 0 (file-level). A file-level
+    citation stays file-level.
     """
     by_file = added_lines_by_file or {}
+    hunks_by_file = {f.path: f.hunks for f in files} if files else {}
     result: list[Finding] = []
     for f in findings:
         added = by_file.get(f.file, set())
-        new_line = snap_line(f.line, added, tolerance=tolerance)
+        hunks = hunks_by_file.get(f.file)
+        if hunks and f.line > 0 and f.line in added:
+            new_line = _realign_member(f, hunks)
+        else:
+            new_line = snap_line(f.line, added, tolerance=tolerance)
         if new_line != f.line:
             result.append(replace(f, line=new_line))
         else:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -105,7 +105,10 @@ def make_pr(title: str = "Add widget") -> PRData:
 
 
 def _added_file_diff(path: str, n_lines: int) -> str:
-    body = "\n".join(f"+line {i}" for i in range(1, n_lines + 1))
+    # ``data`` is the hunk's one tokenizer-visible token: findings citing this
+    # fixture corroborate only if their text mentions it, mirroring how the
+    # content pass validates real anchors (issue #19).
+    body = "\n".join(f"+data {i}" for i in range(1, n_lines + 1))
     return (
         f"diff --git a/{path} b/{path}\n"
         "new file mode 100644\n"
@@ -235,9 +238,9 @@ def _contract_stubs(monkeypatch):
 HAPPY_FINDINGS = {
     "src/app.py": [
         {"file": "src/app.py", "line": 3, "severity": "error", "confidence": 0.9,
-         "title": "Null deref", "body": "x may be None when config is missing."},
+         "title": "Null deref", "body": "x may be None when config is missing; data loss follows."},
         {"file": "src/app.py", "line": 7, "severity": "outofscope", "confidence": 0.8,
-         "title": "Typo", "body": "recieve -> receive."},
+         "title": "Typo", "body": "recieve -> receive in data text."},
     ],
 }
 

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -11,7 +11,7 @@ from prxref.quality import (
     is_duplicate_of_existing,
     snap_line,
 )
-from prxref.triage import Finding
+from prxref.triage import Finding, added_lines_by_file, parse_unified_diff
 
 
 def _f(**kwargs) -> Finding:
@@ -64,6 +64,99 @@ class TestApplyLineAlign:
         finding = _f(file="a.py", line=10)
         aligned = apply_line_align([finding], {"a.py": {10}})
         assert aligned[0] is finding
+
+
+# The issue #19 drift shape: a multi-hunk file where the model adds the wrong
+# hunk's @@ start to an in-hunk offset. The emitted number is a real added
+# line — of the wrong hunk — so membership validation keeps it, and the posted
+# anchor lands ~170 lines from the code the finding describes.
+MULTI_HUNK_DIFF = """\
+diff --git a/src/functions.php b/src/functions.php
+--- a/src/functions.php
++++ b/src/functions.php
+@@ -1260,1 +1260,5 @@ function handle_request(array $input): void {
+     $stmt = $pdo->prepare('SELECT * FROM users WHERE id = :id');
++    if (!array_key_exists('user_id', $input)) {
++        throw new InvalidArgumentException('user_id missing');
++    }
++    $stmt->execute(['id' => $input['user_id']]);
+@@ -1425,2 +1428,4 @@ function cache_prune(): void {
+     $keys = array_keys($this->items);
++    $ttl = $this->ttl;
++    $this->gc->collect();
+"""
+
+
+class TestHunkAwareAlignment:
+    """Exact added-line members are corroborated (or re-resolved) by content.
+
+    Membership alone cannot catch wrong-hunk citations, so when the parsed
+    hunks are supplied, a member anchor whose hunk shares no tokens with the
+    finding's title+body is refuted and re-resolved to the best token-
+    matching added line elsewhere in the file — or to file-level (0) when
+    nothing matches.
+    """
+
+    def _aligned(self, **kwargs) -> list[Finding]:
+        parsed = parse_unified_diff(MULTI_HUNK_DIFF)
+        defaults = {
+            "file": "src/functions.php",
+            "line": 1429,
+            "title": "user_id used without a guard",
+            "body": (
+                "The added code reads $input['user_id'] without an "
+                "array_key_exists or isset check; add the "
+                "InvalidArgumentException guard here."
+            ),
+        }
+        defaults.update(kwargs)
+        finding = _f(**defaults)
+        return apply_line_align(
+            [finding],
+            added_lines_by_file(parsed),
+            files=parsed,
+        )
+
+    def test_wrong_hunk_member_is_reresolved_by_content(self):
+        aligned = self._aligned()
+        assert aligned[0].line == 1261
+
+    def test_refuted_member_with_no_match_anywhere_drops_to_file_level(self):
+        aligned = self._aligned(
+            title="Unhandled edge",
+            body="This branch can crash when empty.",
+        )
+        assert aligned[0].line == 0
+
+    def test_corroborated_member_is_kept(self):
+        aligned = self._aligned(
+            title="ttl not applied to gc sweep",
+            body="cache_prune reads ttl but never passes it to collect().",
+        )
+        assert aligned[0].line == 1429
+
+    def test_alignment_without_files_keeps_membership_behavior(self):
+        finding = _f(file="src/functions.php", line=1429)
+        aligned = apply_line_align(
+            [finding], {"src/functions.php": {1429, 1261}}
+        )
+        assert aligned[0].line == 1429
+
+    def test_file_level_citation_stays_file_level(self):
+        finding = _f(file="src/functions.php", line=0)
+        parsed = parse_unified_diff(MULTI_HUNK_DIFF)
+        aligned = apply_line_align(
+            [finding], added_lines_by_file(parsed), files=parsed
+        )
+        assert aligned[0].line == 0
+
+
+class TestSnapTolerance:
+    def test_distance_four_snaps_at_default_tolerance(self):
+        assert snap_line(1426, {1430}) == 1430
+
+    def test_distance_six_drops_to_file_level(self):
+        assert snap_line(1424, {1430}) == 0
 
 
 class TestThreadDedup:

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -151,6 +151,32 @@ class TestRenderChunk:
         rendered = render_chunk(parsed)
         assert "Binary files a/logo.png and b/logo.png differ" in rendered
 
+    def test_trimmed_multi_hunk_render_keeps_absolute_added_lines(self):
+        # Issue #19 half-diagnosis: the rendered chunk view is NOT the drift
+        # source — per-hunk @@ headers stay absolute after context trimming,
+        # so the model always has correct new-file numbers to cite from.
+        diff = (
+            "diff --git a/big.php b/big.php\n"
+            "--- a/big.php\n"
+            "+++ b/big.php\n"
+            "@@ -10,4 +10,6 @@\n"
+            " ctx\n"
+            "+added_one\n"
+            "+added_two\n"
+            " ctx\n"
+            " pad1\n"
+            " pad2\n"
+            "@@ -500,4 +502,4 @@\n"
+            " ctx\n"
+            "+added_three\n"
+            " ctx\n"
+            " ctx\n"
+        )
+        parsed = parse_unified_diff(diff)
+        rendered = render_chunk(parsed, context_lines=1)
+        reparsed = parse_unified_diff(rendered)
+        assert reparsed[0].added_lines == parsed[0].added_lines
+
 
 class TestReviewChunk:
     def _chunk(self):


### PR DESCRIPTION
Fixes #19. Live audit found 8+ accurate claims anchored 10–420 lines from their code.

## Diagnosed mechanism

`snap_line`'s exact-membership branch returned any cited line that IS an added line — membership, not correspondence. The worker sees per-hunk absolute `@@` headers (rendering sound; now pinned by a test) and must add a header start to an in-hunk offset; mis-attributing another hunk's header yields a *valid added line of the wrong hunk*, which survived alignment since v0.1.

## Rule

- Positional: snap to nearest `+` line within **tolerance 5** (below the smallest observed drift, 10); beyond → content re-resolution.
- Content: an exact member must share ≥1 evidence token (title+body minus stopwords) with its hunk; zero overlap refutes it → re-resolve to the best token-matching added line, ties nearest-to-citation.
- Unresolvable → `line=0` file-level: still active, still itemized; the forges land it honestly (GitHub's 422-skip feeds the #16 accounting line).

## Verification

1012 passed (8 new incl. the wrong-hunk repro that reproduces the audit's 1432-vs-1266 shape), ruff clean, plus a live end-to-end run through `orchestrate_review` posting at the exact cited line.