### PR TITLE
fix: the partial banner names the failed chunk's files, and malformed locations are dropped (fixes #31 #32)

### DIFF
--- a/src/prxref/orchestrator.py
+++ b/src/prxref/orchestrator.py
@@ -14,7 +14,9 @@ Stage order (v1 — no Jira, no graph, no learnings, no investigator):
    reason otherwise; dict findings are coerced to ``triage.Finding``. A
    legacy dict-shaped stub (``{"findings": ..., "error": ...}``) is still
    accepted for test doubles.
-4. Quality passes in order: ``apply_line_align`` → thread dedup
+4. Quality passes in order: location validation (a ``file`` naming no
+   path of the parsed diff is dropped, not rendered) →
+   ``apply_line_align`` → thread dedup
    (existing threads fetched best-effort; failure means no threads) →
    severity consistency (findings sharing a normalized title are raised
    to the group's max severity) →
@@ -24,9 +26,11 @@ Stage order (v1 — no Jira, no graph, no learnings, no investigator):
 5. Verdict: ``"Error"`` when no chunk was reviewed successfully;
    ``"Request-Changes"`` iff any active error-severity finding survives;
    else ``"Approved"``. A partial failure keeps the verdict but the summary
-   declares reduced coverage AND names the distinct reasons (deduplicated,
-   capped, redacted, inside the same blockquote) — a partial review reads as a
-   successful one, so a reason left only in the logs reaches nobody.
+   declares reduced coverage AND itemizes each failed chunk with the files
+   it took unreviewed plus its reason (capped, redacted, inside the same
+   blockquote) — a partial review reads as a successful one, so a failure
+   left only in the logs reaches nobody, and a file list left out of it
+   leaves the operator guessing which files went unreviewed.
 6. Post: summary rendered from ``reviewer.load_prompt("summary")`` with
    placeholders ``{verdict} {title} {file_count} {error_count}
    {warning_count} {outofscope_count} {findings} {attribution}`` filled, plus
@@ -63,6 +67,7 @@ from .llm import LLMClient
 from .quality import (
     active,
     apply_line_align,
+    apply_location_validation,
     apply_quality_gate,
     apply_severity_consistency,
     apply_thread_dedup,
@@ -90,10 +95,10 @@ POST_MODES = frozenset({"summary+inline", "summary", "inline"})
 POST_SUMMARY_MODES = frozenset({"summary+inline", "summary"})
 POST_INLINE_MODES = frozenset({"summary+inline", "inline"})
 
-# How many DISTINCT chunk-failure reasons the partial-review banner names before
-# it starts counting the rest. Three is enough to show a mixed failure (say, a
-# starved budget plus a timeout) without letting a pathological run bury the
-# findings under its own diagnostics.
+# How many failed chunks the partial-review banner itemizes — each with its
+# file list and redacted reason — before it starts counting the rest. Three is
+# enough to show a mixed failure (say, a starved budget plus a timeout) without
+# letting a pathological run bury the findings under its own diagnostics.
 MAX_REPORTED_REASONS = 3
 
 _SEVERITY_MARKERS = {"error": "🟥", "warning": "🟧", "outofscope": "🟦"}
@@ -376,6 +381,15 @@ def orchestrate_review(
 
     findings = [f for r in results if not r["error"] for f in r["findings"]]
 
+    # Futures were submitted in chunk order, so results[i] is chunk[i]'s
+    # outcome: the zip is what pairs each failed review with the files it
+    # took down, which the partial banner now names (issue #31).
+    failed_chunks = [
+        (r["error"], [f.path for f in chunk])
+        for chunk, r in zip(chunks, results, strict=True)
+        if r["error"]
+    ]
+
     if post and post_mode in POST_INLINE_MODES:
         _prune_stale_inline_comments(forge, ref)
 
@@ -385,6 +399,7 @@ def orchestrate_review(
         logger.warning("list_threads failed (best-effort): %s", e)
         threads = []
 
+    findings = apply_location_validation(findings, [f.path for f in files])
     findings = apply_line_align(findings, added_lines_by_file(files), files=files)
     findings = apply_thread_dedup(findings, threads)
     consistent = apply_severity_consistency(findings)
@@ -431,10 +446,9 @@ def orchestrate_review(
             pr, files, verdict, findings_active, model,
             input_tokens, output_tokens, elapsed_ms,
             chunks_reviewed=chunks_reviewed, chunks_failed=chunks_failed,
-            # Every failed chunk already carries its reason here; withholding it
-            # left the one person able to act on "raise PRXREF_LLM_MAX_TOKENS"
-            # reading a banner that said only "findings may be incomplete".
-            failure_reasons=[r["error"] for r in results if r["error"]],
+            # Each failed chunk's reason AND file list reach the banner:
+            # "findings may be incomplete" without which-files acts on nothing.
+            failed_chunks=failed_chunks,
             include_verdict=post_verdict,
         )
         try:
@@ -480,7 +494,7 @@ def orchestrate_review(
             pr, files, verdict, findings_active, model,
             input_tokens, output_tokens, elapsed_ms,
             chunks_reviewed=chunks_reviewed, chunks_failed=chunks_failed,
-            failure_reasons=[r["error"] for r in results if r["error"]],
+            failed_chunks=failed_chunks,
             include_verdict=post_verdict,
             inline_accounting=_inline_accounting(
                 len(findings_active), inline_attempted, inline_posted,
@@ -750,7 +764,7 @@ def _render_summary(
     *,
     chunks_reviewed: int = 0,
     chunks_failed: int = 0,
-    failure_reasons: Sequence[str] = (),
+    failed_chunks: Sequence[tuple[str, Sequence[str]]] = (),
     include_verdict: bool = True,
     inline_accounting: str | None = None,
 ) -> str:
@@ -804,40 +818,62 @@ def _render_summary(
         # because a partial review looks like a successful one and nobody goes
         # looking. The total-failure notice has always posted its reason
         # verbatim; staying silent here was the inconsistency, not the safety.
-        reason_lines = _failure_reason_lines(failure_reasons)
+        reason_lines = _failure_reason_lines(failed_chunks)
         if reason_lines:
             rendered += "\n>\n" + "\n".join(f"> {line}" for line in reason_lines)
     return rendered
 
 
-def _failure_reason_lines(reasons: Sequence[str]) -> list[str]:
-    """Render distinct chunk-failure reasons as blockquote-ready lines.
+def _chunk_files_label(files: Sequence[str]) -> str:
+    """``chunk of 3 files (a.py, b.py, c.py)``, first three then a count."""
+    listing = ", ".join(files[:3])
+    if len(files) > 3:
+        listing = f"{listing}, +{len(files) - 3} more"
+    plural = "s" if len(files) != 1 else ""
+    return f"chunk of {len(files)} file{plural} ({listing})"
 
-    Redacted first (:func:`redact_for_post`), because this text is posted onto
-    a pull request. Redaction runs BEFORE the dedup so that two reasons
-    differing only in a stripped detail collapse into the one fact they are.
 
-    Deduplicated, because seven chunks starved by the same budget is one fact
-    and not seven; capped at :data:`MAX_REPORTED_REASONS`, because a
-    pathological run must not flood the comment. The overflow is counted out
-    loud rather than dropped — a silent truncation here would repeat the very
-    failure this banner exists to fix.
+def _failure_reason_lines(
+    failed_chunks: Sequence[tuple[str, Sequence[str]]],
+) -> list[str]:
+    """Render each failed chunk as a blockquote-ready line naming its files.
 
-    Returns one entry per RENDERED LINE, not one per reason. The caller
+    Each entry is one failed chunk: ``(reason, files)``. The reason is
+    redacted first (:func:`redact_for_post`), because this text is posted
+    onto a pull request; the file list is not, because paths are not
+    secrets — and naming the files is the banner's whole point (issue
+    #31): "7 of 8 chunks were reviewed; 1 failed" told the operator nothing
+    about which files went unreviewed.
+
+    Identical chunk-and-reason pairs collapse to one line, and the list is
+    capped at :data:`MAX_REPORTED_REASONS` chunks, because a pathological
+    run must not flood the comment. The overflow is counted out loud rather
+    than dropped — a silent truncation here would repeat the very failure
+    this banner exists to fix.
+
+    Returns one entry per RENDERED LINE, not one per chunk. The caller
     prefixes ``"> "`` per entry, so a reason containing a newline used to put
     every line after the first outside the blockquote and mangle the rest of
     the comment; continuation lines are indented under their bullet instead.
     """
-    distinct = sorted({redact_for_post(reason) for reason in reasons if reason})
+    distinct: list[tuple[tuple[str, ...], str]] = []
+    seen: set[tuple[tuple[str, ...], str]] = set()
+    for reason, files in failed_chunks:
+        if not reason:
+            continue
+        key = (tuple(files), redact_for_post(reason))
+        if key not in seen:
+            seen.add(key)
+            distinct.append(key)
     lines: list[str] = []
-    for reason in distinct[:MAX_REPORTED_REASONS]:
+    for files, reason in distinct[:MAX_REPORTED_REASONS]:
         first, *rest = reason.splitlines() or [""]
-        lines.append(f"- {first}")
+        lines.append(f"- {_chunk_files_label(files)}: {first}")
         lines.extend(f"  {line}" for line in rest)
     hidden = max(0, len(distinct) - MAX_REPORTED_REASONS)
     if hidden:
         plural = "s" if hidden > 1 else ""
-        lines.append(f"- …and {hidden} more distinct reason{plural} (see logs)")
+        lines.append(f"- …and {hidden} more failed chunk{plural} (see logs)")
     return lines
 
 

--- a/src/prxref/quality.py
+++ b/src/prxref/quality.py
@@ -1,7 +1,11 @@
 """Deterministic quality passes over worker findings.
 
-Four passes run before posting:
-1. ``apply_line_align``: snap each finding's cited line to the nearest
+Five passes run before posting:
+1. ``apply_location_validation``: drop findings whose ``file`` names no
+   path of the parsed diff — an empty, non-path, or invented location is
+   retained with ``drop_reason`` for the audit instead of rendering a
+   bullet anchored to nothing.
+2. ``apply_line_align``: snap each finding's cited line to the nearest
    actual ``+`` line in that file's diff (within tolerance, else line=0),
    then corroborate exact ``+``-line members against the file's hunks by
    content, so an anchor that is a valid added line of the WRONG hunk
@@ -10,13 +14,13 @@ Four passes run before posting:
    an anchor survives only when it ties the file's best evidence match
    or sits within tolerance of it, and a blank or pure-punctuation
    anchor never survives while any token-bearing added line exists.
-2. ``apply_thread_dedup``: drop findings that duplicate an already-open
+3. ``apply_thread_dedup``: drop findings that duplicate an already-open
    or existing thread on the PR (path + line-window + shared distinctive tokens).
-3. ``apply_severity_consistency``: findings sharing one normalized title —
+4. ``apply_severity_consistency``: findings sharing one normalized title —
    within a file or across sibling files — are all raised to the group's
    maximum severity, so per-chunk workers cannot disagree about how
    serious the same pattern is.
-4. ``apply_quality_gate``: drop findings below the confidence floor, cap
+5. ``apply_quality_gate``: drop findings below the confidence floor, cap
    errors per review, and enforce the {error, warning, outofscope} severity
    vocabulary.
 
@@ -50,6 +54,32 @@ DEFAULT_LINE_TOLERANCE: int = 5
 def active(findings: Sequence[Finding]) -> list[Finding]:
     """Return only the findings that survived every quality pass."""
     return [f for f in findings if f.drop_reason is None]
+
+
+def apply_location_validation(
+    findings: Sequence[Finding],
+    diff_paths: Sequence[str],
+) -> list[Finding]:
+    """Drop findings whose ``file`` does not name a path of the diff.
+
+    A worker that answers ``file: "package."`` — or invents a path the
+    diff never touches — used to survive every pass and render as a
+    summary bullet like ``- 🟧 `package.:—```. A finding is reviewable
+    only at a location the diff actually contains, so the accepted set is
+    exactly the diff's own paths: an empty ``file``, a non-path shape,
+    and a plausible-but-absent path all fail the membership check and are
+    retained with ``drop_reason="malformed location: '<file>'"`` for the
+    dropped-findings audit. A file that IS in the diff is never dropped,
+    and findings already carrying a ``drop_reason`` keep it.
+    """
+    known = set(diff_paths)
+    result: list[Finding] = []
+    for f in findings:
+        if f.drop_reason is not None or f.file in known:
+            result.append(f)
+            continue
+        result.append(replace(f, drop_reason=f"malformed location: {f.file!r}"))
+    return result
 
 
 def snap_line(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -731,6 +731,25 @@ _GOOD_CONTENT = json.dumps({
 })
 
 
+def _good_content(path: str) -> str:
+    """A clean finding citing ``path`` — a finding naming no path of the
+    diff under review is dropped by location validation (issue #32), so
+    each scenario cites a file its own diff touches."""
+    return json.dumps({
+        "findings": [
+            {
+                "file": path,
+                "line": 4,
+                "severity": "error",
+                "confidence": 0.95,
+                "title": "Uncaught token decode exception",
+                "body": "decode(token) can raise JWTError if malformed.",
+            }
+        ],
+        "escalations": [],
+    })
+
+
 class _CLIHarness:
     """Runs the real CLI review path against a mock LLM, keeping the forge."""
 
@@ -877,7 +896,7 @@ class TestPartialFailureIsExplainedOnThePR:
         def route(payload):
             state["n"] += 1
             if state["n"] == 1:
-                return 200, _completion(_GOOD_CONTENT, "stop")
+                return 200, _completion(_good_content("src/one.py"), "stop")
             return 200, _completion(_TRUNCATED_CONTENT, second_finish_reason)
 
         server = MockOpenAIServer(routes={"fast": route})
@@ -912,7 +931,8 @@ class TestPartialFailureIsExplainedOnThePR:
         summary = forge.summaries[0]
         assert "⚠️ Partial review: 1 of 2 chunks were reviewed" in summary
         assert (
-            "> - response truncated at max_tokens=256 (finish_reason=length); "
+            "> - chunk of 1 file (src/two.py): "
+            "response truncated at max_tokens=256 (finish_reason=length); "
             "raise PRXREF_LLM_MAX_TOKENS" in summary
         )
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1144,7 +1144,7 @@ class TestPartialBannerNamesTheReasons:
         """Subordinate to the findings, not a second block competing with them."""
         forge, _res = self._with({"a/one.py": TRUNCATED_REASON})
         tail = self._banner(forge)
-        assert f"> - {TRUNCATED_REASON}" in tail
+        assert f"> - chunk of 1 file (a/one.py): {TRUNCATED_REASON}" in tail
         # Line 0 is the rest of the "Partial review:" sentence itself; every
         # line after it must still carry the blockquote marker, or the reasons
         # have escaped into a block of their own.
@@ -1160,15 +1160,24 @@ class TestPartialBannerNamesTheReasons:
             "Findings may be incomplete." in forge.summaries[0]
         )
 
-    def test_identical_reasons_are_reported_once(self):
-        """Three chunks starved by the same budget is one fact, not three."""
+    def test_identical_reasons_still_name_each_failed_chunks_files(self):
+        """The reason is one fact; the file lists are not (issue #31).
+
+        Three chunks starved by the same budget used to collapse into one
+        reason line, leaving the operator to guess which files went
+        unreviewed. Each failed chunk now names its own files, so the same
+        reason appears once per chunk, each line carrying a different list.
+        """
         forge, res = self._with({
             "a/one.py": TRUNCATED_REASON,
             "b/two.py": TRUNCATED_REASON,
             "c/three.py": TRUNCATED_REASON,
         })
         assert res["chunks_failed"] == 3
-        assert forge.summaries[0].count(TRUNCATED_REASON) == 1
+        tail = self._banner(forge)
+        for path in ("a/one.py", "b/two.py", "c/three.py"):
+            assert path in tail
+        assert tail.count("\n> - ") == 3
 
     def test_distinct_reasons_are_all_reported(self):
         forge, _res = self._with({
@@ -1212,7 +1221,7 @@ class TestPartialBannerNamesTheReasons:
         )
         assert res["chunks_failed"] == 4
         tail = self._banner(forge)
-        assert "…and 1 more distinct reason (see logs)" in tail
+        assert "…and 1 more failed chunk (see logs)" in tail
         assert tail.count("\n> - ") == orchestrator.MAX_REPORTED_REASONS + 1
 
     def test_exactly_the_cap_reports_every_reason_and_no_overflow_line(self):
@@ -1416,7 +1425,10 @@ class TestPostedFailureReasonsAreSanitised:
     def test_a_clean_reason_is_posted_unchanged(self, monkeypatch):
         """Control: redaction must not fire on a reason carrying no secret."""
         forge, _res = self._partial(monkeypatch, "RuntimeError: connection reset")
-        assert "- RuntimeError: connection reset" in forge.summaries[0]
+        assert (
+            "- chunk of 1 file (a/one.py): RuntimeError: connection reset"
+            in forge.summaries[0]
+        )
         assert "[redacted]" not in forge.summaries[0]
 
 
@@ -1523,6 +1535,190 @@ class TestMultiLineReasonsStayInTheBlockquote:
     def test_the_continuation_text_is_still_reported(self, monkeypatch):
         forge, _res = self._run(monkeypatch, self.MULTILINE)
         assert "second line of the reason" in forge.summaries[0]
+
+
+class TestChunkFilesLabel:
+    """The per-chunk file list rendered into the banner's reason line."""
+
+    def test_a_single_file_chunk_says_file(self):
+        assert orchestrator._chunk_files_label(("a/one.py",)) == (
+            "chunk of 1 file (a/one.py)"
+        )
+
+    def test_up_to_three_files_are_listed_in_full(self):
+        assert orchestrator._chunk_files_label(("a.py", "b.py", "c.py")) == (
+            "chunk of 3 files (a.py, b.py, c.py)"
+        )
+
+    def test_beyond_three_the_rest_are_counted(self):
+        assert orchestrator._chunk_files_label(("a.py", "b.py", "c.py", "d.py", "e.py")) == (
+            "chunk of 5 files (a.py, b.py, c.py, +2 more)"
+        )
+
+
+class TestFailureReasonLinesCarryTheChunk:
+    """Unit coverage for the per-chunk shape of the banner's reason lines."""
+
+    def test_the_reason_is_redacted_but_the_files_are_not(self):
+        lines = orchestrator._failure_reason_lines([(LEAKY_REASON, ["a/one.py"])])
+        assert len(lines) == 1
+        assert lines[0].startswith("- chunk of 1 file (a/one.py): ")
+        assert LEAKY_SECRET not in lines[0]
+        assert "ConnectionError" in lines[0]
+
+    def test_multiline_reasons_keep_their_continuation_indented(self):
+        lines = orchestrator._failure_reason_lines([
+            ("boom\nsecond line", ["a/one.py"]),
+        ])
+        assert lines == [
+            "- chunk of 1 file (a/one.py): boom",
+            "  second line",
+        ]
+
+    def test_the_cap_counts_chunk_lines_and_the_overflow_counts_chunks(self):
+        failed = [(f"reason {n}", [f"{n}.py"]) for n in ("a", "b", "c", "d")]
+        lines = orchestrator._failure_reason_lines(failed)
+        bullets = [line for line in lines if line.startswith("- ")]
+        assert len(bullets) == orchestrator.MAX_REPORTED_REASONS + 1
+        assert bullets[-1] == "- …and 1 more failed chunk (see logs)"
+
+    def test_identical_chunk_and_reason_pairs_collapse(self):
+        pair = ("same reason", ["a/one.py"])
+        assert orchestrator._failure_reason_lines([pair, pair]) == [
+            "- chunk of 1 file (a/one.py): same reason",
+        ]
+
+    def test_empty_reasons_are_skipped(self):
+        assert orchestrator._failure_reason_lines([("", ["a/one.py"])]) == []
+
+
+class TestPartialBannerNamesTheFailedChunksFiles:
+    """Issue #31: "7 of 8 chunks were reviewed; 1 failed" never said WHICH,
+    so the operator could not tell which files went unreviewed. The
+    orchestrator knows each chunk's file list at failure time; the banner
+    now carries it on the chunk's reason line."""
+
+    def _run(self, monkeypatch, errors_by_path, *, diff, **kwargs):
+        monkeypatch.setattr(
+            orchestrator.reviewer, "review_chunk",
+            _review_chunk_failing(errors_by_path),
+        )
+        forge = FakeForge(diff=diff)
+        res = orchestrate_review(forge, REF, FakeLLM("{}"), post=True, **kwargs)
+        return forge, res
+
+    def _banner(self, forge):
+        return forge.summaries[0].split("> ⚠️ Partial review:")[1]
+
+    def test_the_banner_line_carries_the_failed_chunks_files(self, monkeypatch):
+        forge, _res = self._run(
+            monkeypatch,
+            {"a/one.py": "LLMError: timeout"},
+            diff=FOUR_FILE_DIFF, max_chunks=4, token_budget=1000,
+        )
+        assert (
+            "> - chunk of 1 file (a/one.py): LLMError: timeout"
+            in self._banner(forge)
+        )
+
+    def test_a_multi_file_chunk_lists_three_then_counts_the_rest(self, monkeypatch):
+        five = "".join(
+            _added_file_diff(path, 3)
+            for path in ("a/1.py", "b/2.py", "c/3.py", "d/4.py", "e/5.py")
+        )
+        forge, res = self._run(
+            monkeypatch,
+            {"a/1.py": "LLMError: timeout"},
+            diff=five, max_chunks=5, token_budget=100_000, max_files_per_chunk=4,
+        )
+        assert res["chunks_failed"] == 1
+        assert res["chunks_reviewed"] == 1
+        assert (
+            "> - chunk of 4 files (a/1.py, b/2.py, c/3.py, +1 more): "
+            "LLMError: timeout" in self._banner(forge)
+        )
+
+    def test_the_unreviewed_files_are_not_redacted(self, monkeypatch):
+        """Paths are not secrets: the file list renders verbatim even while
+        the reason beside it is redacted."""
+        forge, _res = self._run(
+            monkeypatch,
+            {"a/one.py": LEAKY_REASON},
+            diff=FOUR_FILE_DIFF, max_chunks=4, token_budget=1000,
+        )
+        body = forge.summaries[0]
+        assert "a/one.py" in body
+        assert LEAKY_SECRET not in body
+        assert LEAKY_HOST not in body
+
+
+class TestMalformedLocationsAreDropped:
+    """Issue #32: a worker answering ``file: "package."`` used to render as
+    ``- 🟧 `package.:—```. A finding whose file names no path of the diff is
+    dropped into the audit record with a reason, and the summary only shows
+    findings anchored to files the diff actually touches."""
+
+    PAYLOAD = [
+        {"file": "package.", "line": 0, "severity": "warning",
+         "confidence": 0.9, "title": "Bad location", "body": "data"},
+        {"file": "src/app.py", "line": 3, "severity": "warning",
+         "confidence": 0.9, "title": "Good location", "body": "data"},
+    ]
+
+    def _run(self):
+        forge = FakeForge(diff=_added_file_diff("src/app.py", 20))
+        res = orchestrate_review(
+            forge, REF,
+            FakeLLM(findings_by_path={"src/app.py": self.PAYLOAD}),
+        )
+        return forge, res
+
+    def test_a_file_outside_the_diff_is_dropped_with_a_reason(self):
+        _forge, res = self._run()
+        assert [f.file for f in res["findings_active"]] == ["src/app.py"]
+        assert len(res["findings_dropped"]) == 1
+        dropped = res["findings_dropped"][0]
+        assert dropped.file == "package."
+        assert dropped.drop_reason == "malformed location: 'package.'"
+
+    def test_the_malformed_bullet_never_reaches_the_summary(self):
+        forge, _res = self._run()
+        assert "package." not in forge.summaries[0]
+        assert "Good location" in forge.summaries[0]
+
+    def test_the_drop_reaches_the_dropped_findings_audit_section(self, monkeypatch):
+        """End to end into the formatter: the dropped section tallies the
+        reason and tables the finding the summary bullets omit. The formatter's
+        own default template carries the dropped section; the reviewer stub
+        this module installs only knows the orchestrator's template name."""
+        from prxref import formatter
+        from prxref.formatter import format_summary
+
+        monkeypatch.setattr(
+            formatter, "_load_summary_template",
+            lambda: formatter._DEFAULT_SUMMARY_TEMPLATE,
+        )
+        _forge, res = self._run()
+        rendered = format_summary(
+            res["verdict"], res["findings_active"], res["findings_dropped"],
+            chunk_count=res["chunk_count"], elapsed_ms=res["elapsed_ms"],
+            input_tokens=res["input_tokens"], output_tokens=res["output_tokens"],
+            model="test-model-1",
+        )
+        assert "- 1 × malformed location: 'package.'" in rendered
+        assert "Bad location" in rendered
+
+    def test_an_empty_file_field_is_dropped_too(self):
+        forge = FakeForge(diff=_added_file_diff("src/app.py", 20))
+        res = orchestrate_review(
+            forge, REF,
+            FakeLLM(findings_by_path={"src/app.py": [
+                {"file": "", "line": 3, "severity": "warning",
+                 "confidence": 0.9, "title": "No location", "body": "data"},
+            ]}),
+        )
+        assert res["findings_active"] == []
+        assert res["findings_dropped"][0].drop_reason == "malformed location: ''"
 
 
 class TestStaleInlinePrune:

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -6,6 +6,7 @@ from prxref.quality import (
     _resolve_max_errors,
     active,
     apply_line_align,
+    apply_location_validation,
     apply_quality_gate,
     apply_severity_consistency,
     apply_thread_dedup,
@@ -43,6 +44,46 @@ class TestSnapLine:
 
     def test_drops_to_file_level_when_no_added_lines(self):
         assert snap_line(10, set()) == 0
+
+
+class TestApplyLocationValidation:
+    """Issue #32: ``file: "package."`` rendered as ``- 🟧 `package.:—```.
+    A location that names no path of the diff is not a review; it drops."""
+
+    def test_a_file_in_the_diff_is_never_dropped(self):
+        finding = _f(file="src/app.py")
+        result = apply_location_validation([finding], ["src/app.py", "other.py"])
+        assert result[0] is finding
+        assert result[0].drop_reason is None
+
+    def test_an_empty_file_field_is_dropped(self):
+        result = apply_location_validation([_f(file="")], ["src/app.py"])
+        assert result[0].drop_reason == "malformed location: ''"
+
+    def test_a_non_path_shape_is_dropped(self):
+        result = apply_location_validation([_f(file="package.")], ["src/app.py"])
+        assert result[0].drop_reason == "malformed location: 'package.'"
+
+    def test_a_plausible_path_missing_from_the_diff_is_dropped(self):
+        result = apply_location_validation([_f(file="src/ghost.py")], ["src/app.py"])
+        assert result[0].drop_reason == "malformed location: 'src/ghost.py'"
+
+    def test_already_dropped_findings_keep_their_reason(self):
+        finding = _f(file="src/ghost.py", drop_reason="confidence 0.10 below floor 0.60")
+        result = apply_location_validation([finding], ["src/app.py"])
+        assert result[0].drop_reason == "confidence 0.10 below floor 0.60"
+
+    def test_the_input_is_not_mutated(self):
+        finding = _f(file="package.")
+        apply_location_validation([finding], ["src/app.py"])
+        assert finding.drop_reason is None
+
+    def test_survivors_and_drops_keep_their_order(self):
+        findings = [_f(file="src/app.py"), _f(file="package."), _f(file="src/app.py")]
+        result = apply_location_validation(findings, ["src/app.py"])
+        assert [f.drop_reason for f in result] == [
+            None, "malformed location: 'package.'", None,
+        ]
 
 
 class TestApplyLineAlign:


### PR DESCRIPTION
Fixes #31, fixes #32.

**#31:** the partial banner now names each failed chunk's files — `> - chunk of 4 files (a/1.py, b/2.py, c/3.py, +1 more): LLMError: timeout` — file paths verbatim, error text still redacted, cap semantics kept.

**#32:** new `apply_location_validation(findings, diff_paths)` pass before line-align: a `file` field that matches no path in the diff (empty, non-path shape, invented — one membership rule covers all three) drops the finding with `malformed location: 'package.'`, landing in the dropped-findings audit section instead of rendering a nonsense bullet like the live `- 🟧 `package.:—``.

## Verification

18 new tests, written failing-first (15 failed → green); 1087 passed, ruff clean. One deliberate behavior change: identical reasons across different chunks no longer dedup to one line — each failed chunk names its own files (that was the issue's point).