### PR TITLE
fix: the sweep digest reaches repo-config, small files, loops, and whole migrations (#29 residual)

### DIFF
--- a/src/prxref/orchestrator.py
+++ b/src/prxref/orchestrator.py
@@ -20,8 +20,9 @@ Stage order (v1 — no Jira, no graph, no learnings, no investigator):
    response-side budget) is not a timeout and never reaches this retry.
 4. Systemic sweep: after the chunk workers, ONE more worker-style
    single-shot call over the whole-PR digest built by
-   ``systemic.build_digest`` (every file, hunk headers, plus only the
-   high-signal added/removed lines, capped inside ``token_budget``). It
+   ``systemic.build_digest`` (every file with hunk headers; short files and
+   migrations render their full added content, the rest only the
+   high-signal matched lines — all capped inside ``token_budget``). It
    hunts the cross-file classes no single chunk seat can see, joins the
    chunk results, and counts as one more review unit: ``chunk_count`` is
    ``len(chunks) + 1`` whenever the sweep ran, and a sweep failure is one

--- a/src/prxref/prompts/systemic.md
+++ b/src/prxref/prompts/systemic.md
@@ -1,4 +1,4 @@
-You are a senior code reviewer running a systemic sweep over a pull request. You see a compact digest of the WHOLE diff — every changed file with its hunk headers, plus only the added/removed lines that matched high-signal patterns (entry points, secrets, auth checks, error handling, migrations, logging). You see no repository checkout, no call graph, no history. Review what the digest shows; do not speculate about code you cannot see.
+You are a senior code reviewer running a systemic sweep over a pull request. You see a compact digest of the WHOLE diff — every changed file with its hunk headers, plus the added/removed lines that matched high-signal patterns (entry points, secrets, auth checks, error handling, migrations, logging, timers, repo config) or, for short files and migrations, the file's full added content. You see no repository checkout, no call graph, no history. Review what the digest shows; do not speculate about code you cannot see.
 
 ## Mission
 
@@ -7,8 +7,10 @@ Per-chunk reviewers each see one slice of the diff and reliably miss classes tha
 - An entry point (serverless handler, route, AJAX action, webhook) that reaches a paid or privileged API — a billable third-party call, a database write, an admin operation — with no authentication, nonce, or referer check visible in the digest.
 - A secret or server-side credential assigned to a client-exposed variable (`VITE_*`, `NEXT_PUBLIC_*`, anything bundled for the browser) or otherwise committed in plain text.
 - A swallowed error — a caught exception reduced to a log line or a bare return — on a code path that bills money or persists state.
-- A migration (DDL) that creates or alters a table without row level security, policies, or a backfill for existing rows.
+- A migration (DDL) that creates or alters a table without row level security or policies: a `CREATE TABLE` with no `ENABLE ROW LEVEL SECURITY` and no `CREATE POLICY` anywhere in the same migration file is itself the finding. Migration files appear in the digest with their full added content, so the absence of those statements is a fact you can assert, not a guess.
 - A destructive operation (drop, delete, overwrite, force-push style cleanup) with no guard or confirmation.
+- A recurring timer or poll (`setInterval`, `setTimeout`, `while (true)`) with no attempt cap, deadline, or termination on its failure path — e.g. a 404 response that resets status and re-queues the poll forever.
+- Repo-config drift: two lockfiles for one package manager root — a lockfile newly added while another lockfile or a `packageManager` pin also appears in the PR. The digest states this collision on a `! repo-config:` line.
 
 Nothing else. Per-file bugs inside one chunk are the chunk workers' job; repeating them here only duplicates their findings, which are deduplicated away.
 
@@ -39,7 +41,7 @@ PR description:
 
 Repo: {repo_hint}
 
-The digest below lists every changed file (`## path`) with its hunk headers (`@@`), then only the added (`+<new-line>|`) and removed (`-<old-line>|`) lines that matched a high-signal pattern. `[digest truncated: token budget reached]` means the cap cut the text short; there is no more.
+The digest below lists every changed file (`## path`) with its hunk headers (`@@`), then its lines: a short file (or any file the migration DDL pattern touches) shows its FULL added content — every `+` line — so a statement you would expect and do not see inside such a file is evidence of absence; larger files show only the added (`+<new-line>|`) and removed (`-<old-line>|`) lines that matched a high-signal pattern, with secret, auth, and entry-point lines listed ahead of noisier matches in a capped file. A `! repo-config:` line is a synthetic note, not a diff line — cite it as a file-level finding (`line: 0`). `[full content omitted: ...]` means that file degraded to pattern lines only. `[digest truncated: token budget reached]` means the cap cut the text short; there is no more.
 
 ### Digest
 

--- a/src/prxref/systemic.py
+++ b/src/prxref/systemic.py
@@ -4,24 +4,65 @@ Per-chunk workers each see one slice of the diff, so patterns that only look
 wrong in aggregate — an unauthenticated handler, a secret in a client-exposed
 constant, a migration with no policy — have no seat that sees enough to name
 them. The systemic sweep spends ONE extra single-shot review call over a
-digest of the whole PR, and this module builds that digest deterministically:
-the full file list with per-file hunk headers, plus the added/removed lines
-that match a curated set of high-signal patterns, capped inside the same
-per-chunk token budget the chunking uses. Grep-like on purpose — no model in
-the loop — so the same diff always digests to the same text.
+digest of the whole PR, and this module builds that digest deterministically.
+Grep-like on purpose — no model in the loop — so the same diff always digests
+to the same text.
+
+Three kinds of content reach the sweep, each closing a measured miss class:
+
+- Pattern-matched lines (always): the added/removed lines that hit a curated
+  high-signal pattern, per file. When a file exceeds the per-file cap, the
+  security-critical classes (entry points, secrets, auth checks) are admitted
+  FIRST so noisier matches — logging above all — cannot fill the cap and
+  push a secret-bearing line into the omission note.
+- Full added content: a file whose added content is short enough that absence
+  is evidence — any file the migration-ddl pattern touches (an RLS-less
+  ``CREATE TABLE`` is only visible when the whole migration is), and any file
+  under :data:`FULL_CONTENT_MAX_ADDED_LINES` added lines (loop bodies, config
+  keys, and store files match few or no patterns yet carry systemic bugs).
+- Repo-config notes: a lockfile newly added while another lockfile or a
+  ``packageManager`` pin also appears in the diff is stated as one synthetic
+  ``! repo-config:`` line — a dual-lockfile adoption is invisible to any
+  line pattern because the conflicting file is often not in the diff at all.
+
+Two caps bound the output, both deterministic: the per-file matched-line cap
+(pattern mode only) and the overall ``token_budget`` on a 4-chars-per-token
+estimate, announced with :data:`TRUNCATION_MARKER`. Full content is charged
+against a bounded share of that budget (:data:`FULL_CONTENT_BUDGET_SHARE`)
+so a PR of many small files cannot crowd out the pattern coverage of the
+rest; a file that does not fit degrades to pattern lines and says so.
 """
 from __future__ import annotations
 
 import re
 
-from .triage import FileDiff
+from .triage import DiffLine, FileDiff
 
-# At most this many matched lines from ONE file enter the digest, so a single
-# noisy file (a minified bundle, a logging-heavy script) cannot eat the whole
-# budget before the sweep has seen the rest of the PR. Per-file, not global:
-# a file that trips the cap keeps its first 40 hits and an explicit omission
-# note, never a silent cut.
+# At most this many matched lines from ONE file enter the digest in pattern
+# mode, so a single noisy file (a minified bundle, a logging-heavy script)
+# cannot eat the whole budget before the sweep has seen the rest of the PR.
+# Per-file, not global: a file that trips the cap keeps its highest-priority
+# hits and an explicit omission note, never a silent cut.
 MAX_LINES_PER_FILE = 40
+
+# A file with at most this many added lines is rendered in FULL — every added
+# line, matched or not. Below this size, absence of a line is evidence: a 7-line
+# migration with no RLS statement, a store file whose poll loop has no attempt
+# cap, a package.json diff. Above it, pattern matching applies (a lockfile's
+# 12k lines must never enter whole).
+FULL_CONTENT_MAX_ADDED_LINES = 60
+
+# Migration files get the same whole-file treatment up to a larger bound,
+# because "this migration never enables RLS or creates a policy" is exactly
+# the negative the sweep exists to assert and migrations are short. Past the
+# bound the file degrades to pattern lines with an omission note.
+MIGRATION_FULL_CONTENT_MAX_ADDED_LINES = 200
+
+# The share of the overall digest budget reserved for full-content bodies of
+# small (non-migration) files. A PR of many tiny files can therefore never
+# crowd out pattern coverage of the big ones: once the share is spent, later
+# eligible files degrade to pattern lines and the digest says so.
+FULL_CONTENT_BUDGET_SHARE = 0.3
 
 # The digest budget is an upper bound on prompt size, not a billing figure;
 # the ~4-chars-per-token estimate is the same order-of-magnitude shortcut
@@ -32,10 +73,35 @@ _CHARS_PER_TOKEN = 4
 # ends early, and in the returned marker so tests can pin the behaviour.
 TRUNCATION_MARKER = "[digest truncated: token budget reached]"
 
+# A file that qualifies for full content but does not fit degrades to pattern
+# lines and announces the omission rather than silently shrinking.
+_FULL_CONTENT_NOTE = "[full content omitted: {reason}]"
+
+# Pattern classes whose lines survive the per-file cap ahead of everything
+# else. A secret or entry point buried at match #41 of a logging-heavy file
+# is the miss that motivates this: without the buckets, the first 40
+# console.log lines consume the cap and the credential line is counted as
+# omitted. Within each bucket, diff order is preserved.
+_MUST_SEE_CLASSES = frozenset({"entry-point", "secret", "auth-check"})
+
+# Lockfile basenames whose coexistence in one diff signals repo-config drift.
+_LOCKFILE_BASENAMES = frozenset({
+    "package-lock.json",
+    "npm-shrinkwrap.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "bun.lockb",
+    "bun.lock",
+})
+
+_MANIFEST_BASENAME = "package.json"
+
 # One pattern class per systemic family the sweep prompt hunts for. Order is
 # the report order of :func:`match_class` when a line matches several —
 # entry-point first, because a line that both defines a handler and reads an
-# env var is best explained as a handler.
+# env var is best explained as a handler. repo-config and loop-timer sit
+# last: they label lines no earlier class wants, and a line that matches both
+# (a packageManager pin inside a polling setup) is more useful as repo-config.
 _DIGEST_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     (
         "entry-point",
@@ -109,7 +175,25 @@ _DIGEST_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
             r"|\blogging\.(?:info|warning|error|debug|exception|critical)\s*\(",
         ),
     ),
+    (
+        "loop-timer",
+        re.compile(
+            r"\bsetInterval\s*\("
+            r"|\bsetTimeout\s*\("
+            r"|\bsetImmediate\s*\("
+            r"|\brequestAnimationFrame\s*\("
+            r"|\bwhile\s*\(\s*true\s*\)"
+            r"|\bfor\s*\(\s*;\s*;\s*\)",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "repo-config",
+        re.compile(r"\bpackageManager\b"),
+    ),
 )
+
+_PATTERN_BY_NAME = dict(_DIGEST_PATTERNS)
 
 
 def match_class(text: str) -> str | None:
@@ -126,25 +210,150 @@ def match_class(text: str) -> str | None:
     return None
 
 
+def _basename(path: str) -> str:
+    return path.rsplit("/", 1)[-1]
+
+
+def _matched_lines(f: FileDiff) -> list[DiffLine]:
+    """Every added/removed line of ``f`` that matches any pattern, in diff
+    order, security-critical classes moved ahead of the rest."""
+    must: list[DiffLine] = []
+    rest: list[DiffLine] = []
+    for h in f.hunks:
+        for ln in h.lines:
+            cls = match_class(ln.text)
+            if ln.kind == " " or cls is None:
+                continue
+            if cls in _MUST_SEE_CLASSES:
+                must.append(ln)
+            else:
+                rest.append(ln)
+    return must + rest
+
+
+def _matches_ddl(f: FileDiff) -> bool:
+    pattern = _PATTERN_BY_NAME["migration-ddl"]
+    return any(
+        pattern.search(ln.text)
+        for h in f.hunks
+        for ln in h.lines
+        if ln.kind != " "
+    )
+
+
+def _rendered(ln: DiffLine) -> str:
+    number = ln.new_line if ln.kind == "+" else ln.old_line
+    return f"{ln.kind}{number}| {ln.text.rstrip()}"
+
+
+def _full_content_lines(f: FileDiff) -> list[DiffLine]:
+    """Every added line of ``f`` plus its pattern-matched removed lines, in
+    diff order. Context lines never appear, in this mode like any other."""
+    out: list[DiffLine] = []
+    for h in f.hunks:
+        for ln in h.lines:
+            if ln.kind == " ":
+                continue
+            if ln.kind == "-" and match_class(ln.text) is None:
+                continue
+            out.append(ln)
+    return out
+
+
+def _lockfile_notes(files: list[FileDiff]) -> dict[str, str]:
+    """One synthetic note per newly added lockfile whose adoption collides
+    with another lockfile or a ``packageManager`` pin elsewhere in the diff."""
+    basenames = {_basename(f.path) for f in files}
+    pin = any(
+        _basename(f.path) == _MANIFEST_BASENAME
+        and any(
+            ln.kind == "+" and _PATTERN_BY_NAME["repo-config"].search(ln.text)
+            for h in f.hunks
+            for ln in h.lines
+        )
+        for f in files
+    )
+    present = sorted(basenames & _LOCKFILE_BASENAMES)
+    notes: dict[str, str] = {}
+    for f in files:
+        base = _basename(f.path)
+        if f.status != "added" or base not in _LOCKFILE_BASENAMES:
+            continue
+        reasons = []
+        others = [name for name in present if name != base]
+        if others:
+            reasons.append("the " + " and the ".join(f"{name} lockfile" for name in others))
+        if pin:
+            reasons.append('a "packageManager" pin in package.json')
+        if reasons:
+            notes[f.path] = (
+                f"! repo-config: {base} is newly added alongside "
+                + " and ".join(reasons)
+                + " — possible dual lockfiles for one package root"
+            )
+    return notes
+
+
+def _full_content_plan(
+    f: FileDiff, share_left: int, global_left: int
+) -> tuple[list[DiffLine], str | None, int]:
+    """Decide how ``f`` renders: its full-content lines with ``None`` (and the
+    small-file share charge), or pattern lines with a degrade note (and a
+    zero charge). ``global_left`` is the budget remaining after the file's
+    fixed skeleton, so a body that cannot fit degrades instead of eating the
+    budget the rest of the PR still needs."""
+    migration = _matches_ddl(f)
+    added = f.lines_added
+    if migration and added > MIGRATION_FULL_CONTENT_MAX_ADDED_LINES:
+        return [], _FULL_CONTENT_NOTE.format(reason="migration exceeds the full-content cap"), 0
+    small = not migration and added <= FULL_CONTENT_MAX_ADDED_LINES
+    if migration or small:
+        body = _full_content_lines(f)
+        total = sum(len(_rendered(ln)) for ln in body)
+        share_charge = sum(len(_rendered(ln)) for ln in body if ln.kind == "+")
+        if total > global_left:
+            return [], _FULL_CONTENT_NOTE.format(reason="token budget"), 0
+        if small and share_charge > share_left:
+            return (
+                [],
+                _FULL_CONTENT_NOTE.format(reason="small-file budget share exhausted"),
+                0,
+            )
+        return body, None, share_charge
+    return [], None, 0
+
+
 def build_digest(files: list[FileDiff], token_budget: int) -> str:
     """Render the whole-PR digest for the systemic sweep.
 
-    Every non-binary file contributes a ``## path`` header and its hunk
-    headers verbatim; under them, only the ``+``/``-`` lines whose text
-    matches a pattern in :data:`_DIGEST_PATTERNS`, rendered as
-    ``+<new-line>| text`` (``-`` lines carry their old-file number). Context
-    lines are never included. Two caps bound the output, both deterministic:
-    :data:`MAX_LINES_PER_FILE` matched lines per file (further matches are
-    counted in an omission note), and ``token_budget`` overall on a 4-chars-
-    per-token estimate, at which point the digest ends with
+    Every non-binary file contributes a ``## path`` header, any repo-config
+    note, and its hunk headers verbatim. Under them the file renders EITHER
+    its full added content — when the migration-ddl pattern touches it (up to
+    :data:`MIGRATION_FULL_CONTENT_MAX_ADDED_LINES` added lines) or when it
+    adds at most :data:`FULL_CONTENT_MAX_ADDED_LINES` lines — OR the
+    added/removed lines matching a pattern in :data:`_DIGEST_PATTERNS`, with
+    security-critical classes admitted ahead of the rest inside
+    :data:`MAX_LINES_PER_FILE`. Lines render as ``+<new-line>| text``
+    (``-`` lines carry their old-file number); context lines never appear.
+
+    Full-content bodies of small files are charged against
+    :data:`FULL_CONTENT_BUDGET_SHARE` of the budget, migrations against the
+    global budget only; a body that does not fit degrades that file to
+    pattern lines with an explicit ``[full content omitted: ...]`` note. The
+    remaining cap is ``token_budget`` overall on a 4-chars-per-token
+    estimate, at which point the digest ends with
     :data:`TRUNCATION_MARKER`. A ``token_budget`` below 1 degrades to that
     truncated one-line digest rather than raising — the sweep is best-effort
     by contract and never blocks a review.
     """
     budget = max(1, token_budget) * _CHARS_PER_TOKEN
+    share_cap = int(budget * FULL_CONTENT_BUDGET_SHARE)
+    share_used = 0
+    notes = _lockfile_notes(files)
     out: list[str] = [
         f"PR changes {len(files)} file(s); each file lists its hunk headers, "
-        "then only its high-signal added/removed lines."
+        "then its full added content when the file is short or a migration, "
+        "otherwise only its high-signal added/removed lines."
     ]
     used = len(out[0])
     for f in files:
@@ -154,10 +363,15 @@ def build_digest(files: list[FileDiff], token_budget: int) -> str:
             return "\n".join(out)
         out.append(header)
         used += len(header)
+        note = notes.get(f.path)
+        if note is not None:
+            if used + len(note) + 1 > budget:
+                out.append(TRUNCATION_MARKER)
+                return "\n".join(out)
+            out.append(note)
+            used += len(note) + 1
         if f.is_binary or not f.hunks:
             continue
-        matched = 0
-        omitted = 0
         for h in f.hunks:
             hunk_header = (
                 f"@@ -{h.old_start},{h.old_count} +{h.new_start},{h.new_count} @@"
@@ -167,22 +381,32 @@ def build_digest(files: list[FileDiff], token_budget: int) -> str:
                 return "\n".join(out)
             out.append(hunk_header)
             used += len(hunk_header)
-            for ln in h.lines:
-                if ln.kind == " ":
-                    continue
-                if match_class(ln.text) is None:
-                    continue
-                if matched >= MAX_LINES_PER_FILE:
-                    omitted += 1
-                    continue
-                number = ln.new_line if ln.kind == "+" else ln.old_line
-                rendered = f"{ln.kind}{number}| {ln.text.rstrip()}"
-                if used + len(rendered) > budget:
-                    out.append(TRUNCATION_MARKER)
-                    return "\n".join(out)
-                out.append(rendered)
-                used += len(rendered)
-                matched += 1
+        body, degrade, share_charge = _full_content_plan(
+            f, share_cap - share_used, budget - used
+        )
+        full_content = degrade is None and bool(body)
+        if degrade is not None:
+            if used + len(degrade) + 1 > budget:
+                out.append(TRUNCATION_MARKER)
+                return "\n".join(out)
+            out.append(degrade)
+            used += len(degrade) + 1
+        if not body:
+            body = _matched_lines(f)
+        matched = 0
+        omitted = 0
+        for ln in body:
+            if not full_content and matched >= MAX_LINES_PER_FILE:
+                omitted += 1
+                continue
+            rendered = _rendered(ln)
+            if used + len(rendered) > budget:
+                out.append(TRUNCATION_MARKER)
+                return "\n".join(out)
+            out.append(rendered)
+            used += len(rendered)
+            matched += 1
+        share_used += share_charge
         if omitted:
             note = f"... {omitted} more matched line(s) in this file omitted"
             out.append(note)

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -2341,8 +2341,9 @@ class TestSystemicSweep:
         assert "## src/supabase.ts" in digest
         assert "## src/plain.ts" in digest
         assert "+2| const supabase = createClient(" in digest
-        # The plain.ts changed lines match no pattern and are excluded.
-        assert "+1| data 1" not in digest
+        # plain.ts matches no pattern, but at 3 added lines it is a small
+        # file: the digest renders its full added content.
+        assert "+1| data 1" in digest
         # Both files fit one chunk; +1 for the sweep unit.
         assert res["chunk_count"] == 2
         assert res["chunks_reviewed"] == 2

--- a/tests/test_systemic.py
+++ b/tests/test_systemic.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 
 import pytest
 
+from prxref.reviewer import load_prompt
 from prxref.systemic import (
+    FULL_CONTENT_MAX_ADDED_LINES,
     MAX_LINES_PER_FILE,
+    MIGRATION_FULL_CONTENT_MAX_ADDED_LINES,
     TRUNCATION_MARKER,
     build_digest,
     match_class,
@@ -80,6 +83,12 @@ class TestPatternClasses:
         ("console.error('write failed', err);", "console-log"),
         ("logger.warn('retrying');", "console-log"),
         ("logging.exception('charge failed')", "console-log"),
+        ("const timer = setInterval(poll, 3000);", "loop-timer"),
+        ("setTimeout(() => refresh(), 500);", "loop-timer"),
+        ("while (true) { tick(); }", "loop-timer"),
+        ("requestAnimationFrame(render);", "loop-timer"),
+        ("for (;;) { poll(); }", "loop-timer"),
+        ("\"packageManager\": \"yarn@4.5.0\",", "repo-config"),
     ])
     def test_high_signal_lines_match(self, line, expected):
         assert match_class(line) == expected
@@ -91,6 +100,9 @@ class TestPatternClasses:
         "}",
         "",
         "users = User.objects.filter(active=True)",
+        "for (const item of items) {",
+        "\"name\": \"web\",",
+        "clearInterval(timer);",
     ])
     def test_ordinary_lines_match_nothing(self, line):
         assert match_class(line) is None
@@ -103,27 +115,37 @@ class TestPatternClasses:
 
 class TestDigestShape:
     def test_every_file_gets_a_header_and_hunk_headers(self):
+        plain = [f"const x{i} = {i};" for i in range(FULL_CONTENT_MAX_ADDED_LINES + 5)]
         digest = _digest(
-            _added_file("src/supabase.ts", ["const x = 1;", "const y = 2;"]),
+            _added_file("src/supabase.ts", plain),
             _modified_file(
                 "src/other.py", ["def helper():"], ["pass"], ["return 1"],
             ),
         )
         assert "## src/supabase.ts" in digest
         assert "## src/other.py" in digest
-        assert "@@ -0,0 +1,2 @@" in digest
+        assert f"@@ -0,0 +1,{len(plain)} @@" in digest
         assert "@@ -1,2 +1,2 @@" in digest
-        # No matched lines in either file: only the skeleton appears.
-        assert "const x = 1;" not in digest
+        # Above the full-content threshold and matching nothing: only the
+        # skeleton appears.
+        assert "const x0 = 0;" not in digest
 
     def test_matched_added_lines_carry_new_file_numbers(self):
+        plain = ["// filler"] * (FULL_CONTENT_MAX_ADDED_LINES + 1)
+        lines = plain[:1] + ["const KEY = process.env.SUPABASE_KEY;"] + plain[1:]
+        digest = _digest(_added_file("src/supabase.ts", lines))
+        assert "+2| const KEY = process.env.SUPABASE_KEY;" in digest
+        assert "+1| // filler" not in digest
+        assert "+3| // filler" not in digest
+
+    def test_a_small_file_shows_every_added_line_with_its_number(self):
         digest = _digest(_added_file(
             "src/supabase.ts",
             ["const a = 1;", "const KEY = process.env.SUPABASE_KEY;", "const c = 3;"],
         ))
+        assert "+1| const a = 1;" in digest
         assert "+2| const KEY = process.env.SUPABASE_KEY;" in digest
-        assert "const a = 1;" not in digest
-        assert "const c = 3;" not in digest
+        assert "+3| const c = 3;" in digest
 
     def test_removed_lines_carry_old_file_numbers(self):
         digest = _digest(_modified_file(
@@ -162,10 +184,10 @@ class TestDigestShape:
 
 class TestDigestCaps:
     def test_per_file_cap_omits_excess_lines_and_says_so(self):
-        lines = [f"console.log('line {i}');" for i in range(MAX_LINES_PER_FILE + 10)]
+        lines = [f"console.log('line {i}');" for i in range(MAX_LINES_PER_FILE + 30)]
         digest = _digest(_added_file("src/noisy.js", lines))
         assert digest.count("console.log") == MAX_LINES_PER_FILE
-        assert f"... {10} more matched line(s) in this file omitted" in digest
+        assert f"... {30} more matched line(s) in this file omitted" in digest
 
     def test_the_token_budget_truncates_and_announces_it(self):
         files = "".join(
@@ -186,3 +208,218 @@ class TestDigestCaps:
     def test_a_degenerate_budget_degrades_to_a_truncated_digest(self):
         digest = _digest(_added_file("src/a.ts", ["const KEY = process.env.TOKEN;"]), token_budget=0)
         assert TRUNCATION_MARKER in digest
+
+
+_RLS_LESS_MIGRATION = [
+    "CREATE TABLE public.user_video_uploads (",
+    "  id uuid primary key default gen_random_uuid(),",
+    "  user_id uuid not null references auth.users(id),",
+    "  storage_path text not null,",
+    "  status text not null default 'processing',",
+    "  created_at timestamptz not null default now()",
+    ");",
+]
+
+
+class TestMigrationFullContent:
+    """A DDL-matched file shows its whole added content, so the ABSENCE of
+    RLS/policy lines inside it is a fact the sweep can check, not an
+    artifact of which lines happened to match a pattern."""
+
+    def test_an_rls_less_migration_shows_its_full_added_content(self):
+        digest = _digest(_added_file("supabase/migrations/0001_uploads.sql", _RLS_LESS_MIGRATION))
+        assert "+1| CREATE TABLE public.user_video_uploads (" in digest
+        assert "+4|   storage_path text not null," in digest
+        assert "+6|   created_at timestamptz not null default now()" in digest
+
+    def test_removed_ddl_in_a_migration_still_carries_old_numbers(self):
+        digest = _digest(_modified_file(
+            "migrations/0001_init.sql",
+            ["-- users table"],
+            ["DROP POLICY tenant_isolation ON users;"],
+            ["DROP POLICY tenant_isolation ON users;"],
+        ))
+        assert "-2| DROP POLICY tenant_isolation ON users;" in digest
+        assert "+2| DROP POLICY tenant_isolation ON users;" in digest
+
+    def test_a_migration_over_the_cap_degrades_to_pattern_lines_with_a_note(self):
+        body = ["CREATE TABLE big ("]
+        body += [f"  col_{i} bigint," for i in range(MIGRATION_FULL_CONTENT_MAX_ADDED_LINES)]
+        body += [");"]
+        digest = _digest(_added_file("migrations/0002_big.sql", body))
+        assert "[full content omitted" in digest
+        assert "+1| CREATE TABLE big (" in digest
+        assert "+2|" not in digest
+
+    def test_a_file_the_ddl_pattern_never_touched_stays_small_file_only(self):
+        digest = _digest(_added_file("src/db.py", ["engine = create_engine(url);"]))
+        assert "+1| engine = create_engine(url);" in digest
+
+
+class TestSmallFileFullContent:
+    """Files under the added-line threshold render whole, so loop bodies and
+    config keys that match no pattern still reach the sweep."""
+
+    def test_the_infinite_poll_store_shows_its_loop_body(self):
+        digest = _digest(_added_file("src/stores/VideoThumbnailStore.ts", [
+            "export const useVideoThumbnailStore = create((set) => ({",
+            "  startPolling: (videoId) => {",
+            "    const timer = setInterval(async () => {",
+            "      const res = await fetch(`/api/videos/${videoId}/thumbnail`);",
+            "      if (res.status === 404) {",
+            "        return;",
+            "      }, 3000);",
+            "  },",
+            "}));",
+        ]))
+        assert "+3|     const timer = setInterval(async () => {" in digest
+        assert "+5|       if (res.status === 404) {" in digest
+        assert "+7|       }, 3000);" in digest
+
+    def test_a_file_over_the_threshold_stays_pattern_matched(self):
+        plain = [f"const x{i} = {i};" for i in range(FULL_CONTENT_MAX_ADDED_LINES + 1)]
+        digest = _digest(_added_file("src/big.ts", plain))
+        assert "const x0 = 0;" not in digest
+
+    def test_context_lines_stay_out_of_a_full_content_file(self):
+        digest = _digest(_modified_file(
+            "src/billing.py",
+            ["import stripe", "def charge(card):", "    plan = lookup(card)"],
+            ["    return bill(card)"],
+            ["    return bill(card, plan)"],
+        ))
+        assert "+2| def charge(card):" not in digest
+        assert "-1| import stripe" not in digest
+        assert "+4|     return bill(card, plan)" in digest
+
+    def test_full_content_inclusion_is_deterministic(self):
+        diff = _added_file("src/small.ts", ["a = 1", "b = 2"])
+        assert _digest(diff) == _digest(diff)
+
+
+class TestFullContentBudgetShare:
+    """Full content is a bounded share of the digest budget, never a way to
+    blow it: files that do not fit degrade to pattern lines and say so."""
+
+    def test_a_small_file_too_big_for_the_share_degrades_to_pattern_lines(self):
+        lines = ["x" * 90 for _ in range(FULL_CONTENT_MAX_ADDED_LINES)]
+        lines[10] = "const KEY = process.env.SUPABASE_KEY;"
+        digest = _digest(_added_file("src/wide.ts", lines), token_budget=100)
+        assert "[full content omitted" in digest
+        assert "+11| const KEY = process.env.SUPABASE_KEY;" in digest
+        assert "+1| " + "x" * 90 not in digest
+        assert TRUNCATION_MARKER not in digest
+
+    def test_a_migration_is_not_share_capped_but_still_budget_capped(self):
+        body = [f"  col_{i} bigint," for i in range(120)]
+        diff = _added_file("migrations/0003.sql", ["CREATE TABLE t ("] + body + [");"])
+        wide_open = _digest(diff, token_budget=2_000)
+        assert "+2|   col_0 bigint," in wide_open
+        assert TRUNCATION_MARKER not in wide_open
+        tight = _digest(diff, token_budget=200)
+        assert "[full content omitted" in tight
+        assert "+1| CREATE TABLE t (" in tight
+
+    def test_the_digest_never_exceeds_its_token_budget(self):
+        files = []
+        for i in range(30):
+            files.append(_added_file(f"src/small{i}.ts", [f"const a{i} = {i};" ] * 55))
+        for i in range(40):
+            files.append(_added_file(f"src/noisy{i}.tsx", [f"console.log('x{i}');" ] * 60))
+        for i in range(10):
+            files.append(_added_file(f"migrations/{i:04}.sql", _RLS_LESS_MIGRATION))
+        digest = _digest(*files, token_budget=25_000)
+        assert len(digest) <= 25_000 * 4
+
+
+class TestRepoConfigNotes:
+    """A lockfile added beside another lockfile or a packageManager pin is a
+    repo-config signal the digest states deterministically."""
+
+    def test_a_new_lockfile_beside_a_package_manager_pin_gets_a_note(self):
+        digest = _digest(
+            _added_file("web/package-lock.json", ['{', '"lockfileVersion": 3', '}']),
+            _modified_file("web/package.json", ['{'], [], ['  "packageManager": "yarn@4.5.0",']),
+        )
+        assert (
+            "! repo-config: package-lock.json is newly added alongside a "
+            '"packageManager" pin in package.json' in digest
+        )
+
+    def test_a_new_lockfile_beside_another_lockfile_names_it(self):
+        digest = _digest(
+            _added_file("web/package-lock.json", ['{']),
+            _modified_file("web/yarn.lock", ["# yarn lockfile v1"], [], ["# yarn lockfile v1"]),
+        )
+        assert (
+            "! repo-config: package-lock.json is newly added alongside the "
+            "yarn.lock lockfile" in digest
+        )
+
+    def test_a_lone_new_lockfile_gets_no_note(self):
+        digest = _digest(_added_file("web/package-lock.json", ['{']))
+        assert "! repo-config:" not in digest
+
+    def test_a_modified_lockfile_gets_no_note(self):
+        digest = _digest(
+            _modified_file("web/package-lock.json", ['{'], [], ['  "x": 1']),
+            _modified_file("web/yarn.lock", ["# yarn lockfile v1"], [], ["# yarn lockfile v1"]),
+        )
+        assert "! repo-config:" not in digest
+
+    def test_two_new_lockfiles_note_each_other(self):
+        digest = _digest(
+            _added_file("web/package-lock.json", ['{']),
+            _added_file("web/pnpm-lock.yaml", ['lockfileVersion: 9']),
+        )
+        assert (
+            "! repo-config: package-lock.json is newly added alongside the "
+            "pnpm-lock.yaml lockfile" in digest
+        )
+        assert (
+            "! repo-config: pnpm-lock.yaml is newly added alongside the "
+            "package-lock.json lockfile" in digest
+        )
+
+
+class TestMustSeeSurvival:
+    """The per-file cap consumes fill-class matches first: a secret or entry
+    point can never be omitted because noisier classes filled the cap."""
+
+    def test_a_secret_beyond_the_cap_is_kept_ahead_of_console_noise(self):
+        lines = [f"console.log('noise {i}');" for i in range(MAX_LINES_PER_FILE + 30)]
+        lines.append("console.log('VITE_VIMEO_ACCESS_TOKEN:', process.env.VITE_VIMEO_ACCESS_TOKEN);")
+        digest = _digest(_added_file("src/config.ts", lines))
+        assert "'VITE_VIMEO_ACCESS_TOKEN:', process.env.VITE_VIMEO_ACCESS_TOKEN" in digest
+        assert "... 31 more matched line(s) in this file omitted" in digest
+
+    def test_an_entry_point_beyond_the_cap_is_kept_ahead_of_console_noise(self):
+        lines = [f"console.log('noise {i}');" for i in range(MAX_LINES_PER_FILE + 30)]
+        lines.append("app.post('/charge', chargeHandler)")
+        digest = _digest(_added_file("src/routes.ts", lines))
+        assert f"+{MAX_LINES_PER_FILE + 31}| app.post('/charge', chargeHandler)" in digest
+
+    def test_fill_lines_keep_their_order_behind_the_must_see_lines(self):
+        lines = [f"console.log('noise {i}');" for i in range(MAX_LINES_PER_FILE + 30)]
+        lines.insert(0, "const SECRET = 'x';")
+        digest = _digest(_added_file("src/config.ts", lines))
+        first_console = digest.index("+2| console.log('noise 0');")
+        last_console = digest.index(f"+{MAX_LINES_PER_FILE}| console.log('noise {MAX_LINES_PER_FILE - 2}');")
+        assert first_console < last_console
+
+
+class TestSweepPromptContract:
+    """The sweep prompt names the classes the digest now makes visible."""
+
+    def test_the_prompt_names_the_new_evidence(self):
+        prompt = load_prompt("systemic.md")
+        assert "CREATE TABLE" in prompt
+        assert "ROW LEVEL SECURITY" in prompt
+        assert "setInterval" in prompt
+        assert "repo-config" in prompt
+        assert "full content" in prompt
+
+    def test_the_prompt_still_keeps_the_context_marker(self):
+        from prxref.reviewer import _CONTEXT_MARKER
+
+        assert _CONTEXT_MARKER in load_prompt("systemic.md")


### PR DESCRIPTION
Follow-up to #29 after the live v0.11.0 re-audit (7/11 recall; 4 classes missed with code present in the diff). Each miss was simulated against v0.11.0 before fixing:

- **RLS-less migration:** the digest showed only pattern-matched fragments of a 7-line migration, so 'no ENABLE ROW LEVEL SECURITY anywhere' was not a checkable fact. Now: migration-ddl-matched files render full added content (≤200 lines), and the prompt states absence-is-evidence.
- **Dual lockfiles:** no pattern could ever express it (yarn.lock wasn't even in the diff). Now: a deterministic synthetic note when an added lockfile coexists with another lockfile or a `packageManager` pin, plus a `repo-config` pattern.
- **Infinite 404 poll:** the store contributed a header and zero body lines — `setInterval`/404/`setStatus` matched nothing. Now: a `loop-timer` class + small-file full content puts the uncapped 404 branch in the digest.
- **Token console.log:** the line matched but was capped out as match #41 behind 40 console.log lines. Now: must-see classes (entry-point, secret, auth-check) admit ahead of fill classes within the per-file cap.

Budget rules: files ≤60 added lines render full content, charged to a 30% budget share; migrations charge the global budget; overflow degrades to pattern mode. Global budget invariant pinned by test on a 90-file mixed PR. All knobs are module constants — no config keys.

**Verification:** 1218 passed, ruff clean; new tests written failing-first.