### PR TITLE
fix: a line cited in the finding body outranks a drifted line field (fixes #28)

### DIFF
--- a/src/prxref/quality.py
+++ b/src/prxref/quality.py
@@ -1,11 +1,18 @@
 """Deterministic quality passes over worker findings.
 
 Four passes run before posting:
-1. ``apply_line_align``: snap each finding's cited line to the nearest
-   actual ``+`` line in that file's diff (within tolerance, else line=0),
-   then corroborate exact ``+``-line members against the file's hunks by
+1. ``apply_line_align``: a line explicitly cited in the finding's own
+   title or body (``line 553``, ``at line 553``, an own-file
+   ``path:line``) outranks a drifted ``line`` field whenever the cited
+   line lands on an added line — or a context line within tolerance of
+   one — of that file's diff and its hunk corroborates against the claim;
+   a non-corroborating citation is ignored. Then snap each finding's
+   cited line to the nearest actual ``+`` line in that file's diff
+   (within tolerance, else line=0), then corroborate exact ``+``-line
+   members against the file's hunks by
    content, so an anchor that is a valid added line of the WRONG hunk
-   (issue #19's drift shape) is re-resolved or demoted to file-level
+   (issue #19's drift shape) is
+   re-resolved or demoted to file-level
    instead of posting at a wrong position. Corroboration is line-level:
    an anchor survives only when it ties the file's best evidence match
    or sits within tolerance of it, and a blank or pure-punctuation
@@ -214,6 +221,97 @@ def _best_candidate(
     return top[0], top[2]
 
 
+_BODY_LINE_CITE_RE = re.compile(
+    r"(?P<path>[\w./\\-]+\.(?:php|phtml|inc|js|cjs|mjs|jsx|ts|tsx|py|pyi|rb|go"
+    r"|rs|java|kt|kts|swift|c|h|cpp|hpp|cc|cs|fs|css|scss|less|sass|html?|htm"
+    r"|vue|svelte|json|ya?ml|toml|ini|cfg|conf|md|markdown|txt|sh|bash|zsh"
+    r"|fish|sql|xml|env|lock|csv|tsv|log)|\S+/\S+\.\w{1,8}):(?P<num>\d+)"
+    r"|\bline\s+(?P<prose>\d+)\b",
+    re.IGNORECASE,
+)
+
+
+def _is_own_file_citation(path: str, file: str) -> bool:
+    """True when a ``path:line`` citation names the finding's own file.
+
+    Exact, or a suffix at a directory separator in either direction, so
+    ``sync.ts:553`` answers a finding filed against ``src/sync.ts`` while
+    a sibling file's ``other.ts:12`` never does. A bare path with no
+    ``:line`` never reaches this check.
+    """
+    cited = path.replace("\\", "/").lower()
+    own = file.replace("\\", "/").lower()
+    if cited.startswith("./"):
+        cited = cited[2:]
+    return cited == own or own.endswith("/" + cited) or cited.endswith("/" + own)
+
+
+def _body_cited_lines(finding: Finding) -> list[int]:
+    """Line numbers the finding's own title+body cite, in document order.
+
+    Grammar: an own-file ``path:line`` citation (``sync.ts:553``,
+    backticked or bare, any known extension or slash path) and prose
+    ``line N`` (``at line 553``, ``Line 553.``). A bare path mention
+    (``sync.ts``) cites no line, and another file's ``path:line`` is
+    ignored.
+    """
+    text = f"{finding.title} {finding.body}"
+    hits: list[tuple[int, int]] = []
+    for m in _BODY_LINE_CITE_RE.finditer(text):
+        if m.group("path") is not None:
+            if _is_own_file_citation(m.group("path"), finding.file):
+                hits.append((m.start(), int(m.group("num"))))
+        else:
+            hits.append((m.start(), int(m.group("prose"))))
+    hits.sort()
+    return [num for _, num in hits]
+
+
+def _hunk_tokens(hunk: Hunk) -> set[str]:
+    """Union of content tokens over the hunk's non-removed lines."""
+    tokens: set[str] = set()
+    for ln in hunk.lines:
+        if ln.kind != "-" and ln.new_line is not None:
+            tokens |= _line_tokens(ln)
+    return tokens
+
+
+def _resolve_body_cited_anchor(
+    finding: Finding,
+    hunks: Sequence[Hunk],
+    added: set[int],
+    tolerance: int = DEFAULT_LINE_TOLERANCE,
+) -> int | None:
+    """The anchor a corroborated in-body line citation demands, or None.
+
+    Issue #28: the model's ``line`` field drifts while its own body still
+    names the right line. The first body citation — ``line N`` or an
+    own-file ``path:line`` — whose cited line sits on an added line (or a
+    context line within ``tolerance`` of one) of this file AND whose
+    containing hunk shares a non-generic evidence token with the claim
+    wins; its snapped anchor outranks the ``line`` field. A citation that
+    fails either check is skipped (later citations still try), and None
+    sends the caller down the shipped resolution path unchanged. A
+    citation never lands on a blank or pure-punctuation anchor while the
+    file carries token-bearing added lines.
+    """
+    evidence = _evidence_tokens(f"{finding.title} {finding.body}")
+    if not evidence:
+        return None
+    blank_guard = _file_has_token_bearing_add(hunks)
+    for cited in _body_cited_lines(finding):
+        anchor = snap_line(cited, added, tolerance=tolerance)
+        if anchor <= 0:
+            continue
+        hunk = _hunk_containing(hunks, cited)
+        if hunk is None or not (_hunk_tokens(hunk) & evidence):
+            continue
+        if blank_guard and _line_is_blankish(hunks, anchor):
+            continue
+        return anchor
+    return None
+
+
 def apply_line_align(
     findings: Sequence[Finding],
     added_lines_by_file: dict[str, set[int]] | None = None,
@@ -221,6 +319,17 @@ def apply_line_align(
     files: Sequence[FileDiff] | None = None,
 ) -> list[Finding]:
     """Snap each finding's line to a defensible anchor in that file's diff.
+
+    Body-citation precedence: when the parsed hunks are supplied, a line
+    cited in the finding's own title or body for this file (``line 553``,
+    ``at line 553``, ``sync.ts:553``) outranks the ``line`` field
+    whenever the cited line lands on an added line — or a context line
+    within ``tolerance`` of one — of this file's diff and the hunk
+    containing the cited line shares a non-generic evidence token with
+    the claim (:func:`_resolve_body_cited_anchor`). The first
+    corroborating citation wins; a citation outside the diff, with no
+    corroborating hunk, or landing on a blank anchor is ignored and the
+    shipped rules below apply unchanged.
 
     Positional pass: within ``tolerance`` of the nearest ``+`` line the
     citation snaps there; beyond it the citation is not trusted and drops
@@ -244,17 +353,23 @@ def apply_line_align(
     for f in findings:
         added = by_file.get(f.file, set())
         hunks = hunks_by_file.get(f.file)
-        if hunks and f.line > 0 and f.line in added:
-            new_line = _realign_member(f, hunks, tolerance=tolerance)
-        else:
-            new_line = snap_line(f.line, added, tolerance=tolerance)
-            if (
-                hunks
-                and new_line > 0
-                and _line_is_blankish(hunks, new_line)
-                and _file_has_token_bearing_add(hunks)
-            ):
+        new_line = (
+            _resolve_body_cited_anchor(f, hunks, added, tolerance=tolerance)
+            if hunks
+            else None
+        )
+        if new_line is None:
+            if hunks and f.line > 0 and f.line in added:
                 new_line = _realign_member(f, hunks, tolerance=tolerance)
+            else:
+                new_line = snap_line(f.line, added, tolerance=tolerance)
+                if (
+                    hunks
+                    and new_line > 0
+                    and _line_is_blankish(hunks, new_line)
+                    and _file_has_token_bearing_add(hunks)
+                ):
+                    new_line = _realign_member(f, hunks, tolerance=tolerance)
         if new_line != f.line:
             result.append(replace(f, line=new_line))
         else:

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from prxref.forges.base import Thread
 from prxref.quality import (
+    _body_cited_lines,
     _resolve_max_errors,
     active,
     apply_line_align,
@@ -674,3 +675,192 @@ class TestLiveAnchorDriftShapes:
             ),
         )
         assert aligned.line == 39
+
+
+# Issue #28 live shapes: the model's line field drifts while its own body
+# still names the right line. SYNC_TS_DIFF is the sync.ts:15-vs-553 shape
+# (added `debugger` lines at 15 and 553); CLI_TS_DIFF is the el.js:3-vs-46
+# shape (added `await init` at 47, citation one line above it).
+SYNC_TS_DIFF = """\
+diff --git a/src/sync.ts b/src/sync.ts
+--- a/src/sync.ts
++++ b/src/sync.ts
+@@ -14,2 +14,3 @@ export async function sync() {
+   const ready = prepare();
++  debugger;
+   await send(ready);
+@@ -553,2 +553,3 @@ export function flushQueue() {
++  debugger;
+   const stale = queue.filter(isDone);
+   persist(stale);
+"""
+
+CLI_TS_DIFF = """\
+diff --git a/src/cli.ts b/src/cli.ts
+--- a/src/cli.ts
++++ b/src/cli.ts
+@@ -44,4 +44,5 @@ function banner() {
+   const opts = parse(argv);
+   applyDefaults(opts);
+   main(opts);
++  await init(opts);
+   return 0;
+"""
+
+WORKER_TS_DIFF = """\
+diff --git a/src/worker.ts b/src/worker.ts
+--- a/src/worker.ts
++++ b/src/worker.ts
+@@ -14,1 +15,2 @@ export function tick() {
++  debugger;
+   const ready = prepare();
+@@ -553,1 +553,2 @@ export function report() {
++  retryBudget = maxRetries;
+   audit(log);
+"""
+
+
+class TestBodyCitedAnchor:
+    """A corroborated body citation outranks a drifted line field."""
+
+    def _align(self, diff: str, path: str, **kwargs) -> Finding:
+        parsed = parse_unified_diff(diff)
+        defaults = {
+            "file": path,
+            "severity": "warning",
+            "confidence": 0.8,
+        }
+        defaults.update(kwargs)
+        return apply_line_align(
+            [_f(**defaults)], added_lines_by_file(parsed), files=parsed
+        )[0]
+
+    def test_body_line_citation_outranks_drifted_field(self):
+        # Live sync.ts shape: field said 15, body said line 553, the
+        # actual `debugger` sits at 553.
+        aligned = self._align(
+            SYNC_TS_DIFF,
+            "src/sync.ts",
+            line=15,
+            title="Leftover debugger statement",
+            body=(
+                "A debugger statement ships in the queue flush; remove "
+                "the debugger before merging (line 553)."
+            ),
+        )
+        assert aligned.line == 553
+
+    def test_backticked_path_citation_resolves_within_tolerance(self):
+        # Live el.js shape: field said 3, body cited `cli.ts:46`, the
+        # actual added line is 47 (one below the cited context line).
+        aligned = self._align(
+            CLI_TS_DIFF,
+            "src/cli.ts",
+            line=3,
+            title="main() entry point never awaits init",
+            body=(
+                "The main() entry point never awaits initialization; "
+                "see `cli.ts:46`."
+            ),
+        )
+        assert aligned.line == 47
+
+    def test_citation_outside_the_diff_is_ignored(self):
+        aligned = self._align(
+            SYNC_TS_DIFF,
+            "src/sync.ts",
+            line=15,
+            title="Leftover debugger statement",
+            body="A debugger statement ships in the flush; see line 999.",
+        )
+        assert aligned.line == 15
+
+    def test_uncorroborated_citation_is_ignored(self):
+        # The cited hunk (retryBudget) shares zero evidence tokens with a
+        # claim about the debugger statement, so the citation is dropped
+        # and the shipped content rules keep the corroborated member 15.
+        aligned = self._align(
+            WORKER_TS_DIFF,
+            "src/worker.ts",
+            line=15,
+            title="Leftover debugger statement",
+            body=(
+                "A debugger statement ships in the tick path; remove "
+                "it, see line 553."
+            ),
+        )
+        assert aligned.line == 15
+
+    def test_first_corroborating_citation_wins(self):
+        # line 553 names the retryBudget hunk (zero shared tokens) and is
+        # skipped; line 15 corroborates.
+        aligned = self._align(
+            WORKER_TS_DIFF,
+            "src/worker.ts",
+            line=15,
+            title="Leftover debugger statement",
+            body=(
+                "Check line 553 first; the debugger statement itself "
+                "sits at line 15."
+            ),
+        )
+        assert aligned.line == 15
+
+    def test_earlier_citation_wins_when_both_corroborate(self):
+        aligned = self._align(
+            SYNC_TS_DIFF,
+            "src/sync.ts",
+            line=15,
+            title="Leftover debugger statement",
+            body=(
+                "The debugger statement at line 553 matters more than "
+                "the one at line 15."
+            ),
+        )
+        assert aligned.line == 553
+
+    def test_file_level_finding_promoted_by_corroborated_citation(self):
+        aligned = self._align(
+            SYNC_TS_DIFF,
+            "src/sync.ts",
+            line=0,
+            title="Leftover debugger statement",
+            body="A debugger statement remains at line 553.",
+        )
+        assert aligned.line == 553
+
+    def test_bare_path_mention_never_overrides(self):
+        aligned = self._align(
+            SYNC_TS_DIFF,
+            "src/sync.ts",
+            line=15,
+            title="Leftover debugger statement",
+            body="See sync.ts for the debugger statement left in flush.",
+        )
+        assert aligned.line == 15
+
+
+class TestBodyCitationGrammar:
+    def test_backticked_own_file_path_line(self):
+        f = _f(file="a/b/sync.ts", body="see `sync.ts:553` for the leak.")
+        assert _body_cited_lines(f) == [553]
+
+    def test_at_line_prose_form(self):
+        f = _f(body="The bug appears at line 46 of the entry path.")
+        assert _body_cited_lines(f) == [46]
+
+    def test_bare_path_cites_nothing(self):
+        f = _f(file="a/b/sync.ts", body="See sync.ts for details.")
+        assert _body_cited_lines(f) == []
+
+    def test_other_file_path_line_ignored(self):
+        f = _f(file="a/b/sync.ts", body="Mirrors other.ts:12 behavior.")
+        assert _body_cited_lines(f) == []
+
+    def test_document_order_across_title_and_body(self):
+        f = _f(
+            file="src/cli.ts",
+            title="Entry at cli.ts:40",
+            body="Also line 55 matters.",
+        )
+        assert _body_cited_lines(f) == [40, 55]


### PR DESCRIPTION
Fixes #28. Live shape: `debugger` finding anchored `sync.ts:15` while its own body said "line 553" (actual code at 553); `main()` finding anchored `el.js:3`, body cited 46, actual 47. The model knew where the code was; the `line` field drifted.

## What

New precedence step in the anchor resolver: line citations parsed from the finding's own title+body (own-file `path:line`, bare or backticked, with an extension/slash grammar; prose `line N` / `at line N` for the own file) — when the cited line is an added line (or context within tolerance) AND its hunk corroborates with a non-generic evidence token, it outranks the model's `line` field. Any failure → next citation → the shipped snap/refutation/line=0 path, byte-identical for the no-citation case. Bare path mentions and other-file citations never override. A corroborated citation also promotes a file-level (line=0) finding to its real anchor.

## Verification

13 new tests (grammar + precedence, incl. both live shapes); the 4 behavior-changing ones were verified to fail with the precedence call disabled. 1078 passed, ruff clean.