### PR TITLE
feat: severity groups also bind on shared rare code tokens (fixes #30)

### DIFF
--- a/src/prxref/orchestrator.py
+++ b/src/prxref/orchestrator.py
@@ -395,7 +395,7 @@ def orchestrate_review(
     )
     if rewrites:
         logger.info(
-            "severity consistency: raised %d finding(s) to their title group's max severity",
+            "severity consistency: raised %d finding(s) to their severity group's max severity",
             rewrites,
         )
     findings = consistent

--- a/src/prxref/quality.py
+++ b/src/prxref/quality.py
@@ -15,7 +15,9 @@ Four passes run before posting:
 3. ``apply_severity_consistency``: findings sharing one normalized title —
    within a file or across sibling files — are all raised to the group's
    maximum severity, so per-chunk workers cannot disagree about how
-   serious the same pattern is.
+   serious the same pattern is. Findings phrased differently but bound
+   by a shared rare code token, with a shared problem class or file,
+   join the same group (issue #30).
 4. ``apply_quality_gate``: drop findings below the confidence floor, cap
    errors per review, and enforce the {error, warning, outofscope} severity
    vocabulary.
@@ -26,8 +28,10 @@ so review runstores and logs can explain every filter decision. Use
 """
 from __future__ import annotations
 
+import logging
 import os
 import re
+from collections import Counter
 from collections.abc import Sequence
 from dataclasses import replace
 
@@ -422,36 +426,224 @@ def normalize_title(title: str) -> str:
     return " ".join(trimmed.split())
 
 
-def apply_severity_consistency(findings: Sequence[Finding]) -> list[Finding]:
-    """Raise every finding in a normalized-title group to the group's max severity.
+logger = logging.getLogger(__name__)
 
-    Per-chunk workers decide severity in isolation, so the same pattern can
-    surface as an error in one file and a warning in a sibling, or as a
-    warning at one anchor and a note at another in the same file. Findings
-    sharing one :func:`normalize_title` form — within a file or across
-    files — are all rewritten to the group's highest severity
-    (error > warning > outofscope). A rewritten finding keeps its own file,
-    line, body, and confidence; only severity changes. Findings carrying a
-    ``drop_reason`` or a severity outside the vocabulary pass through
-    untouched.
+
+def _problem_classes(title: str) -> set[str]:
+    """Canonical problem classes a title names, e.g. ``{"injection"}``.
+
+    Two titles share a verdict class when their sets intersect. Several
+    phrasings map to one class on purpose: the live issue #30 family says
+    "injection", "interpolation", "unescaped", and "filter manipulation"
+    for the same bug, so all four sit in ``injection`` — a guard keyed on
+    literal keyword equality would never bind them, which is the failure
+    this pass fixes.
     """
-    group_max: dict[str, str] = {}
-    for f in findings:
-        if f.drop_reason is not None:
+    return {name for name, pattern in _PROBLEM_CLASSES if pattern.search(title)}
+
+
+def _code_tokens(claim: str) -> set[str]:
+    """Code-identifier tokens in a finding's title+body claim.
+
+    Three shapes qualify: backticked identifier pieces (floor of 3
+    chars, since backticks already mark them as code), bare compound
+    identifiers — snake_case, UPPER_SNAKE_CASE, camelCase — at 6+ chars,
+    and dotted paths as whole lowercase paths. File-path citations are
+    stripped first (a path names a location, not a shared construct),
+    and generic vocabulary is excluded via :data:`_CODE_STOPWORDS`.
+
+    Whole identifiers only: unlike the evidence tokens above, compounds
+    are never split, because grouping binds on the construct itself —
+    ``vimeo_code`` must not match a claim that merely says "code".
+    """
+    text = _CITATION_RE.sub(" ", claim)
+    tokens: set[str] = set()
+    for span in _BACKTICK_RE.findall(text):
+        for piece in _CODE_PIECE_RE.findall(span):
+            tok = piece.lower().strip("._-")
+            if len(tok) >= 3 and tok not in _CODE_STOPWORDS:
+                tokens.add(tok)
+    text = _BACKTICK_RE.sub(" ", text)
+    for pattern in (_SNAKE_RE, _UPPER_SNAKE_RE, _CAMEL_RE, _DOTTED_RE):
+        for raw in pattern.findall(text):
+            if len(raw) >= 6:
+                tokens.add(raw.lower())
+    return tokens
+
+
+CODE_TOKEN_RARITY_MAX: int = 2
+"""Largest claim count a code token may have and still bind a group.
+
+A token appearing in the claims of at most 2 findings names a construct
+specific to one bug family; the same name in 3+ claims is systemic
+vocabulary (an API used everywhere, a framework type), and binding on it
+would chain unrelated findings into one severity. Tuned so the live
+issue #30 pair (each token in exactly 2 claims) binds while the
+3-claim sweep in the tests does not.
+"""
+
+_CODE_STOPWORDS: frozenset[str] = frozenset({
+    "api", "app", "args", "attr", "attrs", "body", "callback", "case",
+    "check", "class", "code", "component", "config", "const", "constant",
+    "content", "context", "count", "create", "ctx", "data", "db",
+    "default", "delete", "element", "err", "error", "example", "field",
+    "file", "find", "func", "function", "get", "global", "handler",
+    "handling", "helper", "id", "impl", "index", "init", "input",
+    "instance", "issue", "item", "key", "length", "line", "list", "load",
+    "local", "log", "logic", "manager", "message", "meta", "method",
+    "mode", "model", "module", "msg", "name", "node", "null", "num",
+    "number", "obj", "object", "option", "options", "output", "param",
+    "params", "pattern", "process", "prop", "property", "record",
+    "req", "request", "res", "response", "result", "return", "review",
+    "route", "schema", "service", "set", "settings", "spec", "state",
+    "store", "str", "string", "temp", "test", "text", "tmp", "type",
+    "update", "util", "utils", "val", "value", "values", "var",
+    "variable", "warning", "worker",
+})
+
+_BACKTICK_RE = re.compile(r"`([^`\n]+)`")
+_CODE_PIECE_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_.\-]*")
+_SNAKE_RE = re.compile(r"\b[a-z][a-z0-9]*(?:_[a-z0-9]+)+\b")
+_UPPER_SNAKE_RE = re.compile(r"\b[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+\b")
+_CAMEL_RE = re.compile(r"\b[a-z]+(?:[A-Z][a-z0-9]+)+\b")
+_DOTTED_RE = re.compile(r"\b[A-Za-z_][A-Za-z0-9_\-]*(?:\.[A-Za-z_][A-Za-z0-9_\-]+)+\b")
+
+_PROBLEM_CLASSES: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("injection", re.compile(
+        r"inject|interpolat|escap|sanitiz|manipulat", re.IGNORECASE)),
+    ("secret", re.compile(
+        r"secret|credential|password|\bapi[ -]?key|\btoken\b|hard[ -]?cod",
+        re.IGNORECASE)),
+    ("auth", re.compile(
+        r"\bauth|unauthori|permission|privilege|access control", re.IGNORECASE)),
+    ("race", re.compile(
+        r"\brace\b|non-?atomic|deadlock|concurren", re.IGNORECASE)),
+    ("leak", re.compile(r"\bleak|expos|disclos", re.IGNORECASE)),
+    ("truncation", re.compile(r"truncat|overflow", re.IGNORECASE)),
+    ("null", re.compile(r"\bnull\b|\bnil\b|nonetype|undefined", re.IGNORECASE)),
+    ("duplicate", re.compile(r"duplicat|redundan", re.IGNORECASE)),
+    ("timeout", re.compile(r"timeout|unbounded|infinite", re.IGNORECASE)),
+    ("ratelimit", re.compile(r"rate[ -]?limit|throttl|\b429\b", re.IGNORECASE)),
+    ("validation", re.compile(r"validat|malformed|invalid", re.IGNORECASE)),
+)
+
+
+def apply_severity_consistency(findings: Sequence[Finding]) -> list[Finding]:
+    """Raise every finding in a severity group to the group's max severity.
+
+    Two grouping mechanisms union into one component graph:
+
+    1. Normalized-title equality (issue #18): findings sharing one
+       :func:`normalize_title` form restate the same pattern and always
+       merge — the strictly stronger rule.
+    2. Shared rare code token (issue #30): the same construct phrased
+       differently across claims — ``vimeo_code`` interpolated into
+       ``filterByFormula``, reported once as injection and once as
+       manipulation — merges only when both a rarity rule and a
+       verdict-class guard hold. Rarity: the token appears in the claims
+       of at most :data:`CODE_TOKEN_RARITY_MAX` findings in this review
+       (see that constant). Verdict-class guard: the pair sits in the
+       same file, or both titles name a common problem class (injection,
+       secret, auth, race, leak, truncation, null, duplicate, timeout,
+       rate limit, validation — see :func:`_problem_classes`). The guard
+       is the over-merging brake: two findings sharing a token but
+       describing different problems stay apart.
+
+    Components bind transitively (A shares a token with B, B with C, so
+    all three group). Each component is rewritten to its highest
+    severity (error > warning > outofscope). A rewritten finding keeps
+    its own file, line, body, and confidence; only severity changes.
+    Findings carrying a ``drop_reason`` or a severity outside the
+    vocabulary pass through untouched. One summary line is logged when
+    token-driven rewrites happen, naming the count and the binding
+    tokens; silent otherwise.
+    """
+    idx = [
+        i for i, f in enumerate(findings)
+        if f.drop_reason is None
+        and (f.severity or "").strip().lower() in _SEVERITY_RANK
+    ]
+    if not idx:
+        return list(findings)
+
+    parent = {i: i for i in idx}
+
+    def find(i: int) -> int:
+        while parent[i] != i:
+            parent[i] = parent[parent[i]]
+            i = parent[i]
+        return i
+
+    def union(a: int, b: int) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[rb] = ra
+
+    by_title: dict[str, int] = {}
+    for i in idx:
+        key = normalize_title(findings[i].title)
+        seen = by_title.get(key)
+        if seen is not None:
+            union(seen, i)
+        else:
+            by_title[key] = i
+
+    claims = [f"{findings[i].title} {findings[i].body}" for i in idx]
+    tok_sets = [_code_tokens(claim) for claim in claims]
+    counts: Counter[str] = Counter()
+    for tokens in tok_sets:
+        counts.update(tokens)
+    rare = {tok for tok, n in counts.items() if n <= CODE_TOKEN_RARITY_MAX}
+    classes = [_problem_classes(findings[i].title) for i in idx]
+
+    token_edges: dict[tuple[int, int], set[str]] = {}
+    for a in range(len(idx)):
+        for b in range(a + 1, len(idx)):
+            shared = tok_sets[a] & tok_sets[b] & rare
+            if not shared:
+                continue
+            if findings[idx[a]].file == findings[idx[b]].file or classes[a] & classes[b]:
+                union(idx[a], idx[b])
+                token_edges[(idx[a], idx[b])] = shared
+
+    components: dict[int, list[int]] = {}
+    for i in idx:
+        components.setdefault(find(i), []).append(i)
+
+    target_of: dict[int, str] = {}
+    token_rewrites = 0
+    binding: set[str] = set()
+    for members in components.values():
+        sevs = {(findings[i].severity or "").strip().lower() for i in members}
+        if len(sevs) < 2:
             continue
-        severity = (f.severity or "").strip().lower()
-        if severity not in _SEVERITY_RANK:
-            continue
-        key = normalize_title(f.title)
-        current = group_max.get(key)
-        if current is None or _SEVERITY_RANK[severity] < _SEVERITY_RANK[current]:
-            group_max[key] = severity
+        top = min(sevs, key=lambda s: _SEVERITY_RANK[s])
+        member = set(members)
+        edges_here = [
+            tokens for (a, b), tokens in token_edges.items()
+            if a in member and b in member
+        ]
+        rewritten_here = 0
+        for i in members:
+            target_of[i] = top
+            if (findings[i].severity or "").strip().lower() != top:
+                rewritten_here += 1
+        if edges_here and rewritten_here:
+            token_rewrites += rewritten_here
+            for tokens in edges_here:
+                binding |= tokens
+
+    if token_rewrites and binding:
+        logger.info(
+            "severity consistency: raised %d finding(s) via shared rare code token(s): %s",
+            token_rewrites, ", ".join(sorted(binding)),
+        )
 
     result: list[Finding] = []
-    for f in findings:
+    for pos, f in enumerate(findings):
         severity = (f.severity or "").strip().lower()
         if f.drop_reason is None and severity in _SEVERITY_RANK:
-            target = group_max.get(normalize_title(f.title), severity)
+            target = target_of.get(pos, severity)
             if severity != target:
                 result.append(replace(f, severity=target))
                 continue

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -480,6 +480,43 @@ class TestSeverityConsistency:
         assert dropped.drop_reason == "error cap exceeded (max 1)"
         assert res["verdict"] == "Request-Changes"
 
+    def test_shared_rare_code_token_raises_sibling_file_warning_to_error(self, caplog):
+        # Issue #30 live shape end to end: per-chunk workers phrase the
+        # same unescaped-interpolation bug differently, so normalized-title
+        # equality (#18) never binds. The rare-token pass must raise both
+        # to error before the gate, and log the binding token.
+        diff = (
+            _added_file_diff("src/airtable-video-processor.ts", 10)
+            + _added_file_diff("src/get-video-feedbacks.ts", 10)
+        )
+        findings = {
+            "src/airtable-video-processor.ts": [
+                {"file": "src/airtable-video-processor.ts", "line": 3,
+                 "severity": "error", "confidence": 0.9,
+                 "title": "Airtable formula injection via unescaped vimeo_code in filterByFormula",
+                 "body": "filterByFormula({vimeo_code}) allows filter manipulation."},
+            ],
+            "src/get-video-feedbacks.ts": [
+                {"file": "src/get-video-feedbacks.ts", "line": 3,
+                 "severity": "warning", "confidence": 0.8,
+                 "title": "Formula interpolation of vimeo_code allows filter manipulation",
+                 "body": "vimeo_code interpolated into filterByFormula."},
+            ],
+        }
+        forge = FakeForge(diff=diff)
+        with caplog.at_level(logging.INFO, logger="prxref.quality"):
+            res = orchestrate_review(forge, REF, FakeLLM(findings_by_path=findings), post=False)
+
+        assert len(res["findings_active"]) == 2
+        assert all(f.severity == "error" for f in res["findings_active"])
+        assert res["verdict"] == "Request-Changes"
+        token_lines = [
+            r for r in caplog.records
+            if r.name == "prxref.quality" and "shared rare code token" in r.getMessage()
+        ]
+        assert len(token_lines) == 1
+        assert "vimeo_code" in token_lines[0].getMessage()
+
 
 class TestErrorPaths:
     def test_total_llm_failure_error_verdict_and_notice_posted(self):

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1,6 +1,8 @@
 """Tests for prxref.quality: line alignment, thread dedup, and quality gate."""
 from __future__ import annotations
 
+import logging
+
 from prxref.forges.base import Thread
 from prxref.quality import (
     _resolve_max_errors,
@@ -341,6 +343,174 @@ class TestSeverityConsistency:
         assert normalize_title("`foo` bar") == normalize_title("foo bar")
         assert normalize_title('"Quoted" title!') == normalize_title("quoted title")
         assert normalize_title("  Mixed   CASE  ") == "mixed case"
+
+
+class TestSeverityTokenGrouping:
+    def test_shared_rare_token_binds_different_phrasings_across_files(self):
+        # The live issue #30 shape (v0.10.1): the same unescaped Airtable
+        # interpolation bug, two phrasings, two files. Title equality (#18)
+        # cannot bind these; the shared rare tokens + common injection
+        # class must.
+        error = _f(
+            file="src/airtable-video-processor.ts", line=80, severity="error",
+            confidence=0.9,
+            title="Airtable formula injection via unescaped vimeo_code in filterByFormula",
+            body="filterByFormula({vimeo_code}) lets a crafted code break out of the quote.",
+        )
+        warning = _f(
+            file="src/get-video-feedbacks.ts", line=72, severity="warning",
+            confidence=0.8,
+            title="Formula interpolation of vimeo_code allows filter manipulation",
+            body="vimeo_code is interpolated into filterByFormula without escaping.",
+        )
+        result = apply_severity_consistency([error, warning])
+        assert result[0].severity == "error"
+        assert result[1].severity == "error"
+
+    def test_shared_token_different_problem_classes_never_merges(self):
+        inject = _f(
+            file="src/deploy.ts", line=10, severity="error", confidence=0.9,
+            title="Command injection building the deploy_script shell command",
+            body="child_process.exec concatenates deploy_script with user input.",
+        )
+        ratelimit = _f(
+            file="src/hooks.ts", line=20, severity="warning", confidence=0.8,
+            title="Missing rate limit on the deploy_script webhook",
+            body="deploy_script triggers fire without throttling.",
+        )
+        result = apply_severity_consistency([inject, ratelimit])
+        assert result[0].severity == "error"
+        assert result[1].severity == "warning"
+
+    def test_shared_generic_token_never_merges(self):
+        # `handler` is on the code-token stopword list: a ubiquitous name
+        # cannot bind findings even when the guard would otherwise pass.
+        f1 = _f(
+            file="src/upload.ts", line=5, severity="error", confidence=0.9,
+            title="Missing rate limit on upload route",
+            body="The `handler` accepts unlimited uploads.",
+        )
+        f2 = _f(
+            file="src/export.ts", line=5, severity="warning", confidence=0.8,
+            title="Missing rate limit on export route",
+            body="The `handler` loops over every record.",
+        )
+        result = apply_severity_consistency([f1, f2])
+        assert result[0].severity == "error"
+        assert result[1].severity == "warning"
+
+    def test_token_in_three_or_more_findings_is_not_rare(self):
+        findings = [
+            _f(
+                file=f"f{i}.ts", line=1, severity=sev, confidence=0.8,
+                title=f"Formula injection via vimeo_code in filter {i}",
+                body="vimeo_code interpolated raw.",
+            )
+            for i, sev in enumerate(["error", "warning", "outofscope"])
+        ]
+        result = apply_severity_consistency(findings)
+        assert [f.severity for f in result] == ["error", "warning", "outofscope"]
+
+    def test_token_in_three_findings_still_merges_via_title_rule(self):
+        shared = "Formula injection via vimeo_code in filterByFormula"
+        err = _f(file="f1.ts", line=1, severity="error", confidence=0.9,
+                 title=shared, body="raw.")
+        warn = _f(file="f2.ts", line=1, severity="warning", confidence=0.8,
+                  title=shared, body="raw.")
+        third = _f(
+            file="f3.ts", line=1, severity="outofscope", confidence=0.7,
+            title="vimeo_code reused for cache keys",
+            body="unrelated rate limit note.",
+        )
+        result = apply_severity_consistency([err, warn, third])
+        assert result[0].severity == "error"
+        assert result[1].severity == "error"
+        assert result[2].severity == "outofscope"
+
+    def test_token_groups_are_transitive(self):
+        # A shares vimeo_code with B, B shares sort_field with C, A and C
+        # share nothing directly: the component still groups all three.
+        a = _f(
+            file="f1.ts", line=1, severity="error", confidence=0.9,
+            title="Formula injection via unescaped vimeo_code",
+            body="vimeo_code builds the filter string.",
+        )
+        b = _f(
+            file="f2.ts", line=1, severity="warning", confidence=0.8,
+            title="Formula injection via unescaped vimeo_code and sort_field",
+            body="vimeo_code and sort_field are concatenated.",
+        )
+        c = _f(
+            file="f3.ts", line=1, severity="outofscope", confidence=0.7,
+            title="Formula injection through sort_field interpolation",
+            body="sort_field interpolated raw.",
+        )
+        result = apply_severity_consistency([a, b, c])
+        assert all(f.severity == "error" for f in result)
+
+    def test_same_file_sharing_rare_token_merges_without_class_keyword(self):
+        f1 = _f(
+            file="src/checkout.ts", line=10, severity="error", confidence=0.9,
+            title="checkout_session_id persists after the tenant is deleted",
+            body="stale row lingers.",
+        )
+        f2 = _f(
+            file="src/checkout.ts", line=40, severity="warning", confidence=0.8,
+            title="checkout_session_id may exceed the schema limit",
+            body="no guard before insert.",
+        )
+        result = apply_severity_consistency([f1, f2])
+        assert result[0].severity == "error"
+        assert result[1].severity == "error"
+
+    def test_shared_rare_token_alone_without_same_file_or_class_never_merges(self):
+        f1 = _f(
+            file="src/a.ts", line=10, severity="error", confidence=0.9,
+            title="checkout_session_id persists after the tenant is deleted",
+            body="stale row.",
+        )
+        f2 = _f(
+            file="src/b.ts", line=40, severity="warning", confidence=0.8,
+            title="checkout_session_id may exceed the schema limit",
+            body="no guard.",
+        )
+        result = apply_severity_consistency([f1, f2])
+        assert result[0].severity == "error"
+        assert result[1].severity == "warning"
+
+    def test_rewritten_via_token_keeps_identity_and_logs_binding_tokens(self, caplog):
+        from prxref.quality import logger as quality_logger
+
+        error = _f(
+            file="src/a.ts", line=80, severity="error", confidence=0.9,
+            title="Airtable formula injection via unescaped vimeo_code",
+            body="filterByFormula({vimeo_code}).",
+        )
+        warning = _f(
+            file="src/b.ts", line=72, severity="warning", confidence=0.8,
+            title="Formula interpolation of vimeo_code allows filter manipulation",
+            body="vimeo_code interpolated.",
+        )
+        with caplog.at_level(logging.INFO, logger=quality_logger.name):
+            result = apply_severity_consistency([error, warning])
+        assert result[1].severity == "error"
+        assert (result[1].file, result[1].line, result[1].body) == ("src/b.ts", 72, "vimeo_code interpolated.")
+        assert result[1].confidence == 0.8
+        lines = [r for r in caplog.records if r.name == quality_logger.name]
+        assert len(lines) == 1
+        assert "1 finding(s)" in lines[0].getMessage()
+        assert "vimeo_code" in lines[0].getMessage()
+
+    def test_no_token_rewrites_logs_nothing(self, caplog):
+        from prxref.quality import logger as quality_logger
+
+        f1 = _f(file="src/a.ts", line=1, severity="error", confidence=0.9,
+                title="Command injection in deploy_script", body="")
+        f2 = _f(file="src/b.ts", line=2, severity="warning", confidence=0.8,
+                title="Missing rate limit on deploy_script webhook", body="")
+        with caplog.at_level(logging.INFO, logger=quality_logger.name):
+            apply_severity_consistency([f1, f2])
+        assert not [r for r in caplog.records if r.name == quality_logger.name]
 
 
 class TestQualityGate:


### PR DESCRIPTION
Fixes #30. Live shape: unescaped Airtable formula interpolation was **error** in airtable-video-processor.ts but **warning** in get-video-feedbacks.ts — differently-phrased titles, so #18's normalized-title equality couldn't bind them.

## What

`apply_severity_consistency` gains a second edge type: findings sharing a **rare code token** (backticked pieces, snake/camel identifiers ≥6 chars, dotted paths; generic stopwords excluded; *rare* = present in ≤2 findings' claims) merge — but only with an over-merging guard: same file **or** both titles in a common problem-class family (injection incl. `interpolat|escap|sanitiz|manipulat`, secret, auth, race, leak, truncation, null, duplicate, timeout, ratelimit, validation). Union-find over both edge types, transitive, component → max severity. The #18 title-equality rule is unchanged and strictly stronger.

## Verification

11 new tests (live shape, transitivity, rarity, guards, silence-when-clean, one orchestrator end-to-end); #18's tests untouched and green. 1076 passed, ruff clean. No new config key — rarity is a documented constant.