### PR TITLE
release: 0.10.0 — the audit release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.10.0] — 2026-09-01
+
+The audit release. Four fixes, every one traced to a live finding by the
+2026-08-31 review-the-reviews audit and verified against real PRs.
+
+### Fixed
+
+- **Truncation advances the fallback chain (#10, PR #23).** A completion cut
+  off by `max_tokens` comes back HTTP 200 with `finish_reason: "length"` and
+  returned as success, so the model chain never advanced. Truncation is now a
+  per-model failure inside the attempt loop; only chain exhaustion returns
+  the truncated result, as a last resort the reviewer already handles.
+
+- **Inline anchors are re-resolved against the diff (#19, PR #25).** A cited
+  line that was merely *an* added line passed alignment even when it belonged
+  to the wrong hunk — accurate claims anchored 10–420 lines from their code.
+  Anchors now snap within a 5-line tolerance, are re-resolved by content
+  overlap when refuted, and post file-level (`line=0`) when unresolvable.
+
+- **Consistent severities for the same pattern (#18, PR #22).** Per-chunk
+  workers decided severity in isolation, so one bug class could arrive as
+  error in one file and note in a sibling. A deterministic pass now
+  normalizes severity across findings sharing a normalized title — same file
+  or not — before the quality gate.
+
+### Changed
+
+- **Reviews are reproducible by default (#11, PR #24).** The effective
+  default sampling temperature is now `0.0` and is sent when the operator
+  sets nothing (an explicit `PRXREF_LLM_TEMPERATURE` still wins), and a new
+  `PRXREF_LLM_SEED` (int >= 0, unset = omitted) seeds OpenAI-compatible
+  requests. Identical diff + identical config now aims for identical
+  findings, which is what `PRXREF_FAIL_ON=error`'s exit code promises.
+
+
 ### Fixed
 
 - **The GitHub prune pass deleted nothing (0.9.0).** The delete route was

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prxref"
-version = "0.9.1"
+version = "0.10.0"
 description = "Fast automated AI code review for Bitbucket, GitLab, and GitHub"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/prxref/__init__.py
+++ b/src/prxref/__init__.py
@@ -1,3 +1,3 @@
 """prxref — fast automated AI code review for Bitbucket, GitLab, and GitHub."""
 
-__version__ = "0.9.1"
+__version__ = "0.10.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1153,7 +1153,7 @@ wheels = [
 
 [[package]]
 name = "prxref"
-version = "0.9.1"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
Version bump to 0.10.0 bundling PRs #22 #23 #24 #25 (issues #10 #11 #18 #19, all found by the 2026-08-31 review-the-reviews audit). 1059 passed, ruff clean. Tag v0.10.0 after merge publishes sdist+wheel+PyPI.