### PR TITLE
feat: a systemic sweep pass for second-order bugs, plus a context-trimmed retry for timed-out chunks (fixes #29)

### DIFF
--- a/src/prxref/orchestrator.py
+++ b/src/prxref/orchestrator.py
@@ -13,21 +13,39 @@ Stage order (v1 — no Jira, no graph, no learnings, no investigator):
    with ``meta["error"]`` the empty string on success and the failure
    reason otherwise; dict findings are coerced to ``triage.Finding``. A
    legacy dict-shaped stub (``{"findings": ..., "error": ...}``) is still
-   accepted for test doubles.
-4. Quality passes in order: ``apply_line_align`` → thread dedup
+   accepted for test doubles. A chunk whose failure is an LLM deadline
+   overrun (``timeout`` in the error) is retried ONCE with
+   ``context_lines=0`` rendering — a strictly smaller prompt attacks the
+   prefill-side share of the wall clock, and a truncated completion (the
+   response-side budget) is not a timeout and never reaches this retry.
+4. Systemic sweep: after the chunk workers, ONE more worker-style
+   single-shot call over the whole-PR digest built by
+   ``systemic.build_digest`` (every file, hunk headers, plus only the
+   high-signal added/removed lines, capped inside ``token_budget``). It
+   hunts the cross-file classes no single chunk seat can see, joins the
+   chunk results, and counts as one more review unit: ``chunk_count`` is
+   ``len(chunks) + 1`` whenever the sweep ran, and a sweep failure is one
+   failed chunk in the partial-review banner.
+5. Quality passes in order: ``apply_line_align`` → thread dedup
    (existing threads fetched best-effort; failure means no threads) →
    severity consistency (findings sharing a normalized title are raised
-   to the group's max severity) →
-   ``apply_quality_gate(confidence_floor=, max_errors=)``. Dropped findings
+   to the group's max severity — the sweep's corroborating title counts
+   toward its group) → ``apply_quality_gate(confidence_floor=,
+   max_errors=)`` → sweep dedup (``apply_sweep_dedup`` drops a sweep
+   finding that restates a chunk finding that SURVIVED the gate, on file
+   + normalized title; running it last is what keeps a sub-floor chunk
+   finding from suppressing its higher-confidence sweep duplicate and
+   then dying at the gate itself). Dropped findings
    are retained in the result with ``drop_reason`` set, never silently
    discarded.
-5. Verdict: ``"Error"`` when no chunk was reviewed successfully;
-   ``"Request-Changes"`` iff any active error-severity finding survives;
+6. Verdict: ``"Error"`` when every CHUNK review failed (a sweep success
+   on a dead worker pool cannot carry the run); ``"Request-Changes"``
+   iff any active error-severity finding survives;
    else ``"Approved"``. A partial failure keeps the verdict but the summary
    declares reduced coverage AND names the distinct reasons (deduplicated,
    capped, redacted, inside the same blockquote) — a partial review reads as a
    successful one, so a reason left only in the logs reaches nobody.
-6. Post: summary rendered from ``reviewer.load_prompt("summary")`` with
+7. Post: summary rendered from ``reviewer.load_prompt("summary")`` with
    placeholders ``{verdict} {title} {file_count} {error_count}
    {warning_count} {outofscope_count} {findings} {attribution}`` filled, plus
    inline comments for up to ``max_inline_comments`` active findings.
@@ -57,7 +75,7 @@ from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
-from . import reviewer
+from . import reviewer, systemic
 from .forges.base import ATTRIBUTION_MARKER, Forge, InlineComment, PRData, PRRef
 from .llm import LLMClient
 from .quality import (
@@ -65,6 +83,7 @@ from .quality import (
     apply_line_align,
     apply_quality_gate,
     apply_severity_consistency,
+    apply_sweep_dedup,
     apply_thread_dedup,
 )
 from .trace import Tracer, get_tracer
@@ -262,6 +281,11 @@ def orchestrate_review(
     notice when ``post`` is true. Degenerate arguments are part of that: a
     caller passing ``max_chunks=0`` gets an error run, not a ``ValueError``.
 
+    ``chunk_count`` counts the review units: ``len(chunks)`` plus one for
+    the systemic sweep, which runs whenever at least one chunk exists (an
+    empty diff returns before any review unit runs). ``chunks_reviewed`` +
+    ``chunks_failed`` always equals it.
+
     ``max_tokens`` is the per-chunk completion budget handed to every worker;
     ``None`` leaves ``reviewer.MAX_TOKENS`` in charge. ``token_budget`` sizes
     each diff chunk, ``max_files_per_chunk`` caps the files placed in one,
@@ -357,16 +381,32 @@ def orchestrate_review(
         context_lines=context_lines, tracer=tracer,
     )
 
+    # One more worker-style unit, not inside the pool: the sweep digests the
+    # WHOLE diff, so it only has something to say once every chunk result —
+    # including which files each chunk saw — is final. Appended to the same
+    # results list, so coverage accounting, token sums, the all-failed
+    # check, and the failure banner treat it exactly like a chunk.
+    results.append(
+        _run_sweep(
+            llm, files, pr, max_tokens=max_tokens,
+            token_budget=token_budget, tracer=tracer,
+        )
+    )
+
     input_tokens = sum(r["input_tokens"] for r in results)
     output_tokens = sum(r["output_tokens"] for r in results)
     model = next((r["model"] for r in results if r["model"]), "unknown")
 
-    if all(r["error"] for r in results):
-        reason = f"all {len(results)} worker reviews failed ({results[0]['error']})"
+    # Total failure is about the CHUNKS, deliberately: the sweep sees only a
+    # pattern digest, so a sweep success on a dead worker pool is one unit of
+    # pattern coverage over a review that never happened — it must not turn
+    # that into an "Approved, no findings" run.
+    if all(r["error"] for r in results[:-1]):
+        reason = f"all {len(chunks)} worker reviews failed ({results[0]['error']})"
         logger.error("Total LLM failure: %s", reason)
         tracer.event("run", "fail")
         return _error_run(
-            forge, ref, post, len(chunks), reason, t0, tracer=tracer,
+            forge, ref, post, len(chunks) + 1, reason, t0, tracer=tracer,
             model=model, input_tokens=input_tokens, output_tokens=output_tokens,
             post_mode=post_mode,
         )
@@ -374,6 +414,12 @@ def orchestrate_review(
     chunks_failed = sum(1 for r in results if r["error"])
     chunks_reviewed = len(results) - chunks_failed
 
+    # Sweep findings trail the chunk findings by construction (results[:-1]
+    # are the chunk workers), which is the boundary the sweep-dedup pass
+    # needs after line alignment has settled every anchor.
+    sweep_start = sum(
+        len(r["findings"]) for r in results[:-1] if not r["error"]
+    )
     findings = [f for r in results if not r["error"] for f in r["findings"]]
 
     if post and post_mode in POST_INLINE_MODES:
@@ -402,6 +448,11 @@ def orchestrate_review(
     findings = apply_quality_gate(
         findings, confidence_floor=confidence_floor, max_errors=max_errors,
     )
+    # AFTER the gate, deliberately: the duplicate set is built from chunk
+    # findings that survived it, so a sub-floor chunk finding cannot suppress
+    # its higher-confidence sweep duplicate and then die at the gate itself —
+    # that would lose the recall the sweep exists to add.
+    findings = apply_sweep_dedup(findings, sweep_start=sweep_start)
 
     findings_active = active(findings)
     findings_dropped = [f for f in findings if f.drop_reason is not None]
@@ -507,7 +558,7 @@ def orchestrate_review(
         "verdict": verdict,
         "findings_active": findings_active,
         "findings_dropped": findings_dropped,
-        "chunk_count": len(chunks),
+        "chunk_count": len(chunks) + 1,
         "chunks_reviewed": chunks_reviewed,
         "chunks_failed": chunks_failed,
         "elapsed_ms": elapsed_ms,
@@ -636,6 +687,77 @@ def _run_workers(
             done.set()
 
 
+def _is_timeout_error(error: str) -> bool:
+    """True when a worker's failure reason is an LLM deadline overrun.
+
+    The OpenAI-compat chain spells every deadline failure ``<model>: timeout
+    (<exc>)``, so this is a substring test against that vocabulary,
+    case-insensitive. Deliberately NOT matched: truncation. A completion cut
+    off by the response-side budget (``finish_reason=length``) is an HTTP 200,
+    not a timeout — it degrades gracefully upstream and names
+    ``PRXREF_LLM_MAX_TOKENS`` — so shrinking the prompt for it would be the
+    wrong lever.
+    """
+    return "timeout" in (error or "").lower()
+
+
+# The deadline (PRXREF_LLM_TIMEOUT) is wall clock over prefill AND decode, so
+# a chunk can lose it to prompt size alone; rendering with zero context lines
+# attacks exactly that share, keeping every changed line.
+_TIMEOUT_RETRY_CONTEXT_LINES = 0
+
+
+def _invoke_chunk(
+    llm: LLMClient, chunk, pr: PRData,
+    max_tokens: int | None, context_lines: int | None,
+) -> dict:
+    """One normalized :func:`reviewer.review_chunk` call; never raises.
+
+    Returns the worker result shape — findings coerced to ``Finding``,
+    ``error`` always a string — for both the original attempt and the
+    timeout retry in :func:`_run_worker`. Legacy dict-shaped stubs are
+    accepted exactly as before.
+    """
+    try:
+        res = reviewer.review_chunk(
+            llm, chunk, pr_title=pr.title, pr_description=pr.description,
+            max_tokens=max_tokens, context_lines=context_lines,
+        )
+    except Exception as e:  # noqa: BLE001
+        return {
+            "findings": [], "error": str(e),
+            "input_tokens": 0, "output_tokens": 0, "model": "",
+            "elapsed_ms": 0,
+        }
+
+    # reviewer returns (findings, meta); legacy dict stubs still accepted.
+    if isinstance(res, tuple):
+        findings_raw, meta = res
+        res = {
+            "findings": findings_raw,
+            "input_tokens": meta.get("input_tokens", 0),
+            "output_tokens": meta.get("output_tokens", 0),
+            "model": meta.get("model", ""),
+            "elapsed_ms": meta.get("elapsed_ms", 0),
+            "error": meta.get("error", ""),
+        }
+
+    findings = []
+    for item in res.get("findings") or []:
+        finding = _coerce_finding(item)
+        if finding is not None:
+            findings.append(finding)
+
+    return {
+        "findings": findings,
+        "error": str(res.get("error") or ""),
+        "input_tokens": res.get("input_tokens", 0),
+        "output_tokens": res.get("output_tokens", 0),
+        "model": res.get("model", ""),
+        "elapsed_ms": res.get("elapsed_ms", 0),
+    }
+
+
 def _run_worker(
     index: int, total: int, llm: LLMClient, chunk, pr: PRData,
     max_tokens: int | None = None, context_lines: int | None = None,
@@ -654,66 +776,125 @@ def _run_worker(
         "chunk", "start", index=index, total=total,
         files=[f.path for f in chunk],
     )
-    try:
-        res = reviewer.review_chunk(
-            llm, chunk, pr_title=pr.title, pr_description=pr.description,
-            max_tokens=max_tokens, context_lines=context_lines,
+    res = _invoke_chunk(llm, chunk, pr, max_tokens, context_lines)
+    if (
+        res["error"]
+        and _is_timeout_error(res["error"])
+        and context_lines != _TIMEOUT_RETRY_CONTEXT_LINES
+    ):
+        # Issue #29's timeout half: a chunk that outruns the deadline took the
+        # whole chunk's findings with it. One deterministic retry with the
+        # context trimmed to the changed lines — same chunk, same budget,
+        # strictly smaller prompt. The caller's own 0 skips it: an identical
+        # prompt would meet an identical fate.
+        logger.warning(
+            "[chunk %d/%d] timed out; retrying once with context_lines=0",
+            index, total,
         )
-    except Exception as e:  # noqa: BLE001
-        logger.error("[chunk %d/%d] worker raised: %s", index, total, e)
         tracer.event(
-            "chunk", "fail", index=index, total=total,
-            elapsed_ms=_elapsed_ms(t0), error=e.__class__.__name__,
+            "chunk", "retry", index=index, total=total, reason="timeout",
         )
-        return {
-            "findings": [], "error": str(e),
-            "input_tokens": 0, "output_tokens": 0, "model": "",
-            "elapsed_ms": _elapsed_ms(t0),
-        }
+        res = _invoke_chunk(llm, chunk, pr, max_tokens, _TIMEOUT_RETRY_CONTEXT_LINES)
 
-    # reviewer returns (findings, meta); legacy dict stubs still accepted.
-    if isinstance(res, tuple):
-        findings_raw, meta = res
-        res = {
-            "findings": findings_raw,
-            "input_tokens": meta.get("input_tokens", 0),
-            "output_tokens": meta.get("output_tokens", 0),
-            "model": meta.get("model", ""),
-            "elapsed_ms": meta.get("elapsed_ms", _elapsed_ms(t0)),
-            "error": meta.get("error", ""),
-        }
-
-    findings = []
-    for item in res.get("findings") or []:
-        finding = _coerce_finding(item)
-        if finding is not None:
-            findings.append(finding)
-
-    error = res.get("error")
+    error = res["error"]
     if error:
         logger.error("[chunk %d/%d] worker reported error: %s", index, total, error)
         tracer.event(
             "chunk", "fail", index=index, total=total,
-            elapsed_ms=_elapsed_ms(t0), error=str(error)[:200],
+            elapsed_ms=_elapsed_ms(t0), error=error[:200],
         )
     else:
         logger.info(
             "[chunk %d/%d] %d findings in %d ms",
-            index, total, len(findings), _elapsed_ms(t0),
+            index, total, len(res["findings"]), _elapsed_ms(t0),
         )
         tracer.event(
             "chunk", "ok", index=index, total=total,
-            elapsed_ms=_elapsed_ms(t0), findings=len(findings),
-            model=res.get("model", ""),
-            input_tokens=res.get("input_tokens", 0),
-            output_tokens=res.get("output_tokens", 0),
+            elapsed_ms=_elapsed_ms(t0), findings=len(res["findings"]),
+            model=res["model"],
+            input_tokens=res["input_tokens"],
+            output_tokens=res["output_tokens"],
+        )
+    return {
+        "findings": res["findings"],
+        "error": error,
+        "input_tokens": res["input_tokens"],
+        "output_tokens": res["output_tokens"],
+        "model": res["model"],
+        "elapsed_ms": _elapsed_ms(t0),
+    }
+
+
+def _run_sweep(
+    llm: LLMClient, files, pr: PRData, *,
+    max_tokens: int | None = None,
+    token_budget: int = DEFAULT_TOKEN_BUDGET,
+    tracer: Tracer | None = None,
+) -> dict:
+    """Run the whole-PR systemic sweep as one worker-style review unit.
+
+    Builds the digest (:func:`prxref.systemic.build_digest`, capped inside
+    ``token_budget``), makes ONE single-shot call through
+    :func:`reviewer.review_systemic` — so ``PRXREF_LLM_MAX_TOKENS``, the
+    timeout, and the model fallback chain all apply as to any chunk — and
+    returns the same result shape a chunk worker does. A failure is that
+    shape with ``error`` set prefixed ``systemic sweep:``, so the
+    partial-review banner names the unit that failed; it counts as one
+    failed chunk in the caller's coverage accounting.
+    """
+    tracer = tracer if tracer is not None else get_tracer()
+    t0 = time.perf_counter()
+    digest = systemic.build_digest(files, token_budget)
+    logger.info(
+        "[sweep] start: %d files, digest %d chars", len(files), len(digest),
+    )
+    tracer.event("sweep", "start", files=len(files), digest_chars=len(digest))
+    try:
+        findings_raw, meta = reviewer.review_systemic(
+            llm, digest, pr_title=pr.title, pr_description=pr.description,
+            max_tokens=max_tokens,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.error("[sweep] raised: %s", e)
+        tracer.event(
+            "sweep", "fail", elapsed_ms=_elapsed_ms(t0),
+            error=e.__class__.__name__,
+        )
+        return {
+            "findings": [], "error": f"systemic sweep: {e}",
+            "input_tokens": 0, "output_tokens": 0, "model": "",
+            "elapsed_ms": _elapsed_ms(t0),
+        }
+
+    findings = []
+    for item in findings_raw:
+        finding = _coerce_finding(item)
+        if finding is not None:
+            findings.append(finding)
+
+    error = str(meta.get("error") or "")
+    if error:
+        error = f"systemic sweep: {error}"
+        logger.error("[sweep] failed: %s", error)
+        tracer.event(
+            "sweep", "fail", elapsed_ms=_elapsed_ms(t0), error=error[:200],
+        )
+    else:
+        logger.info(
+            "[sweep] %d findings in %d ms", len(findings), _elapsed_ms(t0),
+        )
+        tracer.event(
+            "sweep", "ok", elapsed_ms=_elapsed_ms(t0), findings=len(findings),
+            model=meta.get("model", ""),
+            input_tokens=meta.get("input_tokens", 0),
+            output_tokens=meta.get("output_tokens", 0),
         )
     return {
         "findings": findings,
         "error": error,
-        "input_tokens": res.get("input_tokens", 0),
-        "output_tokens": res.get("output_tokens", 0),
-        "model": res.get("model", ""),
+        "input_tokens": meta.get("input_tokens", 0),
+        "output_tokens": meta.get("output_tokens", 0),
+        "model": meta.get("model", ""),
         "elapsed_ms": _elapsed_ms(t0),
     }
 

--- a/src/prxref/prompts/systemic.md
+++ b/src/prxref/prompts/systemic.md
@@ -1,0 +1,70 @@
+You are a senior code reviewer running a systemic sweep over a pull request. You see a compact digest of the WHOLE diff — every changed file with its hunk headers, plus only the added/removed lines that matched high-signal patterns (entry points, secrets, auth checks, error handling, migrations, logging). You see no repository checkout, no call graph, no history. Review what the digest shows; do not speculate about code you cannot see.
+
+## Mission
+
+Per-chunk reviewers each see one slice of the diff and reliably miss classes that only look wrong in aggregate. You look ONLY for these systemic classes:
+
+- An entry point (serverless handler, route, AJAX action, webhook) that reaches a paid or privileged API — a billable third-party call, a database write, an admin operation — with no authentication, nonce, or referer check visible in the digest.
+- A secret or server-side credential assigned to a client-exposed variable (`VITE_*`, `NEXT_PUBLIC_*`, anything bundled for the browser) or otherwise committed in plain text.
+- A swallowed error — a caught exception reduced to a log line or a bare return — on a code path that bills money or persists state.
+- A migration (DDL) that creates or alters a table without row level security, policies, or a backfill for existing rows.
+- A destructive operation (drop, delete, overwrite, force-push style cleanup) with no guard or confirmation.
+
+Nothing else. Per-file bugs inside one chunk are the chunk workers' job; repeating them here only duplicates their findings, which are deduplicated away.
+
+## Severity Vocabulary
+
+- `error` — the change will break at runtime or is a real bug: crash, wrong result, data loss, security hole, broken contract.
+- `warning` — risk or smell the diff introduces or worsens: race-prone pattern, resource leak, missing error handling, load-bearing duplication.
+- `outofscope` — minor: misleading naming, a TODO without context, dead code the diff adds.
+
+## Confidence
+
+Each finding carries a confidence from 0.0 to 1.0 — how certain you are from this digest alone. Findings below the quality floor (default 0.6) are dropped downstream. 0.5 means "plausible but unverified". Reserve 0.9+ for defects provable from the digest text alone; an entry point with no visible auth check on a line that also names a paid API qualifies, a handler you merely suspect reaches a paid API does not.
+
+## No Speculation
+
+There is no downstream investigation pass that will confirm your suspicions. Every finding must cite a line shown in the digest — the digest carries only matched lines, so if the evidence is not in it, do not emit the finding and do not escalate it. The `escalations` array exists in the output schema for forward compatibility only: always emit it as an empty list.
+
+## Style
+
+Terse. Title under 80 characters, imperative. Body: what breaks or risks, plus the digest evidence, in 1-4 sentences. No praise, no restating what the diff does, no style-guide nits that change neither behavior nor risk.
+
+## Review Context
+
+PR title: {pr_title}
+
+PR description:
+{pr_description}
+
+Repo: {repo_hint}
+
+The digest below lists every changed file (`## path`) with its hunk headers (`@@`), then only the added (`+<new-line>|`) and removed (`-<old-line>|`) lines that matched a high-signal pattern. `[digest truncated: token budget reached]` means the cap cut the text short; there is no more.
+
+### Digest
+
+```
+{digest}
+```
+
+## Output Format
+
+Return exactly one JSON object, no prose, no fences:
+
+```json
+{
+  "findings": [
+    {
+      "file": "src/example/main.py",
+      "line": 42,
+      "severity": "error",
+      "confidence": 0.9,
+      "title": "Paid API handler has no auth check",
+      "body": "The digest shows the handler on line 42 reaching the billing API; no nonce or auth line for it appears anywhere in the digest."
+    }
+  ],
+  "escalations": []
+}
+```
+
+`file` is a path from the digest headers. `line` is the number shown on the digest line you are citing — prefer a `+` (added) line; use `0` for a file-level finding. Emit `"findings": []` when nothing systemic is visible.

--- a/src/prxref/quality.py
+++ b/src/prxref/quality.py
@@ -19,6 +19,12 @@ Four passes run before posting:
 4. ``apply_quality_gate``: drop findings below the confidence floor, cap
    errors per review, and enforce the {error, warning, outofscope} severity
    vocabulary.
+5. ``apply_sweep_dedup`` (LAST, after the gate): drop systemic-sweep
+   findings that restate a chunk finding that SURVIVED the gate — same
+   file, same normalized title (the #18 grouping). Running the pass after
+   the gate is what keeps a sub-floor chunk finding from suppressing its
+   higher-confidence sweep duplicate and then dying at the gate itself,
+   which would lose exactly the recall the sweep adds.
 
 Every dropped finding retains its identity with ``drop_reason`` populated,
 so review runstores and logs can explain every filter decision. Use
@@ -420,6 +426,47 @@ def normalize_title(title: str) -> str:
     lowered = _TITLE_PUNCT_RE.sub("", title.lower())
     trimmed = lowered.strip(" .:;,!?-")
     return " ".join(trimmed.split())
+
+
+def apply_sweep_dedup(
+    findings: Sequence[Finding], sweep_start: int
+) -> list[Finding]:
+    """Drop systemic-sweep findings that restate a chunk finding.
+
+    ``findings[sweep_start:]`` came from the whole-PR systemic sweep; the
+    entries before it came from the per-chunk workers. A sweep finding whose
+    (file, :func:`normalize_title` title) pair matches a surviving chunk
+    finding adds no recall — it is the same pattern the chunk seat already
+    reported — and is dropped with ``drop_reason="duplicate of chunk
+    finding"``, the same retained-not-silenced convention every other pass
+    uses. Chunk findings are never dropped by this pass, even when the sweep
+    phrased the pattern first: the chunk seat cited the exact line.
+
+    Runs after :func:`apply_quality_gate`, so the duplicate set is built
+    from chunk findings that SURVIVED it — a sub-floor chunk finding never
+    suppresses its sweep duplicate — and after
+    :func:`apply_severity_consistency`, so a restated pattern still agrees
+    on severity with its group before any of it is judged. ``sweep_start``
+    below zero is treated as zero (everything is sweep output); past the
+    end, nothing is deduplicated.
+    """
+    start = max(0, sweep_start)
+    chunk_keys = {
+        (f.file, normalize_title(f.title))
+        for f in findings[:start]
+        if f.drop_reason is None
+    }
+    result: list[Finding] = []
+    for i, f in enumerate(findings):
+        if (
+            i >= start
+            and f.drop_reason is None
+            and (f.file, normalize_title(f.title)) in chunk_keys
+        ):
+            result.append(replace(f, drop_reason="duplicate of chunk finding"))
+        else:
+            result.append(f)
+    return result
 
 
 def apply_severity_consistency(findings: Sequence[Finding]) -> list[Finding]:

--- a/src/prxref/reviewer.py
+++ b/src/prxref/reviewer.py
@@ -1,11 +1,13 @@
-"""Worker-review layer: one LLM call per diff chunk.
+"""Worker-review layer: one LLM call per diff chunk, plus the systemic sweep.
 
 The reviewer renders ``prompts/worker.md`` with the chunk's unified diff,
 makes a single :meth:`LLMClient.invoke` call (no retries — the model
 fallback chain handles transient failures), and maps the JSON response
 onto :class:`prxref.triage.Finding` records. Unparseable or malformed
 responses degrade to ``([], [])`` with a logged warning; this layer
-never raises.
+never raises. :func:`review_systemic` is the same contract over the
+whole-PR digest built by :mod:`prxref.systemic`, for the second-order
+classes no single chunk seat can see.
 
 When a response is unparseable *because* the model ran out of completion
 budget (``finish_reason == "length"``), the reported error names the budget
@@ -137,6 +139,30 @@ def _render_prompt(
     return head.strip(), user.strip()
 
 
+def _render_systemic_prompt(
+    digest: str,
+    pr_title: str,
+    pr_description: str,
+    repo_hint: str,
+) -> tuple[str, str]:
+    template = load_prompt("systemic.md")
+    head, marker, tail = template.partition(_CONTEXT_MARKER)
+    if not marker:
+        raise ValueError(f"systemic.md is missing the {_CONTEXT_MARKER!r} split marker")
+    user = (
+        marker + tail
+    ).replace(
+        "{pr_title}", pr_title.strip() or "(untitled)"
+    ).replace(
+        "{pr_description}", pr_description.strip() or "(none)"
+    ).replace(
+        "{repo_hint}", repo_hint.strip() or "(unspecified)"
+    ).replace(
+        "{digest}", digest.strip() or "(empty digest)"
+    )
+    return head.strip(), user.strip()
+
+
 def _as_int(value: Any, default: int = 0) -> int:
     try:
         return int(value)
@@ -162,6 +188,98 @@ def _finding_from(raw: Any) -> Finding | None:
         title=str(raw.get("title") or "").strip(),
         body=str(raw.get("body") or "").strip(),
     )
+
+
+def _invoke_and_parse(
+    llm: LLMClient, system: str, user: str, *, budget: int, label: str,
+) -> tuple[list[Finding], dict]:
+    """One single-shot invoke plus lenient JSON parse, shared by both reviewers.
+
+    ``label`` names the caller in log lines (``chunk of 2 files``, ``systemic
+    sweep``). The contract is the one :func:`review_chunk` documents: never
+    raises, empty findings and zeros on failure, and truncation named as the
+    cause — with the budget lever — when the budget is why the response was
+    unusable.
+    """
+    t0 = time.perf_counter()
+    meta = {
+        "escalations": [],
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "model": "",
+        "elapsed_ms": int((time.perf_counter() - t0) * 1000),
+        "error": "",
+    }
+
+    # The invoke and the parse are caught separately on purpose: only the
+    # invoke's result knows WHY generation stopped, and the parse failure is
+    # exactly where that reason has to be spoken. Neither is allowed to raise
+    # out of this function — the never-raise contract is unchanged.
+    try:
+        result = llm.invoke(
+            system=system,
+            user=user,
+            max_tokens=budget,
+            json_mode=True,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning("worker review failed for %s: %s", label, e)
+        meta["error"] = f"{type(e).__name__}: {e}"
+        meta["elapsed_ms"] = int((time.perf_counter() - t0) * 1000)
+        return [], meta
+
+    meta["input_tokens"] = result.input_tokens
+    meta["output_tokens"] = result.output_tokens
+    meta["model"] = result.model
+
+    stop_reason = _budget_stop_reason(result)
+    truncated_error = _TRUNCATED_ERROR.format(budget=budget, reason=stop_reason)
+
+    try:
+        parsed = loads_lenient(result.text)
+    except Exception as e:  # noqa: BLE001
+        # A truncated completion and a model that simply refused to emit JSON
+        # produce the same JSONDecodeError, and only one of them has a lever
+        # the operator can pull. Say which one this is.
+        reason = truncated_error if stop_reason else f"{type(e).__name__}: {e}"
+        logger.warning("worker review failed for %s: %s", label, reason)
+        meta["error"] = reason
+        meta["elapsed_ms"] = int((time.perf_counter() - t0) * 1000)
+        return [], meta
+
+    meta["elapsed_ms"] = int((time.perf_counter() - t0) * 1000)
+
+    if not isinstance(parsed, dict):
+        # Valid JSON of the wrong shape is just as unusable as none, so it gets
+        # the same treatment: if the budget is why it came out that way, say so
+        # rather than reporting the shape and leaving the cause unspoken.
+        detail = f"worker review JSON is not an object: {type(parsed).__name__}"
+        logger.warning(detail)
+        meta["error"] = truncated_error if stop_reason else detail
+        return [], meta
+
+    if stop_reason:
+        # Parseable and usable, so the review still counts — but the model was
+        # cut off mid-answer and the tail of its findings is gone. Loud, not
+        # fatal. Logged only from here, where the response was actually used.
+        logger.warning(
+            "worker review for %s hit the completion budget "
+            "(max_tokens=%d, finish_reason=%s); findings may be incomplete — "
+            "raise %s",
+            label, budget, stop_reason, _MAX_TOKENS_ENV,
+        )
+
+    raw_findings = parsed.get("findings")
+    if not isinstance(raw_findings, list):
+        raw_findings = []
+    findings = [f for f in (_finding_from(r) for r in raw_findings) if f is not None]
+
+    raw_esc = parsed.get("escalations")
+    if not isinstance(raw_esc, list):
+        raw_esc = []
+    meta["escalations"] = [e for e in raw_esc if isinstance(e, dict)]
+
+    return findings, meta
 
 
 def review_chunk(
@@ -213,83 +331,41 @@ def review_chunk(
         repo_hint=repo_hint,
         context_lines=context_lines,
     )
-    t0 = time.perf_counter()
-    meta = {
-        "escalations": [],
-        "input_tokens": 0,
-        "output_tokens": 0,
-        "model": "",
-        "elapsed_ms": int((time.perf_counter() - t0) * 1000),
-        "error": "",
-    }
     budget = MAX_TOKENS if max_tokens is None else max_tokens
+    return _invoke_and_parse(
+        llm, system, user, budget=budget, label=f"chunk of {len(chunk)} files",
+    )
 
-    # The invoke and the parse are caught separately on purpose: only the
-    # invoke's result knows WHY generation stopped, and the parse failure is
-    # exactly where that reason has to be spoken. Neither is allowed to raise
-    # out of this function — the never-raise contract is unchanged.
-    try:
-        result = llm.invoke(
-            system=system,
-            user=user,
-            max_tokens=budget,
-            json_mode=True,
-        )
-    except Exception as e:  # noqa: BLE001
-        logger.warning("worker review failed for chunk of %d files: %s", len(chunk), e)
-        meta["error"] = f"{type(e).__name__}: {e}"
-        meta["elapsed_ms"] = int((time.perf_counter() - t0) * 1000)
-        return [], meta
 
-    meta["input_tokens"] = result.input_tokens
-    meta["output_tokens"] = result.output_tokens
-    meta["model"] = result.model
+def review_systemic(
+    llm: LLMClient,
+    digest: str,
+    *,
+    pr_title: str = "",
+    pr_description: str = "",
+    repo_hint: str = "",
+    max_tokens: int | None = None,
+) -> tuple[list[Finding], dict]:
+    """Review the whole-PR systemic digest with a single LLM call.
 
-    stop_reason = _budget_stop_reason(result)
-    truncated_error = _TRUNCATED_ERROR.format(budget=budget, reason=stop_reason)
+    The second-order complement to :func:`review_chunk`: chunk workers each
+    see one slice of the diff, so cross-file classes — an unauthenticated
+    handler, a secret in a client-exposed constant, a migration with no
+    policy — have no seat that sees enough to name them. ``digest`` is the
+    deterministic whole-PR text built by
+    :func:`prxref.systemic.build_digest`; the prompt
+    (``prompts/systemic.md``) restricts findings to those systemic classes.
 
-    try:
-        parsed = loads_lenient(result.text)
-    except Exception as e:  # noqa: BLE001
-        # A truncated completion and a model that simply refused to emit JSON
-        # produce the same JSONDecodeError, and only one of them has a lever
-        # the operator can pull. Say which one this is.
-        reason = truncated_error if stop_reason else f"{type(e).__name__}: {e}"
-        logger.warning("worker review failed for chunk of %d files: %s", len(chunk), reason)
-        meta["error"] = reason
-        meta["elapsed_ms"] = int((time.perf_counter() - t0) * 1000)
-        return [], meta
-
-    meta["elapsed_ms"] = int((time.perf_counter() - t0) * 1000)
-
-    if not isinstance(parsed, dict):
-        # Valid JSON of the wrong shape is just as unusable as none, so it gets
-        # the same treatment: if the budget is why it came out that way, say so
-        # rather than reporting the shape and leaving the cause unspoken.
-        detail = f"worker review JSON is not an object: {type(parsed).__name__}"
-        logger.warning(detail)
-        meta["error"] = truncated_error if stop_reason else detail
-        return [], meta
-
-    if stop_reason:
-        # Parseable and usable, so the review still counts — but the model was
-        # cut off mid-answer and the tail of its findings is gone. Loud, not
-        # fatal. Logged only from here, where the response was actually used.
-        logger.warning(
-            "worker review for chunk of %d files hit the completion budget "
-            "(max_tokens=%d, finish_reason=%s); findings may be incomplete — "
-            "raise %s",
-            len(chunk), budget, stop_reason, _MAX_TOKENS_ENV,
-        )
-
-    raw_findings = parsed.get("findings")
-    if not isinstance(raw_findings, list):
-        raw_findings = []
-    findings = [f for f in (_finding_from(r) for r in raw_findings) if f is not None]
-
-    raw_esc = parsed.get("escalations")
-    if not isinstance(raw_esc, list):
-        raw_esc = []
-    meta["escalations"] = [e for e in raw_esc if isinstance(e, dict)]
-
-    return findings, meta
+    Returns ``(findings, meta)`` under exactly the :func:`review_chunk`
+    contract — never raises, ``meta["error"]`` empty on success, truncation
+    named when the budget is why — so the orchestrator can treat the sweep
+    as one more worker-style unit for coverage accounting.
+    """
+    system, user = _render_systemic_prompt(
+        digest=digest,
+        pr_title=pr_title,
+        pr_description=pr_description,
+        repo_hint=repo_hint,
+    )
+    budget = MAX_TOKENS if max_tokens is None else max_tokens
+    return _invoke_and_parse(llm, system, user, budget=budget, label="systemic sweep")

--- a/src/prxref/systemic.py
+++ b/src/prxref/systemic.py
@@ -1,0 +1,190 @@
+"""Systemic-sweep digest: a compact, deterministic view of a whole PR diff.
+
+Per-chunk workers each see one slice of the diff, so patterns that only look
+wrong in aggregate — an unauthenticated handler, a secret in a client-exposed
+constant, a migration with no policy — have no seat that sees enough to name
+them. The systemic sweep spends ONE extra single-shot review call over a
+digest of the whole PR, and this module builds that digest deterministically:
+the full file list with per-file hunk headers, plus the added/removed lines
+that match a curated set of high-signal patterns, capped inside the same
+per-chunk token budget the chunking uses. Grep-like on purpose — no model in
+the loop — so the same diff always digests to the same text.
+"""
+from __future__ import annotations
+
+import re
+
+from .triage import FileDiff
+
+# At most this many matched lines from ONE file enter the digest, so a single
+# noisy file (a minified bundle, a logging-heavy script) cannot eat the whole
+# budget before the sweep has seen the rest of the PR. Per-file, not global:
+# a file that trips the cap keeps its first 40 hits and an explicit omission
+# note, never a silent cut.
+MAX_LINES_PER_FILE = 40
+
+# The digest budget is an upper bound on prompt size, not a billing figure;
+# the ~4-chars-per-token estimate is the same order-of-magnitude shortcut
+# build_chunks applies (40 tokens per changed code line).
+_CHARS_PER_TOKEN = 4
+
+# Truncation is announced in the digest itself so the model knows the text
+# ends early, and in the returned marker so tests can pin the behaviour.
+TRUNCATION_MARKER = "[digest truncated: token budget reached]"
+
+# One pattern class per systemic family the sweep prompt hunts for. Order is
+# the report order of :func:`match_class` when a line matches several —
+# entry-point first, because a line that both defines a handler and reads an
+# env var is best explained as a handler.
+_DIGEST_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "entry-point",
+        re.compile(
+            r"export\s+(?:default\s+)?(?:async\s+)?function"
+            r"|\bdef\s+(?:handler|lambda_handler|view|on_request)\b"
+            r"|@(?:\w+[._])?(?:route|get|post|put|patch|delete|use|api_view)\b"
+            r"|\badd_action\s*\(\s*['\"]wp_ajax_"
+            r"|\badd_action\b|\badd_filter\b"
+            r"|\b(?:app|router)\.(?:get|post|put|patch|delete|all)\s*\("
+        ),
+    ),
+    (
+        "secret",
+        re.compile(
+            r"\bprocess\.env\b"
+            r"|\bimport\.meta\.env\b"
+            r"|\bVITE_[A-Z0-9_]+\b"
+            r"|\bNEXT_PUBLIC_[A-Z0-9_]+\b"
+            # The (?:_\w+)? tails keep compound names visible: \bSUPABASE\b
+            # dies at the underscore of SUPABASE_KEY, the exact spelling the
+            # sweep exists to catch.
+            r"|\bSUPABASE(?:_\w+)?\b"
+            r"|\bAPI_KEY(?:_\w+)?\b"
+            r"|\bSECRET(?:_\w+)?\b"
+            r"|\bTOKEN(?:_\w+)?\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "auth-check",
+        re.compile(
+            r"check_ajax_referer"
+            r"|wp_verify_nonce"
+            r"|\bnonce\b"
+            r"|\bjwt\b"
+            r"|\bbearer\b"
+            r"|verify_\w+"
+            r"|\bverify\b"
+            r"|\bauthenticate\b|\bisAuthenticated\b|\bisAuthorized\b"
+            r"|\bauth\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "error-swallow",
+        re.compile(
+            r"\bcatch\s*(?:\(|\{)"
+            r"|\bfinally\b"
+            r"|\bexcept\b[^:\n]*:"
+            r"|\.catch\s*\(\s*(?:\(\s*\)\s*=>|[A-Za-z_$][\w$]*\s*=>\s*\{?\s*\})"
+            r"|\bexcept\s*:\s*pass\b",
+        ),
+    ),
+    (
+        "migration-ddl",
+        re.compile(
+            r"\bCREATE\s+(?:OR\s+REPLACE\s+)?(?:TABLE|INDEX|POLICY|SCHEMA|TYPE|VIEW|FUNCTION)\b"
+            r"|\bALTER\s+TABLE\b"
+            r"|\bDROP\s+(?:TABLE|COLUMN|POLICY|INDEX|SCHEMA)\b"
+            r"|\b(?:ENABLE|FORCE|DISABLE)\s+ROW\s+LEVEL\s+SECURITY\b"
+            r"|\bADD\s+COLUMN\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "console-log",
+        re.compile(
+            r"\bconsole\.\w+\s*\("
+            r"|\blogger\.\w+\s*\("
+            r"|\blogging\.(?:info|warning|error|debug|exception|critical)\s*\(",
+        ),
+    ),
+)
+
+
+def match_class(text: str) -> str | None:
+    """The first pattern class ``text`` matches, or ``None``.
+
+    Applied to one diff body line with its ``+``/``-``/space prefix stripped.
+    Classes are mutually exclusive per line by report order only; a line that
+    matches several is reported under the first, which keeps the digest one
+    line per diff line.
+    """
+    for name, pattern in _DIGEST_PATTERNS:
+        if pattern.search(text):
+            return name
+    return None
+
+
+def build_digest(files: list[FileDiff], token_budget: int) -> str:
+    """Render the whole-PR digest for the systemic sweep.
+
+    Every non-binary file contributes a ``## path`` header and its hunk
+    headers verbatim; under them, only the ``+``/``-`` lines whose text
+    matches a pattern in :data:`_DIGEST_PATTERNS`, rendered as
+    ``+<new-line>| text`` (``-`` lines carry their old-file number). Context
+    lines are never included. Two caps bound the output, both deterministic:
+    :data:`MAX_LINES_PER_FILE` matched lines per file (further matches are
+    counted in an omission note), and ``token_budget`` overall on a 4-chars-
+    per-token estimate, at which point the digest ends with
+    :data:`TRUNCATION_MARKER`. A ``token_budget`` below 1 degrades to that
+    truncated one-line digest rather than raising — the sweep is best-effort
+    by contract and never blocks a review.
+    """
+    budget = max(1, token_budget) * _CHARS_PER_TOKEN
+    out: list[str] = [
+        f"PR changes {len(files)} file(s); each file lists its hunk headers, "
+        "then only its high-signal added/removed lines."
+    ]
+    used = len(out[0])
+    for f in files:
+        header = f"\n## {f.path}"
+        if used + len(header) > budget:
+            out.append(TRUNCATION_MARKER)
+            return "\n".join(out)
+        out.append(header)
+        used += len(header)
+        if f.is_binary or not f.hunks:
+            continue
+        matched = 0
+        omitted = 0
+        for h in f.hunks:
+            hunk_header = (
+                f"@@ -{h.old_start},{h.old_count} +{h.new_start},{h.new_count} @@"
+            )
+            if used + len(hunk_header) > budget:
+                out.append(TRUNCATION_MARKER)
+                return "\n".join(out)
+            out.append(hunk_header)
+            used += len(hunk_header)
+            for ln in h.lines:
+                if ln.kind == " ":
+                    continue
+                if match_class(ln.text) is None:
+                    continue
+                if matched >= MAX_LINES_PER_FILE:
+                    omitted += 1
+                    continue
+                number = ln.new_line if ln.kind == "+" else ln.old_line
+                rendered = f"{ln.kind}{number}| {ln.text.rstrip()}"
+                if used + len(rendered) > budget:
+                    out.append(TRUNCATION_MARKER)
+                    return "\n".join(out)
+                out.append(rendered)
+                used += len(rendered)
+                matched += 1
+        if omitted:
+            note = f"... {omitted} more matched line(s) in this file omitted"
+            out.append(note)
+            used += len(note)
+    return "\n".join(out)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -270,10 +270,22 @@ class TestScenario1HappyPath:
             assert result["findings_active"][0].title == "Uncaught token decode exception"
             assert result["findings_active"][0].severity == "error"
 
-            assert len(result["findings_dropped"]) == 1
-            dropped = result["findings_dropped"][0]
-            assert dropped.title == "Missing audit log"
-            assert "below floor" in dropped.drop_reason
+            assert len(result["findings_dropped"]) == 3
+            # The chunk's own sub-floor finding is retained with its reason...
+            assert "below floor" in result["findings_dropped"][0].drop_reason
+            assert result["findings_dropped"][0].title == "Missing audit log"
+            # ...the sweep re-found both chunk findings (the mock serves every
+            # request the same payload): its low-confidence copy died at the
+            # gate like the chunk's, and its surviving copy of the posted
+            # finding was retained as a duplicate of the chunk finding.
+            assert sum(
+                f.drop_reason == "duplicate of chunk finding"
+                for f in result["findings_dropped"]
+            ) == 1
+            assert sum(
+                "below floor" in f.drop_reason
+                for f in result["findings_dropped"]
+            ) == 2
 
             assert len(forge.summaries) == 1
             summary = forge.summaries[0]
@@ -290,7 +302,8 @@ class TestScenario1HappyPath:
             assert "Uncaught token decode exception" in comments[0].body
             assert "Reviewed by prxref · model=fast" in comments[0].body
 
-            assert [r["model"] for r in server.requests] == ["fast"]
+            # One chunk review plus the systemic-sweep digest review.
+            assert [r["model"] for r in server.requests] == ["fast", "fast"]
         finally:
             server.stop()
 
@@ -370,7 +383,10 @@ class TestScenario2ModelFallback:
             assert result["verdict"] == "Approved"
             assert len(result["findings_active"]) == 1
 
-            assert [r["model"] for r in server.requests] == ["fast", "strong"]
+            # Chunk (fast 500s, strong answers) plus the sweep unit (same chain).
+            assert [r["model"] for r in server.requests] == [
+                "fast", "strong", "fast", "strong",
+            ]
 
             assert len(forge.summaries) == 1
             assert "model=strong" in forge.summaries[0]
@@ -586,7 +602,8 @@ class TestScenario5CliEndToEnd:
             assert rc == 0
             captured = capsys.readouterr()
             assert "verdict: Request-Changes" in captured.out
-            assert [r["model"] for r in server.requests] == ["fast"]
+            # One chunk review plus the systemic-sweep digest review.
+            assert [r["model"] for r in server.requests] == ["fast", "fast"]
         finally:
             server.stop()
 
@@ -632,7 +649,9 @@ class TestLLMBudgetKnobsEndToEnd:
         base_url = server.start()
         try:
             self._run(monkeypatch, base_url, {})
-            assert len(server.requests) == 1
+            # The chunk review plus the systemic-sweep digest review; the
+            # reproducibility contract is asserted on the FIRST (chunk) call.
+            assert len(server.requests) == 2
             payload = server.requests[0]["payload"]
             assert payload["max_tokens"] == 4096
             assert payload["temperature"] == 0.0
@@ -827,9 +846,9 @@ class TestDryRunEndToEnd:
             assert result["posted"] is False
             assert harness.forge.summaries == []
             assert harness.forge.inline_batches == []
-            # The review itself still ran: the model was called and the finding
-            # survived the quality gate.
-            assert len(server.requests) == 1
+            # The review itself still ran: the model was called (chunk plus
+            # the systemic sweep) and the finding survived the quality gate.
+            assert len(server.requests) == 2
             assert len(result["findings_active"]) == 1
         finally:
             server.stop()
@@ -871,13 +890,20 @@ class TestPartialFailureIsExplainedOnThePR:
         return big("src/one.py") + big("src/two.py")
 
     def _run(self, monkeypatch, second_finish_reason: str):
-        """First chunk answers cleanly, second stops with the given reason."""
+        """First chunk answers cleanly, second stops with the given reason.
+
+        The third request is the systemic-sweep digest review, answered clean:
+        this class pins the CHUNK truncation banner, and a sweep failure here
+        would only repeat the same finding under a second reason.
+        """
         state = {"n": 0}
 
         def route(payload):
             state["n"] += 1
             if state["n"] == 1:
                 return 200, _completion(_GOOD_CONTENT, "stop")
+            if state["n"] >= 3:
+                return 200, _completion(json.dumps({"findings": []}), "stop")
             return 200, _completion(_TRUNCATED_CONTENT, second_finish_reason)
 
         server = MockOpenAIServer(routes={"fast": route})
@@ -906,11 +932,12 @@ class TestPartialFailureIsExplainedOnThePR:
     def test_the_truncation_reason_lands_on_the_pr(self, monkeypatch):
         forge, result, server = self._run(monkeypatch, "length")
 
-        assert len(server.requests) == 2
-        assert result["chunks_reviewed"] == 1
+        # 2 chunk reviews + 1 systemic-sweep review.
+        assert len(server.requests) == 3
+        assert result["chunks_reviewed"] == 2
         assert result["chunks_failed"] == 1
         summary = forge.summaries[0]
-        assert "⚠️ Partial review: 1 of 2 chunks were reviewed" in summary
+        assert "⚠️ Partial review: 2 of 3 chunks were reviewed" in summary
         assert (
             "> - response truncated at max_tokens=256 (finish_reason=length); "
             "raise PRXREF_LLM_MAX_TOKENS" in summary
@@ -923,7 +950,7 @@ class TestPartialFailureIsExplainedOnThePR:
 
         assert result["chunks_failed"] == 1
         summary = forge.summaries[0]
-        assert "⚠️ Partial review: 1 of 2 chunks were reviewed" in summary
+        assert "⚠️ Partial review: 2 of 3 chunks were reviewed" in summary
         assert "PRXREF_LLM_MAX_TOKENS" not in summary
         assert "JSONDecodeError" in summary
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -64,6 +64,15 @@ def _contract_review_chunk(
     }
 
 
+def _contract_review_systemic(
+    llm, digest, *, pr_title="", pr_description="", repo_hint="", max_tokens=None,
+):
+    return [], {
+        "escalations": [], "input_tokens": 0, "output_tokens": 0,
+        "model": "", "elapsed_ms": 0, "error": "",
+    }
+
+
 def _contract_load_prompt(name):
     assert name == "summary"
     return SUMMARY_TEMPLATE
@@ -230,8 +239,16 @@ class FakeForge:
 
 @pytest.fixture(autouse=True)
 def _contract_stubs(monkeypatch):
-    """Pin the reviewer contract. Env clearing lives in tests/conftest.py."""
+    """Pin the reviewer contract. Env clearing lives in tests/conftest.py.
+
+    The systemic sweep is stubbed to a clean no-findings success so the
+    sweep-specific classes below can monkeypatch their own doubles; the
+    chunk-count assertions in the older classes include the sweep unit.
+    """
     monkeypatch.setattr(orchestrator.reviewer, "review_chunk", _contract_review_chunk)
+    monkeypatch.setattr(
+        orchestrator.reviewer, "review_systemic", _contract_review_systemic,
+    )
     monkeypatch.setattr(orchestrator.reviewer, "load_prompt", _contract_load_prompt)
 
 
@@ -260,7 +277,8 @@ class TestHappyPath:
         assert res["verdict"] == "Request-Changes"
         assert len(res["findings_active"]) == 2
         assert res["findings_dropped"] == []
-        assert res["chunk_count"] == 1
+        # 1 chunk + 1 systemic-sweep unit.
+        assert res["chunk_count"] == 2
         assert res["input_tokens"] == 100
         assert res["output_tokens"] == 50
         assert res["elapsed_ms"] >= 0
@@ -404,7 +422,8 @@ class TestParallelFanOut:
         forge = FakeForge(diff=diff)
         res = orchestrate_review(forge, REF, FakeLLM())
 
-        assert res["chunk_count"] == 3
+        # 3 chunks + 1 systemic-sweep unit.
+        assert res["chunk_count"] == 4
         assert res["verdict"] == "Approved"
         assert len(res["findings_active"]) == 3
         assert {f.file for f in res["findings_active"]} == set(paths)
@@ -491,7 +510,8 @@ class TestErrorPaths:
         assert res["verdict"] == "Error"
         assert res["findings_active"] == []
         assert res["findings_dropped"] == []
-        assert res["chunk_count"] == 1
+        # 1 chunk + 1 systemic-sweep unit.
+        assert res["chunk_count"] == 2
         assert res["posted"] is True
         assert len(forge.summaries) == 1
         notice = forge.summaries[0]
@@ -594,7 +614,7 @@ class TestCoverageAwareVerdict:
             if next(counter) == 1:
                 return [], {
                     "escalations": [], "input_tokens": 0, "output_tokens": 0,
-                    "model": "", "elapsed_ms": 0, "error": "LLMError: timeout",
+                    "model": "", "elapsed_ms": 0, "error": "LLMError: malformed response",
                 }
             return [], {
                 "escalations": [], "input_tokens": 5, "output_tokens": 5,
@@ -605,8 +625,9 @@ class TestCoverageAwareVerdict:
         forge = FakeForge(diff=TWO_FILE_DIFF)
         result = orchestrate_review(forge, REF, FakeLLM("{}"), post=False, max_chunks=2)
         assert result["verdict"] == "Approved"
+        # The failed chunk counts as failed; the sweep unit reviewed.
         assert result["chunks_failed"] == 1
-        assert result["chunks_reviewed"] == 1
+        assert result["chunks_reviewed"] == 2
         assert result["chunks_reviewed"] + result["chunks_failed"] == result["chunk_count"]
 
     def test_clean_run_reports_full_coverage(self):
@@ -623,7 +644,7 @@ class TestCoverageAwareVerdict:
             if next(counter) == 1:
                 return [], {
                     "escalations": [], "input_tokens": 0, "output_tokens": 0,
-                    "model": "", "elapsed_ms": 0, "error": "LLMError: timeout",
+                    "model": "", "elapsed_ms": 0, "error": "LLMError: malformed response",
                 }
             return [], {
                 "escalations": [], "input_tokens": 5, "output_tokens": 5,
@@ -634,7 +655,8 @@ class TestCoverageAwareVerdict:
         forge = FakeForge(diff=TWO_FILE_DIFF)
         orchestrate_review(forge, REF, FakeLLM("{}"), post=True, max_chunks=2)
         assert "Partial review" in forge.summaries[0]
-        assert "1 of 2" in forge.summaries[0]
+        # 2 of 3 units reviewed: the good chunk plus the systemic sweep.
+        assert "2 of 3" in forge.summaries[0]
 
 
 class TestMaxTokensThreading:
@@ -733,8 +755,9 @@ class TestChunkTokenBudget:
             FakeForge(diff=FOUR_FILE_DIFF), REF, FakeLLM("{}"), post=False,
             token_budget=35_000,
         )
-        assert at_default["chunk_count"] == at_constant["chunk_count"] == 4
-        assert at_wider["chunk_count"] == 2
+        # chunk_count includes the systemic-sweep unit (+1).
+        assert at_default["chunk_count"] == at_constant["chunk_count"] == 5
+        assert at_wider["chunk_count"] == 3
 
     @pytest.mark.parametrize("budget,expected_chunks", [
         (70_000, 1),
@@ -746,8 +769,8 @@ class TestChunkTokenBudget:
         res = orchestrate_review(
             forge, REF, FakeLLM("{}"), post=False, token_budget=budget,
         )
-        assert res["chunk_count"] == expected_chunks
-        assert res["chunks_reviewed"] == expected_chunks
+        assert res["chunk_count"] == expected_chunks + 1
+        assert res["chunks_reviewed"] == expected_chunks + 1
 
 
 class TestChunkFileCapAndContextKnobs:
@@ -792,9 +815,9 @@ class TestChunkFileCapAndContextKnobs:
             FakeForge(diff=six), REF, FakeLLM("{}"), post=False,
             max_files_per_chunk=2,
         )
-        assert wide["chunk_count"] == 1
-        assert capped["chunk_count"] == 3
-        assert capped["chunks_reviewed"] == 3
+        assert wide["chunk_count"] == 2
+        assert capped["chunk_count"] == 4
+        assert capped["chunks_reviewed"] == 4
 
     def test_context_lines_reach_the_worker_prompt(self, monkeypatch):
         """The trim is observable in what the LLM is sent, the changed lines
@@ -822,7 +845,9 @@ class TestChunkFileCapAndContextKnobs:
             FakeForge(diff=FAT_CONTEXT_DIFF), REF, RecordingLLM(), post=False,
             context_lines=1,
         )
-        assert res["chunks_reviewed"] == 1
+        # The contract fixture stubs the sweep, so the only LLM prompt here is
+        # the chunk's; the sweep prompt is covered by the systemic-sweep tests.
+        assert res["chunks_reviewed"] == 2
         assert len(prompts) == 1
         assert " lead1" not in prompts[0]
         assert " lead6" in prompts[0]
@@ -869,8 +894,8 @@ class TestMaxWorkers:
             post=False, max_workers=1,
         )
         assert seen == [1]
-        assert res["chunk_count"] == 4
-        assert res["chunks_reviewed"] == 4
+        assert res["chunk_count"] == 5
+        assert res["chunks_reviewed"] == 5
         assert res["chunks_failed"] == 0
 
     def test_width_never_exceeds_the_chunk_count(self, monkeypatch):
@@ -1071,7 +1096,7 @@ class TestNoStageRaisesOutOfOrchestrateReview:
             post=False, max_chunks=1,
         )
         assert res["verdict"] == "Request-Changes"
-        assert res["chunk_count"] == 1
+        assert res["chunk_count"] == 2
 
 
 TRUNCATED_REASON = (
@@ -1137,7 +1162,7 @@ class TestPartialBannerNamesTheReasons:
     def test_the_truncation_reason_reaches_the_posted_comment(self):
         forge, res = self._with({"a/one.py": TRUNCATED_REASON})
         assert res["chunks_failed"] == 1
-        assert res["chunks_reviewed"] == 3
+        assert res["chunks_reviewed"] == 4
         assert TRUNCATED_REASON in forge.summaries[0]
 
     def test_it_stays_inside_the_existing_blockquote(self):
@@ -1156,7 +1181,7 @@ class TestPartialBannerNamesTheReasons:
     def test_the_existing_coverage_sentence_is_untouched(self):
         forge, _res = self._with({"a/one.py": TRUNCATED_REASON})
         assert (
-            "> ⚠️ Partial review: 3 of 4 chunks were reviewed; 1 failed. "
+            "> ⚠️ Partial review: 4 of 5 chunks were reviewed; 1 failed. "
             "Findings may be incomplete." in forge.summaries[0]
         )
 
@@ -1229,7 +1254,7 @@ class TestPartialBannerNamesTheReasons:
             "c/three.py": "reason C",
         })
         assert res["chunks_failed"] == orchestrator.MAX_REPORTED_REASONS
-        assert res["chunks_reviewed"] == 1
+        assert res["chunks_reviewed"] == 2
         tail = self._banner(forge)
         for reason in ("reason A", "reason B", "reason C"):
             assert reason in tail
@@ -1350,7 +1375,7 @@ class TestPostedFailureReasonsAreSanitised:
         self, monkeypatch,
     ):
         forge, res = self._partial(monkeypatch, LEAKY_REASON)
-        assert res["chunks_failed"] == 1 and res["chunks_reviewed"] == 3
+        assert res["chunks_failed"] == 1 and res["chunks_reviewed"] == 4
         body = forge.summaries[0]
         assert "Partial review" in body
         assert LEAKY_SECRET not in body
@@ -1825,7 +1850,7 @@ class TestRunTrace:
         _, events = self._run(tmp_path, forge, FakeLLM(findings_by_path=HAPPY_FINDINGS))
         assert self._run_phases(events) == ["start", "ok"]
         closing = [e for e in events if e["node"] == "run" and e["phase"] == "ok"][0]
-        assert closing["meta"]["chunks_reviewed"] == 1
+        assert closing["meta"]["chunks_reviewed"] == 2
         assert closing["meta"]["findings"] == 2
 
     def test_the_stages_of_a_completed_review_are_all_there(self, tmp_path):
@@ -1835,11 +1860,11 @@ class TestRunTrace:
         opened = {e["node"] for e in events if e["phase"] == "start"}
         assert opened == {
             "run", "forge.get_pr", "forge.get_diff", "parse_diff", "build_chunks",
-            "chunk", "post",
+            "chunk", "sweep", "post",
         }
         assert {e["node"] for e in events if e["phase"] == "ok"} >= {
             "forge.get_pr", "forge.get_diff", "parse_diff", "build_chunks",
-            "chunk", "post", "run",
+            "chunk", "sweep", "post", "run",
         }
 
     def test_posting_that_was_turned_off_says_so_rather_than_looking_unreached(
@@ -2015,3 +2040,296 @@ class TestRunTrace:
         forge = FakeForge(diff=_added_file_diff("src/app.py", 20))
         orchestrate_review(forge, REF, FakeLLM(findings_by_path=HAPPY_FINDINGS))
         assert list(tmp_path.iterdir()) == []
+
+
+SWEEP_SIGNAL_DIFF = (
+    "diff --git a/src/supabase.ts b/src/supabase.ts\n"
+    "new file mode 100644\n"
+    "--- /dev/null\n"
+    "+++ b/src/supabase.ts\n"
+    "@@ -0,0 +1,3 @@\n"
+    "+import { createClient } from '@supabase/supabase-js';\n"
+    "+const supabase = createClient(process.env.SUPABASE_URL, 'service-key');\n"
+    "+export default supabase;\n"
+    + _added_file_diff("src/plain.ts", 3)
+)
+
+
+def _sweep_double(results: list, **meta_overrides):
+    """A review_systemic double that pops one scripted result per call.
+
+    Each entry is either ``("findings", [payload dicts])`` or
+    ``("error", "reason")``; telemetry defaults apply unless overridden.
+    """
+    calls: list[dict] = []
+
+    def _review_systemic(
+        llm, digest, *, pr_title="", pr_description="", repo_hint="",
+        max_tokens=None,
+    ):
+        calls.append({"digest": digest, "max_tokens": max_tokens})
+        kind, payload = results.pop(0)
+        meta = {
+            "escalations": [], "input_tokens": 7, "output_tokens": 3,
+            "model": "sweep-model", "elapsed_ms": 1, "error": "",
+        }
+        meta.update(meta_overrides)
+        if kind == "error":
+            meta["error"] = payload
+            return [], meta
+        return [Finding(
+            file=item["file"], line=item["line"], severity=item["severity"],
+            confidence=item["confidence"], title=item["title"],
+            body=item["body"],
+        ) for item in payload], meta
+
+    return _review_systemic, calls
+
+
+class TestSystemicSweep:
+    """The whole-PR sweep: one extra worker-style unit per review."""
+
+    SWEEP_FINDING = [{
+        "file": "src/supabase.ts", "line": 2, "severity": "warning",
+        "confidence": 0.85, "title": "Service key in client bundle",
+        "body": "The client is built from a literal service key; the token data leaks.",
+    }]
+
+    def test_the_sweep_runs_once_and_receives_the_whole_pr_digest(self, monkeypatch):
+        double, calls = _sweep_double([("findings", [])])
+        monkeypatch.setattr(orchestrator.reviewer, "review_systemic", double)
+        forge = FakeForge(diff=SWEEP_SIGNAL_DIFF)
+        res = orchestrate_review(forge, REF, FakeLLM('{"findings": []}'), post=False)
+
+        assert len(calls) == 1
+        digest = calls[0]["digest"]
+        assert "## src/supabase.ts" in digest
+        assert "## src/plain.ts" in digest
+        assert "+2| const supabase = createClient(" in digest
+        # The plain.ts changed lines match no pattern and are excluded.
+        assert "+1| data 1" not in digest
+        # Both files fit one chunk; +1 for the sweep unit.
+        assert res["chunk_count"] == 2
+        assert res["chunks_reviewed"] == 2
+
+    def test_sweep_findings_flow_to_active_inline_and_summary(self, monkeypatch):
+        double, _calls = _sweep_double([("findings", self.SWEEP_FINDING)])
+        monkeypatch.setattr(orchestrator.reviewer, "review_systemic", double)
+        forge = FakeForge(diff=SWEEP_SIGNAL_DIFF)
+        res = orchestrate_review(forge, REF, FakeLLM('{"findings": []}'))
+
+        assert [f.title for f in res["findings_active"]] == [
+            "Service key in client bundle",
+        ]
+        # A warning-severity finding approves; it still posts inline.
+        assert res["verdict"] == "Approved"
+        comments = forge.inline_batches[0]
+        assert [c.line for c in comments] == [2]
+        assert "Service key in client bundle" in comments[0].body
+        assert "Service key in client bundle" in forge.summaries[0]
+
+    def test_sweep_tokens_and_model_reach_the_totals(self, monkeypatch):
+        double, _calls = _sweep_double([("findings", [])])
+        monkeypatch.setattr(orchestrator.reviewer, "review_systemic", double)
+        forge = FakeForge(diff=SWEEP_SIGNAL_DIFF)
+        res = orchestrate_review(forge, REF, FakeLLM("{}"), post=False)
+        # 1 chunk x (100+50) from FakeLLM + the sweep's (7+3).
+        assert res["input_tokens"] == 107
+        assert res["output_tokens"] == 53
+
+    def test_a_max_tokens_override_reaches_the_sweep(self, monkeypatch):
+        double, calls = _sweep_double([("findings", [])])
+        monkeypatch.setattr(orchestrator.reviewer, "review_systemic", double)
+        orchestrate_review(
+            FakeForge(diff=SWEEP_SIGNAL_DIFF), REF, FakeLLM("{}"),
+            post=False, max_tokens=9001,
+        )
+        assert calls[0]["max_tokens"] == 9001
+
+    def test_a_sweep_finding_restating_a_surviving_chunk_finding_is_dropped(
+        self, monkeypatch,
+    ):
+        double, _calls = _sweep_double([("findings", [dict(self.SWEEP_FINDING[0])])])
+        monkeypatch.setattr(orchestrator.reviewer, "review_systemic", double)
+        forge = FakeForge(diff=SWEEP_SIGNAL_DIFF)
+        res = orchestrate_review(forge, REF, FakeLLM(
+            '{"findings": [{"file": "src/supabase.ts", "line": 2, '
+            '"severity": "warning", "confidence": 0.9, '
+            '"title": "Service key in client bundle", "body": "data token leaks"}]}'
+        ), post=False)
+        assert len(res["findings_active"]) == 1
+        assert res["findings_active"][0].confidence == 0.9
+        dupes = [f for f in res["findings_dropped"]
+                 if f.drop_reason == "duplicate of chunk finding"]
+        assert len(dupes) == 1
+        assert dupes[0].file == "src/supabase.ts"
+
+    def test_a_dying_chunk_finding_cannot_suppress_its_sweep_duplicate(
+        self, monkeypatch,
+    ):
+        """The dedup pass runs AFTER the quality gate on purpose: a chunk
+        finding below the floor must not suppress the sweep's higher-
+        confidence restatement and then die at the gate itself."""
+        double, _calls = _sweep_double([("findings", [dict(
+            self.SWEEP_FINDING[0], confidence=0.9,
+        )])])
+        monkeypatch.setattr(orchestrator.reviewer, "review_systemic", double)
+        res = orchestrate_review(
+            FakeForge(diff=SWEEP_SIGNAL_DIFF), REF, FakeLLM(
+                '{"findings": [{"file": "src/supabase.ts", "line": 2, '
+                '"severity": "warning", "confidence": 0.3, '
+                '"title": "Service key in client bundle", "body": "data token leaks"}]}'
+            ),
+            post=False, confidence_floor=0.6,
+        )
+        assert len(res["findings_active"]) == 1
+        assert res["findings_active"][0].confidence == 0.9
+
+    def test_a_sweep_failure_counts_as_one_failed_chunk(self, monkeypatch):
+        double, _calls = _sweep_double([("error", "LLMError: all models failed")])
+        monkeypatch.setattr(orchestrator.reviewer, "review_systemic", double)
+        forge = FakeForge(diff=_added_file_diff("src/app.py", 20))
+        res = orchestrate_review(forge, REF, FakeLLM('{"findings": []}'))
+
+        assert res["chunk_count"] == 2
+        assert res["chunks_reviewed"] == 1
+        assert res["chunks_failed"] == 1
+        assert res["verdict"] == "Approved"
+        summary = forge.summaries[0]
+        assert "Partial review: 1 of 2 chunks were reviewed; 1 failed." in summary
+        assert "systemic sweep" in summary
+
+    def test_all_chunks_failing_is_still_a_total_failure_even_if_the_sweep_answers(
+        self, monkeypatch,
+    ):
+        """The sweep sees only a pattern digest; it cannot carry a review
+        whose every chunk died into an "Approved, no findings" verdict."""
+        double, _calls = _sweep_double([("findings", self.SWEEP_FINDING)])
+        monkeypatch.setattr(orchestrator.reviewer, "review_systemic", double)
+
+        def _all_fail(llm, files, **kwargs):
+            return [], {
+                "escalations": [], "input_tokens": 0, "output_tokens": 0,
+                "model": "", "elapsed_ms": 0, "error": "LLMError: provider down",
+            }
+
+        monkeypatch.setattr(orchestrator.reviewer, "review_chunk", _all_fail)
+        forge = FakeForge(diff=_added_file_diff("src/app.py", 20))
+        res = orchestrate_review(forge, REF, FakeLLM("{}"), post=True)
+        assert res["verdict"] == "Error"
+        assert res["chunks_failed"] == 2
+        assert "Partial review" not in forge.summaries[0]
+
+    def test_an_empty_diff_runs_no_sweep(self, monkeypatch):
+        double, calls = _sweep_double([("findings", [])])
+        monkeypatch.setattr(orchestrator.reviewer, "review_systemic", double)
+        res = orchestrate_review(FakeForge(diff=""), REF, FakeLLM("{}"), post=False)
+        assert calls == []
+        assert res["chunk_count"] == 0
+
+
+class TestChunkTimeoutRetry:
+    """A chunk that outruns the LLM deadline gets ONE smaller-prompt retry."""
+
+    TIMEOUT = "LLMError: m1: timeout (ReadTimeout)"
+
+    @staticmethod
+    def _scripted_double(outcomes: list[dict]):
+        """A review_chunk double popping one outcome dict per call."""
+        calls: list[dict] = []
+
+        def _rc(llm, files, *, pr_title="", pr_description="", repo_hint="",
+                max_tokens=None, context_lines=None):
+            calls.append({"context_lines": context_lines, "path": files[0].path})
+            outcome = outcomes.pop(0)
+            return [Finding(
+                file=files[0].path, line=1, severity="outofscope",
+                confidence=0.9, title="ok", body="b",
+            )] if outcome.get("findings") else [], {
+                "escalations": [], "input_tokens": 5, "output_tokens": 5,
+                "model": "m", "elapsed_ms": 1,
+                "error": outcome.get("error", ""),
+            }
+
+        return _rc, calls
+
+    def test_a_timed_out_chunk_is_retried_once_with_zero_context(self, monkeypatch):
+        double, calls = self._scripted_double([
+            {"error": self.TIMEOUT},
+            {"findings": True},
+        ])
+        monkeypatch.setattr(orchestrator.reviewer, "review_chunk", double)
+        forge = FakeForge(diff=_added_file_diff("src/app.py", 20))
+        res = orchestrate_review(forge, REF, FakeLLM("{}"), post=False, context_lines=3)
+
+        assert [(c["context_lines"]) for c in calls] == [3, 0]
+        assert res["chunks_failed"] == 0
+        assert res["chunks_reviewed"] == 2
+
+    def test_a_persistent_timeout_still_fails_the_chunk(self, monkeypatch):
+        double, calls = self._scripted_double([
+            {"error": self.TIMEOUT}, {"error": self.TIMEOUT},
+        ])
+        monkeypatch.setattr(orchestrator.reviewer, "review_chunk", double)
+        forge = FakeForge(diff=_added_file_diff("src/app.py", 20))
+        res = orchestrate_review(
+            forge, REF, FakeLLM("{}"), post=True, context_lines=3,
+        )
+        assert len(calls) == 2
+        # The only chunk failed, so this is the total-failure notice path
+        # (both units counted failed), and the notice names the timeout.
+        assert res["verdict"] == "Error"
+        assert res["chunks_failed"] == 2
+        assert res["chunks_reviewed"] == 0
+        assert "timeout" in forge.summaries[0]
+
+    def test_a_non_timeout_error_is_not_retried(self, monkeypatch):
+        double, calls = self._scripted_double([
+            {"error": "LLMError: m1: HTTP 500"}, {"findings": True},
+        ])
+        monkeypatch.setattr(orchestrator.reviewer, "review_chunk", double)
+        res = orchestrate_review(
+            FakeForge(diff=_added_file_diff("src/app.py", 20)), REF, FakeLLM("{}"),
+            post=False, context_lines=3,
+        )
+        assert len(calls) == 1
+        assert res["verdict"] == "Error"
+        assert res["chunks_failed"] == 2
+
+    def test_a_timeout_at_zero_context_is_not_retried(self, monkeypatch):
+        """context_lines=0 is already the smallest rendering; an identical
+        prompt would meet an identical fate."""
+        double, calls = self._scripted_double([
+            {"error": self.TIMEOUT}, {"findings": True},
+        ])
+        monkeypatch.setattr(orchestrator.reviewer, "review_chunk", double)
+        res = orchestrate_review(
+            FakeForge(diff=_added_file_diff("src/app.py", 20)), REF, FakeLLM("{}"),
+            post=False, context_lines=0,
+        )
+        assert len(calls) == 1
+        assert res["verdict"] == "Error"
+        assert res["chunks_failed"] == 2
+
+    def test_truncation_is_never_retried(self, monkeypatch):
+        """finish_reason=length is the RESPONSE-side budget, not the deadline;
+        shrinking the prompt is not its lever."""
+        double, calls = self._scripted_double([
+            {"error": TRUNCATED_REASON}, {"findings": True},
+        ])
+        monkeypatch.setattr(orchestrator.reviewer, "review_chunk", double)
+        res = orchestrate_review(
+            FakeForge(diff=_added_file_diff("src/app.py", 20)), REF, FakeLLM("{}"),
+            post=False, context_lines=3,
+        )
+        assert len(calls) == 1
+        assert res["verdict"] == "Error"
+        assert res["chunks_failed"] == 2
+
+    def test_the_retry_predicate_is_the_backend_timeout_vocabulary(self):
+        assert orchestrator._is_timeout_error(
+            "LLMError: m1: timeout (ReadTimeout)")
+        assert orchestrator._is_timeout_error("LLMError: m2: Timeout (read)")
+        assert not orchestrator._is_timeout_error("LLMError: m1: HTTP 500")
+        assert not orchestrator._is_timeout_error("JSONDecodeError: bad json")
+        assert not orchestrator._is_timeout_error("")

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -7,7 +7,13 @@ import logging
 import pytest
 
 from prxref.llm import InvokeResult
-from prxref.reviewer import MAX_TOKENS, load_prompt, render_chunk, review_chunk
+from prxref.reviewer import (
+    MAX_TOKENS,
+    load_prompt,
+    render_chunk,
+    review_chunk,
+    review_systemic,
+)
 from prxref.triage import Finding, parse_unified_diff
 
 MINI_DIFF = """\
@@ -581,3 +587,75 @@ class TestReviewChunkThreadsContextLines:
         )
         assert len(findings) == 2
         assert meta["error"] == ""
+
+
+class TestReviewSystemic:
+    """review_systemic: the review_chunk contract over the whole-PR digest."""
+
+    DIGEST = "## src/app.py\n@@ -1,2 +1,2 @@\n+2| const KEY = process.env.TOKEN;"
+
+    def test_a_clean_response_maps_onto_findings(self):
+        llm = FakeLLM(CLEAN_RESPONSE)
+        findings, meta = review_systemic(llm, self.DIGEST)
+        assert meta["error"] == ""
+        assert len(findings) == 2
+        assert findings[0].file == "src/app.py"
+        assert meta["escalations"] != []
+
+    def test_the_digest_reaches_the_prompt_and_the_placeholders_fill(self):
+        llm = FakeLLM(CLEAN_RESPONSE)
+        review_systemic(
+            llm, self.DIGEST, pr_title="Add billing", pr_description="charges",
+        )
+        call = llm.calls[0]
+        assert "+2| const KEY = process.env.TOKEN;" in call["user"]
+        assert "Add billing" in call["user"]
+        assert "charges" in call["user"]
+        assert "{digest}" not in call["user"]
+        assert call["json_mode"] is True
+        assert call["max_tokens"] == MAX_TOKENS
+
+    def test_the_shipped_template_has_the_split_marker(self):
+        template = load_prompt("systemic.md")
+        assert template.count("## Review Context") == 1
+        assert "{digest}" in template
+
+    def test_the_shipped_prompt_carries_the_systemic_classes(self):
+        template = load_prompt("systemic.md")
+        for phrase in (
+            "no authentication", "client-exposed", "swallowed error",
+            "row level security", "destructive",
+        ):
+            assert phrase in template
+
+    def test_an_llm_failure_yields_empty_findings_and_the_error(self):
+        llm = _RaisingLLM()
+        findings, meta = review_systemic(llm, self.DIGEST)
+        assert findings == []
+        assert "RuntimeError" in meta["error"]
+        assert meta["input_tokens"] == 0
+
+    def test_a_truncated_digest_review_names_the_budget(self):
+        llm = FakeLLM("", finish_reason="length")
+        _findings, meta = review_systemic(llm, self.DIGEST, max_tokens=256)
+        assert "response truncated at max_tokens=256" in meta["error"]
+        assert "PRXREF_LLM_MAX_TOKENS" in meta["error"]
+
+    def test_a_wrong_shaped_response_keeps_the_shape_message(self):
+        llm = FakeLLM("[1, 2]")
+        _findings, meta = review_systemic(llm, self.DIGEST)
+        assert meta["error"] == "worker review JSON is not an object: list"
+
+    def test_max_tokens_none_uses_the_module_default(self):
+        llm = FakeLLM('{"findings": []}')
+        review_systemic(llm, self.DIGEST)
+        assert llm.calls[0]["max_tokens"] == MAX_TOKENS
+        llm = FakeLLM('{"findings": []}')
+        review_systemic(llm, self.DIGEST, max_tokens=1234)
+        assert llm.calls[0]["max_tokens"] == 1234
+
+
+class _RaisingLLM:
+    def invoke(self, system, user, *, max_tokens=4096, json_mode=False,
+               timeout_s=60.0):
+        raise RuntimeError("provider down")

--- a/tests/test_systemic.py
+++ b/tests/test_systemic.py
@@ -1,0 +1,188 @@
+"""Digest extractor tests: prxref.systemic.build_digest and its patterns."""
+from __future__ import annotations
+
+import pytest
+
+from prxref.systemic import (
+    MAX_LINES_PER_FILE,
+    TRUNCATION_MARKER,
+    build_digest,
+    match_class,
+)
+from prxref.triage import parse_unified_diff
+
+
+def _added_file(path: str, lines: list[str]) -> str:
+    body = "".join(f"+{text}\n" for text in lines)
+    return (
+        f"diff --git a/{path} b/{path}\n"
+        "new file mode 100644\n"
+        "--- /dev/null\n"
+        f"+++ b/{path}\n"
+        f"@@ -0,0 +1,{len(lines)} @@\n"
+        f"{body}"
+    )
+
+
+def _modified_file(path: str, before: list[str], removed: list[str], after: list[str]) -> str:
+    body = (
+        "".join(f" {text}\n" for text in before)
+        + "".join(f"-{text}\n" for text in removed)
+        + "".join(f"+{text}\n" for text in after)
+    )
+    return (
+        f"diff --git a/{path} b/{path}\n"
+        f"--- a/{path}\n+++ b/{path}\n"
+        f"@@ -1,{len(before) + len(removed)} +1,{len(before) + len(after)} @@\n"
+        f"{body}"
+    )
+
+
+def _digest(*file_diffs: str, token_budget: int = 25_000) -> str:
+    return build_digest(parse_unified_diff("\n".join(file_diffs)), token_budget)
+
+
+class TestPatternClasses:
+    @pytest.mark.parametrize("line,expected", [
+        ("export async function handler(req, res) {", "entry-point"),
+        ("export function main() {}", "entry-point"),
+        ("def handler(event, context):", "entry-point"),
+        ("def lambda_handler(event, context):", "entry-point"),
+        ("@app.route('/billing/charge', methods=['POST'])", "entry-point"),
+        ("@router.post('/subscriptions')", "entry-point"),
+        ("@api_view(['POST'])", "entry-point"),
+        ("add_action('wp_ajax_nopriv_avatar_upload', 'avatar_upload');", "entry-point"),
+        ("add_action('wp_ajax_avatar_upload', 'avatar_upload');", "entry-point"),
+        ("router.get('/invoice/:id', invoiceHandler)", "entry-point"),
+        ("app.post('/charge', chargeHandler)", "entry-point"),
+        ("const key = process.env.STRIPE_SECRET_KEY;", "secret"),
+        ("const cfg = import.meta.env;", "secret"),
+        ("export const API_URL = import.meta.env.VITE_LOCAL_SUPABASE_URL;", "secret"),
+        ("const SUPABASE_KEY = 'eyJhbGciOi';", "secret"),
+        ("apiKey = config['API_KEY']", "secret"),
+        ("const token = await jwt.sign(payload);", "secret"),
+        ("check_ajax_referer('avatar_nonce', 'nonce');", "auth-check"),
+        ("if (!wp_verify_nonce($_POST['_wpnonce'], 'avatar')) {", "auth-check"),
+        ("const decoded = verify_jwt(payload);", "auth-check"),
+        ("const user = authenticate(request);", "auth-check"),
+        ("if (!isAuthenticated(session)) return 401;", "auth-check"),
+        ("} catch (err) {", "error-swallow"),
+        ("except ValueError:", "error-swallow"),
+        ("except: pass", "error-swallow"),
+        ("fetch(url).catch(() => {})", "error-swallow"),
+        ("CREATE TABLE users (id bigint);", "migration-ddl"),
+        ("alter table subscriptions add column trial bool;", "migration-ddl"),
+        ("ENABLE ROW LEVEL SECURITY;", "migration-ddl"),
+        ("CREATE POLICY tenant_isolation ON users;", "migration-ddl"),
+        ("DROP TABLE audit_log;", "migration-ddl"),
+        ("ALTER TABLE invoices ADD COLUMN paid_at timestamptz;", "migration-ddl"),
+        ("console.log('charging card', card);", "console-log"),
+        ("console.error('write failed', err);", "console-log"),
+        ("logger.warn('retrying');", "console-log"),
+        ("logging.exception('charge failed')", "console-log"),
+    ])
+    def test_high_signal_lines_match(self, line, expected):
+        assert match_class(line) == expected
+
+    @pytest.mark.parametrize("line", [
+        "const total = a + b;",
+        "  return render(<Invoice rows={rows} />);",
+        "self.assertEqual(result.status, 200)",
+        "}",
+        "",
+        "users = User.objects.filter(active=True)",
+    ])
+    def test_ordinary_lines_match_nothing(self, line):
+        assert match_class(line) is None
+
+    def test_a_multi_match_line_reports_the_first_class(self):
+        # Defines a handler AND reads an env var: entry-point wins, and the
+        # line enters the digest exactly once.
+        assert match_class("export async function handler(req) { run(process.env.X) }") == "entry-point"
+
+
+class TestDigestShape:
+    def test_every_file_gets_a_header_and_hunk_headers(self):
+        digest = _digest(
+            _added_file("src/supabase.ts", ["const x = 1;", "const y = 2;"]),
+            _modified_file(
+                "src/other.py", ["def helper():"], ["pass"], ["return 1"],
+            ),
+        )
+        assert "## src/supabase.ts" in digest
+        assert "## src/other.py" in digest
+        assert "@@ -0,0 +1,2 @@" in digest
+        assert "@@ -1,2 +1,2 @@" in digest
+        # No matched lines in either file: only the skeleton appears.
+        assert "const x = 1;" not in digest
+
+    def test_matched_added_lines_carry_new_file_numbers(self):
+        digest = _digest(_added_file(
+            "src/supabase.ts",
+            ["const a = 1;", "const KEY = process.env.SUPABASE_KEY;", "const c = 3;"],
+        ))
+        assert "+2| const KEY = process.env.SUPABASE_KEY;" in digest
+        assert "const a = 1;" not in digest
+        assert "const c = 3;" not in digest
+
+    def test_removed_lines_carry_old_file_numbers(self):
+        digest = _digest(_modified_file(
+            "migrations/001_init.sql",
+            ["-- users table"],
+            ["CREATE TABLE users (id bigint);"],
+            ["CREATE TABLE users (id bigint, org bigint);"],
+        ))
+        assert "-2| CREATE TABLE users (id bigint);" in digest
+        assert "+2| CREATE TABLE users (id bigint, org bigint);" in digest
+
+    def test_context_lines_are_never_included(self):
+        digest = _digest(_modified_file(
+            "src/billing.py",
+            ["import stripe", "def charge(card):", "    plan = lookup(card)"],
+            ["    return bill(card)"],
+            ["    return bill(card, plan)"],
+        ))
+        assert "def charge(card):" not in digest
+        assert "-1| import stripe" not in digest
+
+    def test_binary_files_contribute_only_a_header(self):
+        digest = _digest(
+            "diff --git a/logo.png b/logo.png\n"
+            "Binary files a/logo.png and b/logo.png differ\n"
+        )
+        assert "## logo.png" in digest
+        assert "@@" not in digest
+
+    def test_the_digest_is_deterministic(self):
+        diff = _added_file("src/supabase.ts", ["const KEY = process.env.TOKEN;"]) * 1
+        first = _digest(diff, diff)
+        second = _digest(diff, diff)
+        assert first == second
+
+
+class TestDigestCaps:
+    def test_per_file_cap_omits_excess_lines_and_says_so(self):
+        lines = [f"console.log('line {i}');" for i in range(MAX_LINES_PER_FILE + 10)]
+        digest = _digest(_added_file("src/noisy.js", lines))
+        assert digest.count("console.log") == MAX_LINES_PER_FILE
+        assert f"... {10} more matched line(s) in this file omitted" in digest
+
+    def test_the_token_budget_truncates_and_announces_it(self):
+        files = "".join(
+            _added_file(f"src/f{i}.ts", ["const KEY = process.env.TOKEN;"] * 5)
+            for i in range(20)
+        )
+        digest = _digest(files, token_budget=1)
+        assert TRUNCATION_MARKER in digest
+        # The skeleton header survived; most files did not.
+        assert digest.count("## src/") < 20
+
+    def test_a_budget_that_fits_everything_adds_no_marker(self):
+        files = _added_file("src/small.ts", ["const KEY = process.env.TOKEN;"])
+        digest = _digest(files, token_budget=25_000)
+        assert TRUNCATION_MARKER not in digest
+        assert "+1| const KEY = process.env.TOKEN;" in digest
+
+    def test_a_degenerate_budget_degrades_to_a_truncated_digest(self):
+        digest = _digest(_added_file("src/a.ts", ["const KEY = process.env.TOKEN;"]), token_budget=0)
+        assert TRUNCATION_MARKER in digest


### PR DESCRIPTION
Fixes #29. Live evidence: 4 of 8 known-real bugs sat in files chunk workers demonstrably read and were still missed — the swallowed Supabase failure 100 lines from prxref's own posted comment, server-side VITE_LOCAL_SUPABASE secrets in the same file, zero-auth paid-API handlers.

## What

**Systemic sweep** (`src/prxref/systemic.py`): one extra single-shot call per review over a deterministic digest of the whole PR — full file list + hunk headers + the ±lines matching six high-signal patterns (entry points, env/secret refs, auth checks, error-swallows, migration DDL, console/logs), capped per-file and at the chunk token budget. A new `prompts/systemic.md` scopes the model to the five systemic classes only (missing auth on paid/privileged entry points, client-exposed secrets, swallowed errors in billing/persistence paths, RLS/policy/backfill-less migrations, destructive ops without guards). Sweep findings flow through the SAME pipeline (align → thread-dedup → severity-consistency → gate → post); a sweep finding duplicating a chunk finding drops with `duplicate of chunk finding` — deliberately AFTER the quality gate, so a sub-floor chunk finding cannot suppress its higher-confidence sweep duplicate and then die itself. Sweep failure counts as one failed chunk in the partial banner.

**Chunk retry:** deadline overruns are dominated by prompt prefill, so a timed-out chunk retries ONCE with `context_lines=0` before failing. The response-side-budget hypothesis was investigated and refuted (truncation returns 200 and degrades gracefully already) — the context-trim retry is the honest lever.

## Verification

1141 passed, ruff clean. No new config keys. ~35 existing assertions updated for the +1 sweep-chunk accounting (the accounting change is the feature).