### PR TITLE
fix: anchor re-resolution prefers token-bearing hunks over nearest ties (#19 follow-up)

### DIFF
--- a/src/prxref/quality.py
+++ b/src/prxref/quality.py
@@ -6,7 +6,10 @@ Four passes run before posting:
    then corroborate exact ``+``-line members against the file's hunks by
    content, so an anchor that is a valid added line of the WRONG hunk
    (issue #19's drift shape) is re-resolved or demoted to file-level
-   instead of posting at a wrong position.
+   instead of posting at a wrong position. Corroboration is line-level:
+   an anchor survives only when it ties the file's best evidence match
+   or sits within tolerance of it, and a blank or pure-punctuation
+   anchor never survives while any token-bearing added line exists.
 2. ``apply_thread_dedup``: drop findings that duplicate an already-open
    or existing thread on the PR (path + line-window + shared distinctive tokens).
 3. ``apply_severity_consistency``: findings sharing one normalized title —
@@ -29,7 +32,7 @@ from collections.abc import Sequence
 from dataclasses import replace
 
 from .forges.base import Thread
-from .triage import FileDiff, Finding, Hunk
+from .triage import DiffLine, FileDiff, Finding, Hunk
 
 SEVERITIES: frozenset[str] = frozenset({"error", "warning", "outofscope"})
 
@@ -70,10 +73,6 @@ def snap_line(
     return 0
 
 
-def _hunk_text(hunk: Hunk) -> str:
-    return "\n".join(ln.text for ln in hunk.lines)
-
-
 def _hunk_containing(hunks: Sequence[Hunk], line: int) -> Hunk | None:
     """The hunk whose new-file span holds ``line``, or None."""
     for h in hunks:
@@ -82,58 +81,137 @@ def _hunk_containing(hunks: Sequence[Hunk], line: int) -> Hunk | None:
     return None
 
 
-def _realign_member(finding: Finding, hunks: Sequence[Hunk]) -> int:
+def _line_at(hunk: Hunk, line: int) -> DiffLine | None:
+    """The hunk body line rendered at new-file ``line``, or None."""
+    for ln in hunk.lines:
+        if ln.kind != "-" and ln.new_line == line:
+            return ln
+    return None
+
+
+def _line_tokens(ln: DiffLine) -> set[str]:
+    return _tokens(ln.text, split_compounds=True)
+
+
+_PUNCT_RE = re.compile(r"[A-Za-z0-9]")
+
+
+def _is_blankish(ln: DiffLine) -> bool:
+    """True for blank or pure-punctuation lines (no alphanumeric at all).
+
+    Deliberately narrower than "no content tokens": a real code line whose
+    identifiers are below the 4-char token floor (``$ttl = $this->ttl;``)
+    is not a blank anchor and stays eligible for the tolerance reprieve.
+    """
+    return _PUNCT_RE.search(ln.text) is None
+
+
+def _line_is_blankish(hunks: Sequence[Hunk], line: int) -> bool:
+    for h in hunks:
+        ln = _line_at(h, line)
+        if ln is not None:
+            return _is_blankish(ln)
+    return False
+
+
+def _file_has_token_bearing_add(hunks: Sequence[Hunk]) -> bool:
+    return any(
+        ln.kind == "+" and ln.new_line is not None and _line_tokens(ln)
+        for h in hunks
+        for ln in h.lines
+    )
+
+
+def _realign_member(
+    finding: Finding,
+    hunks: Sequence[Hunk],
+    tolerance: int = DEFAULT_LINE_TOLERANCE,
+) -> int:
     """Re-resolve an exact ``+``-line member anchor by content, or keep it.
 
-    Membership alone cannot catch issue #19's drift: a model that adds the
-    wrong hunk's ``@@`` start to an in-hunk offset emits a number that IS a
-    valid added line, of the wrong hunk. The one checkable property left is
-    content correspondence — the finding's own evidence tokens (title +
-    body, minus stopwords) must occur in the anchor hunk's text. Zero
-    overlap refutes the anchor: it re-anchors to the best token-matching
-    added line elsewhere in the file (context lines score too; the target
-    is the nearest ``+`` line to the best match), or drops to file-level 0
-    when no line matches anywhere. Non-empty overlap corroborates the
-    anchor and the citation stands.
+    Membership alone cannot catch drift: a model that adds the wrong
+    hunk's ``@@`` start to an in-hunk offset emits a number that IS a
+    valid added line, of the wrong hunk or of the wrong construct. The
+    checkable property is line-level content correspondence. A blank or
+    pure-punctuation anchor never survives while any token-bearing added
+    line exists in the file. Any other anchor survives only when it ties
+    the file's best evidence match — the non-removed line sharing the
+    most claim evidence — or sits within ``tolerance`` of that line, so
+    the cited code is still visible in the posted comment card.
+    Otherwise the anchor is re-resolved to the best-matching added line,
+    ranked by breadth of shared evidence tokens, then by the most
+    specific (longest) shared token, then by proximity to the citation;
+    the anchor's own hunk competes like any other. When no line matches
+    the evidence anywhere, the finding drops to file-level 0.
+
+    Evidence tokens come from title + body with backticked-style
+    ``path:line`` citation strings stripped (so a ``file.js:31`` mention
+    cannot collide with path words) and compound identifiers split into
+    their snake/camel parts (so ``wp_ajax_nopriv_avatar_upload`` can
+    answer a claim about "nopriv avatar upload").
     """
-    ftoks = _tokens(f"{finding.title} {finding.body}")
+    ftoks = _evidence_tokens(f"{finding.title} {finding.body}")
     if not ftoks:
         return finding.line
     anchor = _hunk_containing(hunks, finding.line)
-    if anchor is not None and ftoks & _tokens(_hunk_text(anchor)):
+    anchor_ln = _line_at(anchor, finding.line) if anchor else None
+    if (
+        anchor_ln is not None
+        and _is_blankish(anchor_ln)
+        and not _file_has_token_bearing_add(hunks)
+    ):
         return finding.line
-    best_line, best_key = 0, (0, 0)
-    for h in hunks:
-        if h is anchor:
-            continue
-        scored = [
-            (len(ftoks & _tokens(ln.text)), -abs((ln.new_line or 0) - finding.line), ln)
-            for ln in h.lines
-            if ln.kind != "-" and ln.new_line is not None
-        ]
-        scored = [s for s in scored if s[0] > 0]
-        if not scored:
-            continue
-        _, _, best = max(scored, key=lambda s: (s[0], s[1]))
-        if best.kind == "+":
-            target = best
-        else:
-            adds = [
-                ln for ln in h.lines
-                if ln.kind == "+" and ln.new_line is not None
-            ]
-            if not adds:
-                continue
-            target = min(
-                adds, key=lambda a: abs((a.new_line or 0) - (best.new_line or 0))
-            )
-        key = (
-            len(ftoks & _tokens(best.text)),
-            -abs((target.new_line or 0) - finding.line),
+    best = _best_candidate(hunks, ftoks, finding.line)
+    if anchor_ln is not None and not _is_blankish(anchor_ln) and best is not None:
+        anchor_shared = ftoks & _line_tokens(anchor_ln)
+        anchor_key = (
+            (len(anchor_shared), max(map(len, anchor_shared)))
+            if anchor_shared
+            else (0, 0)
         )
-        if key > best_key:
-            best_key, best_line = key, target.new_line or 0
-    return best_line
+        if anchor_key >= best[0] or abs(
+            (anchor_ln.new_line or 0) - (best[1].new_line or 0)
+        ) <= tolerance:
+            return finding.line
+    if best is None:
+        return 0
+    target = best[1]
+    if target.kind == "+":
+        return target.new_line or 0
+    adds = [
+        ln for h in hunks for ln in h.lines
+        if ln.kind == "+" and ln.new_line is not None
+    ]
+    if not adds:
+        return 0
+    return min(
+        adds, key=lambda a: abs((a.new_line or 0) - (target.new_line or 0))
+    ).new_line or 0
+
+
+def _best_candidate(
+    hunks: Sequence[Hunk], ftoks: set[str], citation: int
+) -> tuple[tuple[int, int], DiffLine] | None:
+    """The non-removed line sharing the most claim evidence.
+
+    Ranked by shared-token breadth, then longest shared token, then
+    proximity to the citation line. Context lines can win; callers move
+    a context winner to its nearest added line before anchoring.
+    """
+    candidates: list[tuple[tuple[int, int], int, DiffLine]] = []
+    for h in hunks:
+        for ln in h.lines:
+            if ln.kind == "-" or ln.new_line is None:
+                continue
+            shared = ftoks & _line_tokens(ln)
+            if not shared:
+                continue
+            key = (len(shared), max(map(len, shared)))
+            candidates.append((key, -abs(ln.new_line - citation), ln))
+    if not candidates:
+        return None
+    top = max(candidates, key=lambda c: (c[0], c[1]))
+    return top[0], top[2]
 
 
 def apply_line_align(
@@ -149,9 +227,12 @@ def apply_line_align(
     to file-level (0) — the summary still carries the finding, at an
     honest location. Content pass: an exact ``+``-line member is
     corroborated against the file's hunks when ``files`` is supplied
-    (see :func:`_realign_member`) — that is the only way a wrong-hunk
-    citation becomes visible, and it is corrected or demoted instead of
-    posted at a wrong position.
+    (see :func:`_realign_member`) — that is the only way a wrong-hunk or
+    wrong-construct citation becomes visible, and it is corrected or
+    demoted instead of posted at a wrong position. A citation that snaps
+    onto a blank or pure-punctuation added line is re-resolved the same
+    way whenever the file also carries token-bearing added lines, so a
+    blank line never outranks the line the evidence lives on.
 
     When ``added_lines_by_file`` is omitted or has no entry for a file,
     the finding's line is dropped to 0 (file-level). A file-level
@@ -164,9 +245,16 @@ def apply_line_align(
         added = by_file.get(f.file, set())
         hunks = hunks_by_file.get(f.file)
         if hunks and f.line > 0 and f.line in added:
-            new_line = _realign_member(f, hunks)
+            new_line = _realign_member(f, hunks, tolerance=tolerance)
         else:
             new_line = snap_line(f.line, added, tolerance=tolerance)
+            if (
+                hunks
+                and new_line > 0
+                and _line_is_blankish(hunks, new_line)
+                and _file_has_token_bearing_add(hunks)
+            ):
+                new_line = _realign_member(f, hunks, tolerance=tolerance)
         if new_line != f.line:
             result.append(replace(f, line=new_line))
         else:
@@ -191,14 +279,51 @@ _STOPWORDS: frozenset[str] = frozenset({
 })
 
 _TOKEN_RE = re.compile(r"[A-Za-z0-9_]{4,}")
+_CAMEL_PART_RE = re.compile(r"[A-Z]+(?![a-z])|[A-Z]?[a-z]+|[0-9]+")
+
+_CITATION_RE = re.compile(
+    r"\b[\w./\\-]+\.(?:php|phtml|inc|js|cjs|mjs|jsx|ts|tsx|py|pyi|rb|go|rs"
+    r"|java|kt|kts|swift|c|h|cpp|hpp|cc|cs|fs|css|scss|less|sass|html?|htm"
+    r"|vue|svelte|json|ya?ml|toml|ini|cfg|conf|md|markdown|txt|sh|bash|zsh"
+    r"|fish|sql|xml|env|lock|csv|tsv|log)(?::\d+)?"
+    r"|\S+/\S+\.\w{1,8}",
+    re.IGNORECASE,
+)
 
 
-def _tokens(text: str) -> set[str]:
-    return {
-        t.lower()
-        for t in _TOKEN_RE.findall(text)
-        if t.lower() not in _STOPWORDS
-    }
+def _tokens(text: str, *, split_compounds: bool = False) -> set[str]:
+    """Lowercased content tokens, stopwords dropped.
+
+    With ``split_compounds`` each token is accompanied by its snake_case
+    and camelCase parts (each still length- and stopword-filtered), so
+    ``wp_ajax_nopriv_avatar_upload`` also yields {ajax, nopriv, avatar,
+    upload} and claims can match the constructs they name.
+    """
+    tokens: set[str] = set()
+    for raw in _TOKEN_RE.findall(text):
+        lowered = raw.lower()
+        if lowered in _STOPWORDS:
+            continue
+        tokens.add(lowered)
+        if not split_compounds:
+            continue
+        for part in raw.split("_"):
+            for piece in _CAMEL_PART_RE.findall(part):
+                piece = piece.lower()
+                if len(piece) >= 4 and piece not in _STOPWORDS:
+                    tokens.add(piece)
+    return tokens
+
+
+def _evidence_tokens(text: str) -> set[str]:
+    """Content tokens for claim-to-code correspondence.
+
+    Path-like citation strings (``functions.php:1520``, ``src/a/b.py``,
+    ``assets/exercise-library-el.js:31``) are stripped first so a
+    backticked file reference in the claim cannot collide with path or
+    module words inside unrelated hunks.
+    """
+    return _tokens(_CITATION_RE.sub(" ", text), split_compounds=True)
 
 
 def is_duplicate_of_existing(

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -121,7 +121,9 @@ class TestHunkAwareAlignment:
 
     def test_wrong_hunk_member_is_reresolved_by_content(self):
         aligned = self._aligned()
-        assert aligned[0].line == 1261
+        # 1262 (the InvalidArgumentException throw) now outranks 1261: the
+        # claim's most specific evidence token lives on the throw line.
+        assert aligned[0].line == 1262
 
     def test_refuted_member_with_no_match_anywhere_drops_to_file_level(self):
         aligned = self._aligned(
@@ -422,3 +424,253 @@ class TestMaxErrorFindingsEnv:
     def test_explicit_argument_beats_both_env_names(self, monkeypatch):
         monkeypatch.setenv("PRXREF_MAX_ERROR_FINDINGS", "2")
         assert _resolve_max_errors(7) == 7
+
+
+# The five shapes below reconstruct the live anchor misses from the v0.10.0
+# re-audit (14/19 on-target). Each fixture is a self-contained unified diff
+# whose cited line is a valid added line, so the drift survives membership
+# validation exactly the way the audited reviews did.
+SHAPE1_DIFF = """\
+diff --git a/src/functions.php b/src/functions.php
+--- a/src/functions.php
++++ b/src/functions.php
+@@ -1498,2 +1498,28 @@ function register_ajax_handlers(): void {
+     add_action('wp_ajax_avatar_upload', 'handle_legacy_upload');
++    add_action('wp_ajax_nopriv_avatar_upload', 'handle_avatar_upload');
++    add_action('wp_ajax_avatar_upload', 'handle_avatar_upload');
++    add_action('wp_ajax_fetch_notifications', 'handle_fetch_notifications');
++    add_action('wp_ajax_save_settings', 'handle_save_settings');
++    add_action('wp_ajax_load_settings', 'handle_load_settings');
++    add_action('admin_menu', 'register_settings_screen');
++    add_action('admin_enqueue_scripts', 'enqueue_settings_assets');
++    add_filter('plugin_action_links', 'add_settings_link');
++    add_action('plugins_loaded', 'bootstrap_settings');
++    add_action('admin_init', 'register_settings_group');
++    add_action('rest_api_init', 'register_rest_routes');
++
++    /**
++     * Renders the admin settings screen for the plugin.
++     */
++    function render_settings_screen(): void {
++        if (!current_user_can('manage_options')) {
++            wp_die(esc_html__('Insufficient permissions.'));
++        }
++        echo '<div class="wrap">';
++        echo '<form method="post">';
++        settings_fields('prxref_settings');
++        do_settings_sections('prxref_settings');
++        echo '</form>';
++        echo '</div>';
++    }
+ }
+"""
+
+SHAPE2_DIFF = """\
+diff --git a/src/functions.php b/src/functions.php
+--- a/src/functions.php
++++ b/src/functions.php
+@@ -2398,2 +2398,4 @@ function enqueue_badge_styles(): void {
+     $css = '<style>.badge { color: #333; }';
++    $css .= '.like-button .rating-star { font-weight: 600; }';
++    $css .= '.badge { padding: 12px 16px; }';
+     wp_add_inline_style('prxref', $css);
+@@ -3200,2 +3200,6 @@ function bp_like_get_rating(): int {
+     $post_id = intval($_POST['post_id']);
++    if (!isset($_POST['member_id'])) {
++        bp_core_add_message(__('Missing member id.'));
++    }
++    $member_id = intval($_POST['member_id']);
+     bp_like_register_vote($post_id, $member_id);
+"""
+
+SHAPE3_DIFF = """\
+diff --git a/src/components/ExerciseFeedbackDialog.tsx b/src/components/ExerciseFeedbackDialog.tsx
+--- a/src/components/ExerciseFeedbackDialog.tsx
++++ b/src/components/ExerciseFeedbackDialog.tsx
+@@ -20,3 +20,8 @@ export const ExerciseFeedbackDialog = observer(() => {
+     const [visible, setVisible] = useState(false);
++    const summary = useMemo(
++        () => computeSummary(feedback),
++        [feedback, store],
++    );
+     const theme = useTheme();
++    const dense = useDenseViewport();
+     return (
+@@ -40,2 +45,4 @@ function FeedbackBody(props) {
+     const dialog = useDialog();
++    const { rating, feedback } = exerciseStore.observables;
++    const canSubmit = rating !== null;
+     return (
+"""
+
+SHAPE4_DIFF = """\
+diff --git a/src/components/SessionDialog.tsx b/src/components/SessionDialog.tsx
+--- a/src/components/SessionDialog.tsx
++++ b/src/components/SessionDialog.tsx
+@@ -96,2 +96,34 @@ render() {
+     <div className="dialog-header">
++        <button
++            type="button"
++            className="btn-close"
++            aria-label="Close dialog"
++            onClick={this.handleClose}
++        >
++            ×
++        </button>
++    </div>
++    <div className="dialog-body">
++        <p>Review the session details below.</p>
++        <label htmlFor="session-topic">Topic</label>
++        <input id="session-topic" readOnly />
++        <label htmlFor="session-length">Length</label>
++        <select id="session-length">
++            <option value="30">30 minutes</option>
++            <option value="60">60 minutes</option>
++        </select>
++        <label htmlFor="session-notes">Notes</label>
++        <textarea id="session-notes" rows={4} />
++    </div>
++    <div className="dialog-footer">
++        <span className="footer-note">
++            Saved responses appear here.
++        </span>
++        <button className="btn-secondary" onClick={this.handleCancel}>
++            Cancel
++        </button>
++    </div>
++    <div className="dialog-preview">
++        <input placeholder={formatStamp(FIXED_EPOCH)} disabled />
++    </div>
+     )
+"""
+
+SHAPE5_DIFF = """\
+diff --git a/assets/js/el.js b/assets/js/el.js
+--- a/assets/js/el.js
++++ b/assets/js/el.js
+@@ -30,6 +30,11 @@ import boot from './boot.js';
+     const registry = new Map();
++
++    export function ready() {
+     startTimers();
+     }
++    const state = { ready: false };
+     function tick() {}
+     function idle() {}
++    const legacy = buildLegacyEntry();
++    const fs = require('fs');
+     export default ready;
+"""
+
+
+class TestLiveAnchorDriftShapes:
+    """One test per audited v0.10.0 anchor miss (live kzetxa PR shapes)."""
+
+    def _align(self, diff: str, path: str, **kwargs) -> list[Finding]:
+        parsed = parse_unified_diff(diff)
+        defaults = {
+            "file": path,
+            "severity": "warning",
+            "confidence": 0.8,
+        }
+        defaults.update(kwargs)
+        finding = _f(**defaults)
+        return apply_line_align(
+            [finding], added_lines_by_file(parsed), files=parsed
+        )[0]
+
+    def test_shape1_docblock_near_miss_resolves_to_registration_line(self):
+        # Live: functions.php:1520 — a claim about the nopriv avatar upload
+        # registration anchored on an unrelated docblock inside the right
+        # hunk, ~15 lines from the real add_action line.
+        aligned = self._align(
+            SHAPE1_DIFF,
+            "src/functions.php",
+            line=1512,
+            title="Unauthenticated avatar upload handler registered for nopriv",
+            body=(
+                "The upload callback runs with no capability check, so any "
+                "visitor can upload a file through the avatar endpoint."
+            ),
+        )
+        assert aligned.line == 1499
+
+    def test_shape2_far_hunk_generic_overlap_resolves_to_evidence_hunk(self):
+        # Live: functions.php:2400 — a member_id claim corroborated by a far
+        # CSS-tweak hunk purely because its like/rating class names overlap
+        # the title; the evidence hunk is ~800 lines away.
+        aligned = self._align(
+            SHAPE2_DIFF,
+            "src/functions.php",
+            line=2400,
+            title="Like/rating handlers trust client-supplied member_id",
+            body=(
+                "The vote callback reads member_id straight from the "
+                "request, so one member can act as another."
+            ),
+        )
+        assert aligned.line == 3204
+
+    def test_shape3_deps_line_resolves_to_actual_destructure(self):
+        # Live: ExerciseFeedbackDialog.tsx:30 — a destructuring claim
+        # anchored on the related-but-wrong useMemo deps line, 12+ lines
+        # above the actual destructure.
+        aligned = self._align(
+            SHAPE3_DIFF,
+            "src/components/ExerciseFeedbackDialog.tsx",
+            line=23,
+            title="Destructured MobX observables read before store hydration",
+            body=(
+                "rating and feedback come straight off the root store "
+                "before it finishes hydrating, so both can be undefined "
+                "on first paint."
+            ),
+        )
+        assert aligned.line == 46
+
+    def test_shape4_click_handler_resolves_to_placeholder_timestamp(self):
+        # Live: ExerciseFeedbackDialog.tsx:101 — a placeholder-timestamp
+        # claim anchored on an unrelated close-button onClick, ~26 lines
+        # from the code the claim describes.
+        aligned = self._align(
+            SHAPE4_DIFF,
+            "src/components/SessionDialog.tsx",
+            line=101,
+            title="Placeholder timestamp shows a fixed epoch",
+            body=(
+                "The field placeholder renders a frozen timestamp instead "
+                "of the current local time, so the sample reads as stale."
+            ),
+        )
+        assert aligned.line == 127
+
+    def test_shape5_blank_added_line_never_beats_token_bearing_line(self):
+        # Live: el.js:31 — the claim text itself cited a line that is a
+        # blank added line; the require("fs") evidence sits 8 lines lower.
+        aligned = self._align(
+            SHAPE5_DIFF,
+            "assets/js/el.js",
+            line=31,
+            title="require used in ES module",
+            body=(
+                'require("fs") is CommonJS and will crash the ES module '
+                "build; see assets/exercise-library-el.js:31."
+            ),
+        )
+        assert aligned.line == 39
+
+    def test_blank_landing_from_snap_pass_also_resolves_to_tokens(self):
+        # The blank-anchor rule must hold on the snap path too: a citation
+        # that snaps onto a blank added line re-resolves to the nearest
+        # token-bearing evidence instead of posting on the blank line.
+        aligned = self._align(
+            SHAPE5_DIFF,
+            "assets/js/el.js",
+            line=30,
+            title="require used in ES module",
+            body=(
+                'require("fs") is CommonJS and will crash the ES module '
+                "build; see assets/exercise-library-el.js:31."
+            ),
+        )
+        assert aligned.line == 39


### PR DESCRIPTION
Follow-up to #25 (still #19). The live v0.10.0 re-audit found 14/19 anchors on-target but 5 still drifting — including one 391 lines into an unrelated hunk whose content shared zero claim tokens, and one anchored on a blank line.

## What changed in the resolver (`quality.py`)

- An anchor's hunk must share a NON-GENERIC evidence token with the claim — the stopword/genericity rules were strengthened so words like handler/line/code cannot corroborate a hunk.
- Ties prefer the hunk containing the claim's most-specific (longest/rarest) token, THEN nearest-to-citation — nearest no longer wins a tie it didn't earn.
- A blank or pure-context anchor never survives when any token-bearing added line exists in the file.
- The shipped 5-line tolerance and the `line=0` last resort are unchanged.

## Verification

Six new fixture tests under `TestLiveAnchorDriftShapes`, one per live miss shape (the 391-line zero-overlap hunk, the blank-line anchor, the near-miss constructs) — 1065 passed, ruff clean.