### PR TITLE
release: 0.12.0 — the context release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.12.0] — 2026-09-04
+
 The context release. A real-PR audit of 0.11.0/0.11.1 — two review passes over
 ten Bitbucket Server PRs — produced a twelve-issue bundle dated 2026-09-03/04,
 and this entry answers all of it. Four of the eleven verified findings were
@@ -117,6 +119,10 @@ GitHub issues.
   it happens. Applies to both the openai-compat and litellm backends; only a 4xx
   qualifies, never a 5xx.
 
+## [0.11.1] — 2026-09-02
+
+### Fixed
+
 - **The sweep digest reaches the four classes the 2026-09-02 re-audit found
   missing (#29 residual, PR #38).** Migration-ddl-matched files render their
   full added content (absence of RLS becomes a checkable fact); an added
@@ -180,6 +186,7 @@ anchor shape surviving; all five findings are addressed here.
   invented) drops with `malformed location: '<file>'` into the
   dropped-findings audit section, instead of rendering `- 🟧 `package.:—``.
 
+## [0.10.1] — 2026-09-01
 
 ### Fixed
 
@@ -738,7 +745,15 @@ Development baseline. Never published to PyPI and never tagged; superseded by
 - Diff content is sent to whichever OpenAI-compatible endpoint you configure.
 - Requires Python 3.12+. Tested on 3.12 and 3.13.
 
-[Unreleased]: https://github.com/sblattj/prxref/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/sblattj/prxref/compare/v0.12.0...HEAD
+[0.11.1]: https://github.com/sblattj/prxref/releases/tag/v0.11.1
+[0.11.0]: https://github.com/sblattj/prxref/releases/tag/v0.11.0
+[0.10.1]: https://github.com/sblattj/prxref/releases/tag/v0.10.1
+[0.10.0]: https://github.com/sblattj/prxref/releases/tag/v0.10.0
+[0.9.0]: https://github.com/sblattj/prxref/releases/tag/v0.9.0
+[0.8.0]: https://github.com/sblattj/prxref/releases/tag/v0.8.0
+[0.7.0]: https://github.com/sblattj/prxref/releases/tag/v0.7.0
+[0.6.0]: https://github.com/sblattj/prxref/releases/tag/v0.6.0
 [0.5.0]: https://github.com/sblattj/prxref/releases/tag/v0.5.0
 [0.4.0]: https://github.com/sblattj/prxref/releases/tag/v0.4.0
 [0.3.0]: https://github.com/sblattj/prxref/releases/tag/v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,115 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+The context release. A real-PR audit of 0.11.0/0.11.1 — two review passes over
+ten Bitbucket Server PRs — produced a twelve-issue bundle dated 2026-09-03/04,
+and this entry answers all of it. Four of the eleven verified findings were
+wrong for the same reason: the worker was reasoning about code it could not
+see, so it now receives the versions of the libraries a chunk imports and the
+definitions of the symbols it references. Around that sit five new
+deterministic gates that drop a claim the diff itself contradicts, a systemic
+sweep that finally sees deletions and the PR's own discussion, a stable
+finding order with a `sampling` record on every run, a run-lifetime cache for a
+model the provider has taken away, and machine-readable CLI output.
+
+Inbox issue numbers below refer to `docs/issues/inbox-2026-09-04/`, not to
+GitHub issues.
+
+### Added
+
+- **Workers see the versions of the third-party packages a chunk imports**
+  (inbox issue 01), resolved from the nearest `package.json`, `pyproject.toml`,
+  `go.mod`, or `Cargo.toml` at the PR head, so a review no longer guesses which
+  library major the code runs against. The audit's headline false positive was
+  Effect 3 semantics asserted against an Effect 4 repo, with a suggested fix
+  that would have created the bug it alleged.
+- **Workers see the definitions of same-file symbols a chunk references** whose
+  declaration sits outside the rendered hunk (inbox issue 02), so a finding is
+  no longer inferred from an identifier's name alone. Both blocks are best
+  effort, capped (40 entries / 6 lines / 8000 chars / 512 KiB), fetched at most
+  once per file per run, and a forge that cannot serve file content reviews
+  exactly as before.
+- **Forge adapters can serve a file's content at a commit** — a new optional
+  `get_file_content(ref, path, *, sha)` on all four adapters (GitHub, GitLab,
+  Bitbucket Cloud, Bitbucket Server), read-only and best effort, using the token
+  already configured for reviews. No new environment variable.
+- **A deterministic release-shaped-PR check** (inbox issue 10): a PR that is at
+  least 80% release machinery — manifests, changelogs, lockfiles, changesets —
+  yet still touches source flags every offending path, with no extra LLM call.
+  The body ends `(deterministic check, no model)`.
+- **`prxref review --format {text,json}`** (inbox issue 08). `json` prints
+  exactly one JSON object to stdout — verdict, active and dropped findings,
+  chunk and token counts, posted — for scriptable, diffable output. Default
+  remains `text`.
+- **Every review result carries a `sampling` record** (inbox issue 04) —
+  temperature, seed, and the model chain — including on a failed or empty-diff
+  run, and on the `run/start` trace event, so a report says which knobs were
+  actually in force.
+- **New file status `copied`** (inbox issue 03), rendered back into the worker
+  prompt as `copy from` / `copy to` so the model can tell a copy from a move.
+- **`docs/quality.md`**, the single reference for the deterministic checks, the
+  eleven quality passes, and every `drop_reason` string; plus
+  `docs/systemic-sweep.md` for the sweep's digest classes and caps.
+
+### Changed
+
+- **Five new deterministic gates run before posting**, all unconditional and
+  all named in the run record: `apply_manifest_claim_check`,
+  `apply_settled_thread_suppression`, `apply_removal_claim_check`,
+  `apply_hedge_gate`, and the decorating `apply_containment_note`. See
+  `docs/quality.md` for the full order and reasons.
+- **The systemic sweep now sees deleted guards** (inbox issue 06): a removed
+  numeric limit constant or validator/sanitiser definition is classed
+  `guard-removal` and admitted to the digest ahead of noisier matches, so a PR
+  whose only risk is a deletion no longer digests to nothing.
+- **The sweep prompt carries the PR's existing review discussion** (inbox issue
+  06), so it stops re-raising subjects the team already argued out. Existing
+  threads are fetched once per review, before the review units run rather than
+  after them, and still after the stale-inline prune.
+- **The worker prompt demands more of a finding**: a claim that turns on an
+  unlisted library version or an unshown definition caps confidence at 0.5 and
+  is phrased as a question (inbox issues 01, 02); a claim conditioned on a
+  precondition the diff never established must be omitted or filed as a
+  question (inbox issue 05); and a throw, panic, crash, or unhandled-rejection
+  claim must name its containment boundary (inbox issue 07).
+- **`--no-post` and `-v` now print the findings** in text mode — every active
+  finding's file, line, title, and body, plus dropped findings with their drop
+  reason (inbox issue 08).
+
 ### Fixed
+
+- **Findings are emitted in a stable `(file, line, title)` order** (inbox issue
+  04), and the error and inline-comment caps break ties by finding content
+  instead of by whichever worker answered first. The audit ran the same commit
+  twice and got 7 findings then 2 — the one that vanished was the security
+  finding. Documented in `docs/llm.md` and the README: temperature 0 and
+  `PRXREF_LLM_SEED` are sent but do **not** make a review bit-reproducible.
+- **A `copy from` / `copy to` diff header is parsed as a copied file** (inbox
+  issue 03), git or Bitbucket Server `src://`/`dst://` form, instead of being
+  mistaken for a rename — and a finding claiming a named path was removed is
+  dropped when that path is still present after the PR lands
+  (`claims removal of a path present in the post-image: <path>`). A claim about
+  a file that really was deleted still posts.
+- **Self-hedged findings are dropped before the confidence floor** (inbox
+  issues 05, 11) — "If X still leases a client", "unless the backfill already
+  ran", "I cannot verify" — with `drop_reason` `hedged: "<matched phrase>"`. A
+  hedged finding no longer consumes an error-cap slot ahead of a proven one.
+- **A `package.json` finding anchored on the wrong dependency is dropped**
+  (inbox issue 12) with `anchor mismatch:`, and one that calls a `devDependency`
+  a runtime dependency (or the reverse) with `section mismatch:`. Line
+  realignment on a manifest no longer lets the section word `dependencies`
+  outrank the package name and drag a correct comment onto its neighbour.
+- **A finding that re-litigates a settled thread is dropped** (inbox issue 06)
+  with `settled in thread: <author>`, regardless of whether it could be anchored
+  to a line. A resolved thread still settles its subject.
+- **A "this throws" finding that never names its containment boundary is
+  flagged inline** (inbox issue 07) with `[containment boundary not stated]`, so
+  a correct-but-underscoped finding cannot read as a smaller bug than it is.
+- **A model that reports itself permanently unavailable is skipped for the rest
+  of the run** (inbox issue 09) — deprovisioned, renamed, unsupported — instead
+  of being retried on every chunk and the sweep, with one warning the first time
+  it happens. Applies to both the openai-compat and litellm backends; only a 4xx
+  qualifies, never a 5xx.
 
 - **The sweep digest reaches the four classes the 2026-09-02 re-audit found
   missing (#29 residual, PR #38).** Migration-ddl-matched files render their

--- a/README.md
+++ b/README.md
@@ -49,6 +49,28 @@ prxref inspects pull and merge requests across the three major code hosting forg
                   └──────────────────────┘
 ```
 
+## Deterministic Quality Passes
+
+Every finding a worker returns runs the same deterministic passes before
+anything posts. A filtered finding is never discarded silently: it is kept
+with a `drop_reason` for the run log.
+
+| Pass | Drops findings that… |
+| --- | --- |
+| Location validation | name a file that is not in the diff (`malformed location`) |
+| Line alignment | cannot be anchored to a real added line of that file |
+| Thread dedup | duplicate an already-open thread on the PR |
+| Severity consistency | (rewrites only) disagree about the severity of one shared title |
+| Removal-claim check | claim a path was removed while it is still present in the post-image (`claims removal of a path present in the post-image: <path>`) |
+| Quality gate | use an invalid severity, fall below the confidence floor, or exceed the per-review error cap |
+| Sweep dedup | repeat a chunk finding the systemic sweep found again |
+
+The removal-claim check exists because a `copy from` / `copy to` diff header
+copies a file without touching its source. Diff sections are classified as
+`added`, `modified`, `removed`, `renamed`, or `copied`, and a `copied`
+section leaves its source file present — so a worker that reads the copy as
+a move and reports the source "deleted" is contradicted by the diff itself.
+
 ## Quickstart
 
 Run reviews instantly without local installation using `uvx`, or install the CLI globally:

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ The service exposes:
 - `--no-post` — dry run; run review analysis and quality passes without writing comments to the forge. In text mode this also prints every active finding's location, title, and body, and every dropped finding with its drop reason.
 - `--max-chunks N` — override maximum diff chunks evaluated (default `8`).
 - `-v, --verbose` — output run timing, token counts, and finding breakdowns to stdout; in text mode this also prints finding bodies and dropped findings, same as `--no-post`.
-- `--format {text,json}` — output format for `review` (default `text`). `json` prints exactly one JSON object to stdout — `verdict`, `findings` (active first, then dropped, each with `file`, `line`, `severity`, `confidence`, `title`, `body`, `drop_reason`), `chunk_count`, `chunks_reviewed`, `chunks_failed`, `elapsed_ms`, `input_tokens`, `output_tokens`, `posted` — and nothing else on stdout.
+- `--format {text,json}` — output format for `review` (default `text`). `json` prints exactly one JSON object to stdout — `verdict`, `findings` (active first, then dropped, each with `file`, `line`, `severity`, `confidence`, `title`, `body`, `drop_reason`), `chunk_count`, `chunks_reviewed`, `chunks_failed`, `elapsed_ms`, `input_tokens`, `output_tokens`, `posted`, and `sampling` (the `temperature`, `seed`, and `models` the run had in force — every review result carries it).
 
 ## Exit Codes
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Configure the authentication token matching your forge:
 | **GitHub Enterprise** | `PRXREF_GITHUB_ENTERPRISE_TOKEN` | Used when host is not `github.com` (falls back to `PRXREF_GITHUB_TOKEN`) |
 | **GitLab** | `PRXREF_GITLAB_TOKEN` | Personal, project, or group access token (`PRIVATE-TOKEN`) |
 
-See [docs/env-vars.md](docs/env-vars.md) for the full configuration reference and [docs/forges.md](docs/forges.md) for forge specifics.
+See [docs/env-vars.md](docs/env-vars.md) for the full configuration reference, [docs/forges.md](docs/forges.md) for forge specifics, and [docs/systemic-sweep.md](docs/systemic-sweep.md) for the whole-PR sweep's digest classes and drop reasons.
 
 ## Webhook Server
 

--- a/README.md
+++ b/README.md
@@ -142,9 +142,10 @@ The service exposes:
 ## CLI Flags
 
 - `--pr-url URL` — full web URL of the PR or MR (required for `review`).
-- `--no-post` — dry run; run review analysis and quality passes without writing comments to the forge.
+- `--no-post` — dry run; run review analysis and quality passes without writing comments to the forge. In text mode this also prints every active finding's location, title, and body, and every dropped finding with its drop reason.
 - `--max-chunks N` — override maximum diff chunks evaluated (default `8`).
-- `-v, --verbose` — output run timing, token counts, and finding breakdowns to stdout.
+- `-v, --verbose` — output run timing, token counts, and finding breakdowns to stdout; in text mode this also prints finding bodies and dropped findings, same as `--no-post`.
+- `--format {text,json}` — output format for `review` (default `text`). `json` prints exactly one JSON object to stdout — `verdict`, `findings` (active first, then dropped, each with `file`, `line`, `severity`, `confidence`, `title`, `body`, `drop_reason`), `chunk_count`, `chunks_reviewed`, `chunks_failed`, `elapsed_ms`, `input_tokens`, `output_tokens`, `posted` — and nothing else on stdout.
 
 ## Exit Codes
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Fast automated AI code review for Bitbucket, GitLab, and GitHub — Cloud and self-hosted.
 
-prxref inspects pull and merge requests across the three major code hosting forges in sub-minute review cycles. It parses unified diffs, partitions changes into risk-ranked chunks, fans out parallel single-shot LLM reviews across a cheap-first model fallback chain, filters findings through deterministic quality gates, and publishes inline comments alongside an executive summary.
+prxref inspects pull and merge requests across the three major code hosting forges in sub-minute review cycles. It parses unified diffs, partitions changes into risk-ranked chunks, gives each worker the dependency pins and out-of-hunk definitions its chunk references when the forge can serve file content, fans out parallel single-shot LLM reviews across a cheap-first model fallback chain, filters findings through deterministic quality gates, and publishes inline comments alongside an executive summary.
 
 ```
                   ┌──────────────────────┐

--- a/README.md
+++ b/README.md
@@ -49,27 +49,20 @@ prxref inspects pull and merge requests across the three major code hosting forg
                   └──────────────────────┘
 ```
 
-## Deterministic Quality Passes
+## Deterministic Checks and Quality Passes
 
-Every finding a worker returns runs the same deterministic passes before
-anything posts. A filtered finding is never discarded silently: it is kept
-with a `drop_reason` for the run log.
+Not every finding comes from a model, and no finding posts unfiltered. prxref
+computes one class of finding directly from the parsed diff — the
+release-shaped-PR check — and then runs every finding, model-authored or not,
+through eleven deterministic passes: location validation, `package.json` claim
+checks, line alignment, thread dedup, settled-thread suppression, severity
+consistency, the removal-claim check, the hedge gate, the quality gate, sweep
+dedup, and the containment note. A filtered finding is never discarded
+silently — it is kept with a `drop_reason` for the run log, and visible in a
+`--no-post` dry run or under `--format json`.
 
-| Pass | Drops findings that… |
-| --- | --- |
-| Location validation | name a file that is not in the diff (`malformed location`) |
-| Line alignment | cannot be anchored to a real added line of that file |
-| Thread dedup | duplicate an already-open thread on the PR |
-| Severity consistency | (rewrites only) disagree about the severity of one shared title |
-| Removal-claim check | claim a path was removed while it is still present in the post-image (`claims removal of a path present in the post-image: <path>`) |
-| Quality gate | use an invalid severity, fall below the confidence floor, or exceed the per-review error cap |
-| Sweep dedup | repeat a chunk finding the systemic sweep found again |
-
-The removal-claim check exists because a `copy from` / `copy to` diff header
-copies a file without touching its source. Diff sections are classified as
-`added`, `modified`, `removed`, `renamed`, or `copied`, and a `copied`
-section leaves its source file present — so a worker that reads the copy as
-a move and reports the source "deleted" is contradicted by the diff itself.
+The passes, the checks, every `drop_reason` string, and which of them have a
+knob: [docs/quality.md](docs/quality.md).
 
 ## Quickstart
 
@@ -135,10 +128,6 @@ Temperature `0.0` and an optional `PRXREF_LLM_SEED` are sent on every call, but 
 
 See [docs/llm.md](docs/llm.md) for architecture, failover behavior, and backend setup, and [docs/env-vars.md](docs/env-vars.md#tuning-for-your-team) for tuning the confidence floor and finding caps to your team.
 
-## Deterministic Checks
-
-Most findings come from the LLM fallback chain, but a few are computed directly from the parsed diff, no model call involved. **Release-shaped PRs**: when a PR changes at least 2 files and at least 80% of them are release machinery (version manifests, `CHANGELOG`/`HISTORY`/`RELEASE_NOTES` files, lockfiles, `.changeset/` entries, the release-please manifest), any remaining non-machinery file is flagged with a warning naming every offending path — the body ends with `(deterministic check, no model)` so it reads distinctly from an LLM finding in the posted summary. This catches a release cut from an unmerged branch or a hand edit smuggled into a release, the way issue #10 first surfaced it.
-
 ## Forge Authentication
 
 Configure the authentication token matching your forge:
@@ -153,7 +142,7 @@ Configure the authentication token matching your forge:
 | **GitHub Enterprise** | `PRXREF_GITHUB_ENTERPRISE_TOKEN` | Used when host is not `github.com` (falls back to `PRXREF_GITHUB_TOKEN`) |
 | **GitLab** | `PRXREF_GITLAB_TOKEN` | Personal, project, or group access token (`PRIVATE-TOKEN`) |
 
-See [docs/env-vars.md](docs/env-vars.md) for the full configuration reference, [docs/forges.md](docs/forges.md) for forge specifics, and [docs/systemic-sweep.md](docs/systemic-sweep.md) for the whole-PR sweep's digest classes and drop reasons.
+See [docs/env-vars.md](docs/env-vars.md) for the full configuration reference, [docs/forges.md](docs/forges.md) for forge specifics, [docs/quality.md](docs/quality.md) for the deterministic checks and every drop reason, and [docs/systemic-sweep.md](docs/systemic-sweep.md) for the whole-PR sweep's digest classes.
 
 ## Webhook Server
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ On a reasoning model the hidden reasoning trace draws from the **same** completi
 
 See [docs/llm.md](docs/llm.md) for architecture, failover behavior, and backend setup, and [docs/env-vars.md](docs/env-vars.md#tuning-for-your-team) for tuning the confidence floor and finding caps to your team.
 
+## Deterministic Checks
+
+Most findings come from the LLM fallback chain, but a few are computed directly from the parsed diff, no model call involved. **Release-shaped PRs**: when a PR changes at least 2 files and at least 80% of them are release machinery (version manifests, `CHANGELOG`/`HISTORY`/`RELEASE_NOTES` files, lockfiles, `.changeset/` entries, the release-please manifest), any remaining non-machinery file is flagged with a warning naming every offending path — the body ends with `(deterministic check, no model)` so it reads distinctly from an LLM finding in the posted summary. This catches a release cut from an unmerged branch or a hand edit smuggled into a release, the way issue #10 first surfaced it.
+
 ## Forge Authentication
 
 Configure the authentication token matching your forge:

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ export PRXREF_LLM_MODELS="openrouter/meta-llama/llama-3.3-70b-instruct,bedrock/a
 
 On a reasoning model the hidden reasoning trace draws from the **same** completion budget as the answer, so turning `PRXREF_LLM_REASONING_EFFORT` up makes truncation *more* likely. A truncated chunk is counted as failed and the posted summary names the reason and the variable to raise; see [Reasoning models and the token budget](docs/env-vars.md#reasoning-models-and-the-token-budget).
 
+Temperature `0.0` and an optional `PRXREF_LLM_SEED` are sent on every call, but neither makes a review bit-reproducible — provider fingerprints, load-balanced backends, and gateways that ignore `seed` all still vary the model's output. Everything downstream of the model is deterministic: findings are ordered by `(file, line, title)` and the caps break ties by content, and the run record's `sampling` field reports which knobs were in force. See [Determinism](docs/llm.md#determinism-what-is-pinned-and-what-still-varies).
+
 See [docs/llm.md](docs/llm.md) for architecture, failover behavior, and backend setup, and [docs/env-vars.md](docs/env-vars.md#tuning-for-your-team) for tuning the confidence floor and finding caps to your team.
 
 ## Forge Authentication

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -115,6 +115,8 @@ export PRXREF_MAX_ERROR_FINDINGS=10
 
 The trade-off is the whole difference: the advisory profile gives you the three findings most likely to be real, and the thorough profile gives you ten that might be. Raising the floor does not make the reviewer smarter — it just moves where the cut falls, and everything below the cut is dropped unseen. A team that ignores prxref's comments should raise the floor before turning it off; a team reviewing machine-written code should leave it where it ships.
 
+One filter has no knob and always runs: the **hedge gate**, immediately before the confidence floor. A finding whose own title or body conditions the defect on a precondition the model never established from the diff ("If X still leases a client", "Unless the backfill already ran", "if they are members of the root workspaces") is dropped regardless of its confidence, with `drop_reason` `hedged: "<matched phrase>"` in the run record, and never consumes an error-cap slot.
+
 Neither knob affects the exit code — `PRXREF_FAIL_ON` is the only one that can. See [Bad Configuration Is the Only Thing That Fails a Build](#bad-configuration-is-the-only-thing-that-fails-a-build).
 
 ## Environment Cross-Check & Defaults

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -117,6 +117,23 @@ The trade-off is the whole difference: the advisory profile gives you the three 
 
 Neither knob affects the exit code — `PRXREF_FAIL_ON` is the only one that can. See [Bad Configuration Is the Only Thing That Fails a Build](#bad-configuration-is-the-only-thing-that-fails-a-build).
 
+## Quality Passes and Drop Reasons
+
+Before anything is posted, every finding runs the deterministic passes in `src/prxref/quality.py`. A finding that fails one is never deleted — it keeps its identity and gains a `drop_reason`, so a run store or a `--no-post` dry run can explain every filter decision. The reasons you will see:
+
+| `drop_reason` | Pass | Meaning |
+| --- | --- | --- |
+| `malformed location: '<file>'` | `apply_location_validation` | The finding names a path the diff never touches. |
+| `anchor mismatch: claims <pkg> but line <n> is <key>` | `apply_manifest_claim_check` | A `package.json` finding names one dependency but is anchored on a different entry. |
+| `section mismatch: claims <section> but <pkg> is under <actual>` | `apply_manifest_claim_check` | A `package.json` finding calls an entry a runtime dependency when it lives under `devDependencies` (or vice versa). |
+| `duplicate of existing thread` | `apply_thread_dedup` | An open thread on the PR already says this. |
+| `duplicate of chunk finding` | `apply_sweep_dedup` | A whole-diff sweep finding restates a chunk finding that already survived. |
+| `invalid severity: '<sev>'` | `apply_quality_gate` | Severity outside {error, warning, outofscope}. |
+| `confidence <x> below floor <y>` | `apply_quality_gate` | Below `PRXREF_CONFIDENCE_FLOOR`. |
+| `error cap exceeded (max <n>)` | `apply_quality_gate` | Beyond `PRXREF_MAX_ERROR_FINDINGS`, lowest confidence first. |
+
+The two manifest reasons are not tunable — they are correctness checks against the diff itself, not a noise knob.
+
 ## Environment Cross-Check & Defaults
 
 The tables above define all **35** configuration keys in `src/prxref/config.py` (`_DEFAULTS`), and every one of them appears in `.env.example`:

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -121,20 +121,7 @@ Neither knob affects the exit code — `PRXREF_FAIL_ON` is the only one that can
 
 ## Quality Passes and Drop Reasons
 
-Before anything is posted, every finding runs the deterministic passes in `src/prxref/quality.py`. A finding that fails one is never deleted — it keeps its identity and gains a `drop_reason`, so a run store or a `--no-post` dry run can explain every filter decision. The reasons you will see:
-
-| `drop_reason` | Pass | Meaning |
-| --- | --- | --- |
-| `malformed location: '<file>'` | `apply_location_validation` | The finding names a path the diff never touches. |
-| `anchor mismatch: claims <pkg> but line <n> is <key>` | `apply_manifest_claim_check` | A `package.json` finding names one dependency but is anchored on a different entry. |
-| `section mismatch: claims <section> but <pkg> is under <actual>` | `apply_manifest_claim_check` | A `package.json` finding calls an entry a runtime dependency when it lives under `devDependencies` (or vice versa). |
-| `duplicate of existing thread` | `apply_thread_dedup` | An open thread on the PR already says this. |
-| `duplicate of chunk finding` | `apply_sweep_dedup` | A whole-diff sweep finding restates a chunk finding that already survived. |
-| `invalid severity: '<sev>'` | `apply_quality_gate` | Severity outside {error, warning, outofscope}. |
-| `confidence <x> below floor <y>` | `apply_quality_gate` | Below `PRXREF_CONFIDENCE_FLOOR`. |
-| `error cap exceeded (max <n>)` | `apply_quality_gate` | Beyond `PRXREF_MAX_ERROR_FINDINGS`, lowest confidence first. |
-
-The two manifest reasons are not tunable — they are correctness checks against the diff itself, not a noise knob.
+The two knobs above are the only configuration that touches the filtering. The eleven deterministic passes themselves, the release-shaped-PR check, and every `drop_reason` string they emit are documented in one place: **[docs/quality.md](quality.md)**. Everything on that page other than the confidence floor and the error cap is a correctness check against the diff itself, not a noise lever, and has no environment variable.
 
 ## Environment Cross-Check & Defaults
 

--- a/docs/forges.md
+++ b/docs/forges.md
@@ -30,6 +30,7 @@ Every host is covered, but not by the same means. GitHub and GitLab are host-agn
   - **Summary Comments:** `POST /2.0/repositories/{owner}/{repo}/pullrequests/{number}/comments` with `{"content": {"raw": body}}`, or `PUT .../comments/{id}` when a previous prxref summary is found. The comment feed is scanned for the summary marker first, so a re-review updates its own summary rather than adding another one; inline comments and tombstoned deletions are skipped as update targets.
   - **Inline Comments:** `POST /2.0/repositories/{owner}/{repo}/pullrequests/{number}/comments` with `inline.path` and `inline.to`. Non-fatal 4xx errors on individual inline comments are skipped.
   - **Thread List:** `GET /2.0/repositories/{owner}/{repo}/pullrequests/{number}/comments`, following the cursor until the feed is exhausted. A walk that stops early logs a warning naming the count rather than silently under-reporting.
+  - **File Content:** `GET /2.0/repositories/{owner}/{repo}/src/{sha}/{path}`, best-effort, read with the same token as everything else above (no extra scope beyond `pullrequest:write`/repository read). A 404, oversize, or binary body returns `None` and is logged at debug, never a hard error.
 - **Webhook Integration:**
   - **Event Header:** `X-Event-Key`
   - **Accepted Events:** `pullrequest:created`, `pullrequest:updated`
@@ -54,6 +55,7 @@ Every host is covered, but not by the same means. GitHub and GitLab are host-agn
   - **Summary Comments:** Managed on the issue comments endpoint (`/repos/{owner}/{repo}/issues/{number}/comments`). Summary deduplication is handled via the embedded hidden HTML marker `<!-- prxref-summary -->`. If an existing review comment contains this marker, it is updated via `PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}` instead of creating a duplicate comment.
   - **Inline Comments:** `POST /repos/{owner}/{repo}/pulls/{number}/comments` with `body`, `path`, `line`, and `side` (`RIGHT`). HTTP 422 errors (e.g. comment line not part of diff hunk) are gracefully skipped.
   - **Thread List:** `GET /repos/{owner}/{repo}/pulls/{number}/comments`.
+  - **File Content:** `GET /repos/{owner}/{repo}/contents/{path}?ref={sha}` with `Accept: application/vnd.github.raw+json`, best-effort, read with the same token as everything else above (no extra scope). A 403/404, a JSON body (directory or a file over the 1 MB raw ceiling), oversize, or binary body returns `None` and is logged at debug, never a hard error.
 - **Webhook Integration:**
   - **Event Header:** `X-GitHub-Event` (must equal `pull_request`)
   - **Accepted Actions:** `opened`, `synchronize`
@@ -76,6 +78,7 @@ Every host is covered, but not by the same means. GitHub and GitLab are host-agn
   - **Summary Comments:** Managed via `GET/POST/PUT /merge_requests/{number}/notes`. Searches for `<!-- prxref-summary -->` and updates existing note via `PUT` if found.
   - **Inline Comments:** Posted as discussions via `POST /merge_requests/{number}/discussions` with text position references (`base_sha`, `start_sha`, `head_sha`, `new_path`, `new_line`). If position anchoring fails with HTTP 400 (e.g. line outside diff or obsolete context), it automatically falls back to posting a plain note via `POST /merge_requests/{number}/notes` formatted with `file: {path}\n\n{body}`.
   - **Thread List:** `GET /merge_requests/{number}/discussions`.
+  - **File Content:** `GET /repository/files/{url_encoded_path}/raw?ref={sha}` (path percent-encoded including slashes), best-effort, read with the same `PRIVATE-TOKEN` as everything else above (no extra scope). A non-2xx, oversize, or binary body returns `None` and is logged at debug, never a hard error.
 - **Webhook Integration:**
   - **Event Header:** `X-Gitlab-Event` (normalized to `MergeRequestHook`)
   - **Accepted Actions:** `open`, `update`
@@ -145,6 +148,10 @@ paging rather than `page`/`pagelen`. It therefore gets its own adapter.
     re-review ends up posting a second one.
   - **Resolution:** read from whichever of `state == "RESOLVED"`, `threadResolved`, or
     `resolvedDate` the deployment's version exposes.
+  - **File Content:** `GET {scheme}://{host}{context}/rest/api/1.0/projects/{key}/repos/{slug}/raw/{path}?at={sha}`
+    (the `~{slug}` personal-repository form of `{key}` too), best-effort, read with the same
+    token as everything else above (no extra scope). A non-2xx, oversize, or binary body
+    returns `None` and is logged at debug, never a hard error.
 - **Webhook Integration:**
   - **Event Header:** `X-Event-Key` (shared with Cloud; the two are told apart by event
     name and payload shape)

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -58,6 +58,7 @@ The client iterates through `PRXREF_LLM_MODELS` in left-to-right priority order 
   - Malformed JSON response
 - On any failure, `OpenAICompatClient` logs the model error and tries the next model in the chain immediately.
 - If all configured models fail, `LLMError` is raised containing the per-model failure reasons.
+- A 4xx body that names a model as permanently gone (deprovisioned, renamed, not supported, or never enabled for this integrator) is cached for the life of the client: every later call skips that model outright — no request, no per-call log — with a single WARNING logged the one time it is marked. `LiteLLMClient` mirrors the same cache, keyed on the exception litellm raises (a 4xx-shaped error naming a model) instead of an HTTP status; it filters the unavailable model out of both the primary `model` and its native `fallbacks` before calling litellm, and raises `LLMError` without calling litellm at all once every configured model has been marked. A 5xx, a timeout, or a connection error is never cached — only a 4xx carrying that phrasing is treated as permanent.
 
 ---
 

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -81,3 +81,24 @@ PRXREF_LLM_MODELS=bedrock/anthropic.claude-3-7-sonnet-20250219-v1:0,vertex_ai/ge
 - The first model in `PRXREF_LLM_MODELS` is used as the primary model.
 - Remaining models in the list are passed to `litellm.completion` via the `fallbacks=` parameter.
 - `num_retries=0` is enforced to ensure immediate failover to backup models without blocking retries on failed endpoints.
+
+---
+
+## Determinism: what is pinned, and what still varies
+
+- `PRXREF_LLM_TEMPERATURE` defaults to `0.0`, and `0.0` is **sent** on the wire
+  rather than omitted.
+- `PRXREF_LLM_SEED` is sent whenever it is set, on both backends.
+- **Neither makes a review bit-reproducible.** Providers vary by system
+  fingerprint, load-balanced backends serve the same model from different
+  hardware, MoE routing shifts with batch composition, and many gateways accept
+  an unknown top-level `seed` and ignore it. Two identical runs may still return
+  different findings, and `prxref` cannot detect a gateway that dropped the seed.
+- The `sampling` field in the run record — `{"temperature", "seed", "models"}`,
+  present on every exit including a failed run — tells you which knobs were
+  actually in force for the run you are looking at.
+- What *is* deterministic is everything downstream of the model: findings are
+  ordered by `(file, line, title)`, and the error and inline-comment caps break
+  ties by finding content (confidence first, then file, line, and normalized
+  title), never by the order the workers happened to return in. The same
+  findings in any arrival order therefore produce the same review.

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -81,3 +81,20 @@ PRXREF_LLM_MODELS=bedrock/anthropic.claude-3-7-sonnet-20250219-v1:0,vertex_ai/ge
 - The first model in `PRXREF_LLM_MODELS` is used as the primary model.
 - Remaining models in the list are passed to `litellm.completion` via the `fallbacks=` parameter.
 - `num_retries=0` is enforced to ensure immediate failover to backup models without blocking retries on failed endpoints.
+
+---
+
+## Worker Prompt Context
+
+Each worker sees one chunk's unified diff, trimmed to `PRXREF_CHUNK_CONTEXT_LINES` lines around every change. Two optional blocks are appended after the diff to answer the questions the diff alone cannot.
+
+### Dependency versions and definitions
+
+- **`### Dependency versions`** — `name@version` for each third-party package the chunk's *added* lines import, resolved from the nearest manifest walking up from each changed file to the repository root: `package.json` (`dependencies` + `devDependencies`), `pyproject.toml` (`[project] dependencies` and `[tool.poetry.dependencies]`), `go.mod` `require` lines, and `Cargo.toml` `[dependencies]`. Only imported packages appear. Relative and `node:` specifiers, Python stdlib modules, and relative Python imports are excluded. Without this block a reviewer answers library semantics from whichever major dominates its training data.
+- **`### Definitions referenced by this chunk`** — for identifiers used on added lines whose definition sits in the same file but *outside* the rendered hunk, one `path:line: definition` entry each, taken from the file as served at the PR head. The entry is the defining line plus continuation lines up to a balanced bracket or 6 lines. Caps: at most 40 entries and 8000 characters, with a trailing `… N more definitions omitted` when trimmed; files over 512 KiB are skipped. Definitions the chunk itself adds are never repeated.
+
+Both blocks are **best effort**. They are built from an optional forge method, `get_file_content(ref, path, *, sha) -> str | None`, resolved with `getattr` and always called at the PR head sha (`pr.source_sha`). Every read is cached per run, so one manifest is fetched once no matter how many chunks want it, and any exception from the adapter degrades to no block. A forge that does not implement the method — and a PR with no head sha — reviews exactly as before, with no header and no extra requests. Nothing here can fail a review.
+
+The worker prompt also carries two confidence rules tied to these blocks: a finding that depends on third-party runtime semantics whose version is not listed, or on the semantics of a symbol whose definition is not shown, must cap confidence at 0.5 and be phrased as a question.
+
+On the timeout retry — the one deterministic re-run with `context_lines=0` — the dependency block is kept and the definitions block is dropped, because shrinking the prompt is the entire point of that retry.

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -22,6 +22,13 @@ from an unmerged branch, or a hand edit smuggled into a release.
 
 The finding is folded into the raw results **before** the passes below, so it
 is validated, aligned, deduplicated and gated exactly like a model finding.
+It is spliced in at the chunk/sweep boundary — before the systemic sweep's
+own findings, never after — so `apply_sweep_dedup` always treats it as a
+CHUNK-side finding and can never drop it as a duplicate of a chunk worker's
+own restatement of the same file and title. It also runs on a diff that
+yields zero chunks (every file binary, or an empty diff): the heuristic
+needs no chunk to fire on, so it is computed and gated on that path too,
+not only when at least one chunk survives `build_chunks`.
 
 ## The passes, in the order they run
 

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -1,0 +1,100 @@
+# Deterministic Checks, Quality Passes, and Drop Reasons
+
+Most findings come from the LLM fallback chain. Everything on this page is
+computed from the parsed diff and the PR's own discussion — no model call, no
+non-determinism, no knob unless one is named below.
+
+A finding that fails a pass is **never deleted silently**. It keeps its
+identity and gains a `drop_reason`, so a run store, a `--no-post` dry run, or
+`--format json` can explain every filter decision. `active(findings)` is the
+subset that actually posts.
+
+## Deterministic checks (findings prxref computes itself)
+
+**Release-shaped PRs.** When a PR changes at least 2 files and at least 80% of
+them are release machinery — version manifests, `CHANGELOG` / `HISTORY` /
+`RELEASE_NOTES` files, lockfiles, `.changeset/` entries, the release-please
+manifest — every remaining non-machinery file is flagged with a `warning`
+naming each offending path. The body ends with `(deterministic check, no
+model)` so it reads distinctly from an LLM finding in the posted summary. The
+ratio is exact rational arithmetic, never a float. This catches a release cut
+from an unmerged branch, or a hand edit smuggled into a release.
+
+The finding is folded into the raw results **before** the passes below, so it
+is validated, aligned, deduplicated and gated exactly like a model finding.
+
+## The passes, in the order they run
+
+`orchestrate_review` applies these in a fixed order; several of them depend on
+it (noted in the table).
+
+| # | Pass | What it does |
+|---|---|---|
+| 1 | `apply_location_validation` | Drops a finding whose `file` names no path of the parsed diff. |
+| 2 | `apply_manifest_claim_check` | `package.json` only. Runs **before** line align, deliberately, so it reads the model's raw anchor. |
+| 3 | `apply_line_align` | Re-anchors a cited line to a real added line of that file, or demotes it to file-level. |
+| 4 | `apply_thread_dedup` | Drops a finding an existing PR thread already makes (path + line window + shared distinctive tokens). |
+| 5 | `apply_settled_thread_suppression` | Drops a finding that re-litigates a subject a thread already argued out. Line-independent by design. |
+| 6 | `apply_severity_consistency` | Rewrites only: findings sharing a normalized title are all raised to the group's maximum severity. |
+| 7 | `apply_removal_claim_check` | Drops a claim that a **named** path was removed when the post-image still carries it. |
+| 8 | `apply_hedge_gate` | Drops a finding whose own text conditions the defect on a precondition never established from the diff. |
+| 9 | `apply_quality_gate` | Severity vocabulary, confidence floor, per-review error cap. Returns its findings in content order. |
+| 10 | `apply_sweep_dedup` | Drops a sweep finding that restates a chunk finding which **survived** the gate. |
+| 11 | `apply_containment_note` | Decoration only: suffixes a throw/panic/crash finding that never named its containment boundary. |
+
+Threads are fetched once per review, **before** the workers run and **after**
+the stale-inline-comment prune — reading threads first would let a run suppress
+its own findings against prxref's own stale comments and then delete them.
+
+## Drop reasons
+
+| `drop_reason` | Pass | Meaning |
+| --- | --- | --- |
+| `malformed location: '<file>'` | `apply_location_validation` | The finding names a path the diff never touches — empty, non-path, or invented. |
+| `anchor mismatch: claims <pkg> but line <n> is <key>` | `apply_manifest_claim_check` | A `package.json` finding names one dependency but is anchored on a different entry. |
+| `section mismatch: claims <section> but <pkg> is under <actual>` | `apply_manifest_claim_check` | A `package.json` finding calls an entry a runtime dependency when it lives under `devDependencies`, or the reverse. |
+| `duplicate of existing thread` | `apply_thread_dedup` | An open thread on the PR already says this. |
+| `settled in thread: <author>` | `apply_settled_thread_suppression` | A thread on the same path already argued this subject out. A **resolved** thread still settles it — resolution is a decision, not an expiry. |
+| `claims removal of a path present in the post-image: <path>` | `apply_removal_claim_check` | Every path the claim names is still present after the PR lands. |
+| `hedged: "<matched phrase>"` | `apply_hedge_gate` | The finding's own text conditions the defect on something the model never established. |
+| `invalid severity: '<sev>'` | `apply_quality_gate` | Severity outside {`error`, `warning`, `outofscope`}. |
+| `confidence <x> below floor <y>` | `apply_quality_gate` | Below `PRXREF_CONFIDENCE_FLOOR`. |
+| `error cap exceeded (max <n>)` | `apply_quality_gate` | Beyond `PRXREF_MAX_ERROR_FINDINGS`. Ties break on finding content, not arrival order, so the cap is reproducible. |
+| `duplicate of chunk finding` | `apply_sweep_dedup` | A whole-diff sweep finding restates a chunk finding that already survived the gate. |
+
+One more marker is **not** a drop reason. `apply_containment_note` appends
+`" [containment boundary not stated]"` to the body of a finding that asserts a
+throw, panic, crash, or unhandled rejection without naming the enclosing catch
+or the caller it propagates to. The finding still posts; the suffix stops a
+correct-but-underscoped "this throws" from reading as a smaller bug than it is.
+It runs last, so the posted comment and the dropped-audit copy carry the same
+text.
+
+## What is and is not tunable
+
+- `PRXREF_CONFIDENCE_FLOOR` and `PRXREF_MAX_ERROR_FINDINGS` are the only knobs
+  here, and they only move `apply_quality_gate`. See
+  [Tuning for Your Team](env-vars.md#tuning-for-your-team).
+- The hedge gate, the manifest checks, and the removal-claim check have **no
+  knob**. They are correctness checks against the diff itself, not noise
+  levers. A hedged finding is unverified by its own admission; the escape hatch
+  is at the prompt level, where the worker is told to file such a thing as a
+  question at confidence ≤ 0.5 and let the floor handle it.
+- A hedged finding never consumes an error-cap slot ahead of a proven one.
+
+## File statuses
+
+Diff sections are classified `added`, `modified`, `removed`, `renamed`, or
+`copied`. A `copied` section — a git `copy from` / `copy to` header, or the
+Bitbucket Server `src://` / `dst://` form — leaves its **source file present**,
+which is why `apply_removal_claim_check` exists: a worker that reads the copy as
+a move and reports the source "deleted" is contradicted by the diff itself. The
+copy headers are rendered back into the worker prompt so the model can tell a
+copy from a move in the first place.
+
+## See also
+
+- [docs/systemic-sweep.md](systemic-sweep.md) — the whole-PR sweep's digest
+  classes, its existing-discussion block, and its caps.
+- [docs/llm.md](llm.md) — the worker prompt's context blocks, failover, and
+  what determinism does and does not buy you.

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -43,7 +43,7 @@ it (noted in the table).
 | 4 | `apply_thread_dedup` | Drops a finding an existing PR thread already makes (path + line window + shared distinctive tokens). |
 | 5 | `apply_settled_thread_suppression` | Drops a finding that re-litigates a subject a thread already argued out. Line-independent by design. |
 | 6 | `apply_severity_consistency` | Rewrites only: findings sharing a normalized title are all raised to the group's maximum severity. |
-| 7 | `apply_removal_claim_check` | Drops a claim that a **named** path was removed when the post-image still carries it. |
+| 7 | `apply_removal_claim_check` | Drops a claim that a **named** path was removed when the post-image still carries it. The removal verb must **govern** that path (`removed src/app.py`, `src/app.py was removed`); a bare "removed" elsewhere in the body is not a removal claim. |
 | 8 | `apply_hedge_gate` | Drops a finding whose own text conditions the defect on a precondition never established from the diff. |
 | 9 | `apply_quality_gate` | Severity vocabulary, confidence floor, per-review error cap. Returns its findings in content order. |
 | 10 | `apply_sweep_dedup` | Drops a sweep finding that restates a chunk finding which **survived** the gate. |
@@ -62,7 +62,7 @@ its own findings against prxref's own stale comments and then delete them.
 | `section mismatch: claims <section> but <pkg> is under <actual>` | `apply_manifest_claim_check` | A `package.json` finding calls an entry a runtime dependency when it lives under `devDependencies`, or the reverse. |
 | `duplicate of existing thread` | `apply_thread_dedup` | An open thread on the PR already says this. |
 | `settled in thread: <author>` | `apply_settled_thread_suppression` | A thread on the same path already argued this subject out. A **resolved** thread still settles it — resolution is a decision, not an expiry. |
-| `claims removal of a path present in the post-image: <path>` | `apply_removal_claim_check` | Every path the claim names is still present after the PR lands. |
+| `claims removal of a path present in the post-image: <path>` | `apply_removal_claim_check` | A removal verb governs this path, and every path the claim names is still present after the PR lands. |
 | `hedged: "<matched phrase>"` | `apply_hedge_gate` | The finding's own text conditions the defect on something the model never established. |
 | `invalid severity: '<sev>'` | `apply_quality_gate` | Severity outside {`error`, `warning`, `outofscope`}. |
 | `confidence <x> below floor <y>` | `apply_quality_gate` | Below `PRXREF_CONFIDENCE_FLOOR`. |

--- a/docs/systemic-sweep.md
+++ b/docs/systemic-sweep.md
@@ -1,0 +1,68 @@
+# The systemic sweep
+
+Per-chunk workers each see one slice of the diff, so a defect that only looks
+wrong in aggregate has no seat that sees enough to name it. The sweep spends
+ONE extra single-shot review call over a deterministic digest of the whole PR
+(`prxref/systemic.py`), then feeds its findings into the same quality passes as
+every chunk finding.
+
+## Digest classes
+
+`match_class(text, *, kind="+")` labels one diff line with the first class it
+matches, in this order. `kind` is the line's diff marker; only
+`guard-removal` reads it.
+
+| Class | Fires on | Kind |
+|---|---|---|
+| `entry-point` | exported/handler functions, route and AJAX registrations | any |
+| `secret` | `process.env`, `VITE_*`, `NEXT_PUBLIC_*`, `*_API_KEY`, `*SECRET*`, `*TOKEN*` | any |
+| `auth-check` | nonce / JWT / bearer / `verify_*` / `authenticate` | any |
+| `guard-removal` | a DELETED numeric limit constant (`MAX_*_LENGTH`, `*_SIZE`, `*_BYTES`, `*_TIMEOUT`, `*_CAP`, `*_LIMIT`) or a DELETED validator definition (`is*`, `isValid*`, `validate*`, `sanitize*`, `check*`, `assert*`, `escape*`, `guard*`) | `-` only |
+| `error-swallow` | `catch`/`except`/`finally`, empty `.catch()` | any |
+| `migration-ddl` | `CREATE TABLE`, `ALTER TABLE`, RLS statements | any |
+| `console-log` | `console.*`, `logger.*`, `logging.*` | any |
+| `loop-timer` | `setInterval`, `setTimeout`, `while (true)` | any |
+| `repo-config` | a `packageManager` pin | any |
+
+`guard-removal` is removal-only by design: the same text ADDED is a guard being
+put in place, which is not a finding. It sits in `_MUST_SEE_CLASSES` alongside
+entry points, secrets and auth checks, so it survives the per-file matched-line
+cap ahead of noisier classes; and because a removed line only reaches the digest
+when it carries a class, a PR that deletes nothing but guards is no longer
+digested as an empty file. Removed lines render with their `-` marker and their
+OLD-file line number (`-2| const MAX_TOOL_NAME_LENGTH = 128;`).
+
+## Existing discussion
+
+Threads already open on the PR are fetched once, before the review units are
+dispatched, and the ones whose path is in the digest are appended to the sweep's
+user prompt as an `### Existing discussion` block — one
+`- <path>: <author>: <snippet>` line per thread. Snippets are truncated to 200
+characters and the block is capped at 15 threads / 1200 characters (roughly 300
+tokens against a sweep input of 1878–3585), with a final
+`… N more threads omitted` line when the cap bites. With no threads, no header
+is printed at all. The prompt tells the model not to raise a subject already
+argued out there, and to say why the discussion's conclusion is wrong if it
+raises it anyway.
+
+The fetch is best-effort: a forge that cannot list threads still gets a full
+review, with an empty discussion block. It is deliberately ordered AFTER the
+stale-inline-comment prune, or the run would suppress its own findings against
+comments it is about to delete.
+
+## Drop reasons
+
+Every dropped finding keeps its identity and states why:
+
+| Reason | Pass |
+|---|---|
+| `malformed location: '<file>'` | `apply_location_validation` |
+| `duplicate of existing thread` | `apply_thread_dedup` — same path, line window, shared tokens |
+| `settled in thread: <author>` | `apply_settled_thread_suppression` — same path and 4+ shared tokens, NO line test |
+| `severity '<x>' not in vocabulary` / confidence floor / error cap | `apply_quality_gate` |
+| duplicate of a chunk finding | `apply_sweep_dedup` |
+
+`settled in thread` is line-independent on purpose: `apply_line_align` has
+already demoted a file-level finding to line 0 by the time it runs, so a
+distance test could never fire. A resolved thread still settles its subject —
+resolution is a decision, not an expiry.

--- a/docs/systemic-sweep.md
+++ b/docs/systemic-sweep.md
@@ -52,15 +52,14 @@ comments it is about to delete.
 
 ## Drop reasons
 
-Every dropped finding keeps its identity and states why:
-
-| Reason | Pass |
-|---|---|
-| `malformed location: '<file>'` | `apply_location_validation` |
-| `duplicate of existing thread` | `apply_thread_dedup` — same path, line window, shared tokens |
-| `settled in thread: <author>` | `apply_settled_thread_suppression` — same path and 4+ shared tokens, NO line test |
-| `severity '<x>' not in vocabulary` / confidence floor / error cap | `apply_quality_gate` |
-| duplicate of a chunk finding | `apply_sweep_dedup` |
+A sweep finding runs the same deterministic passes as a chunk finding, and
+every `drop_reason` string is tabulated in
+[docs/quality.md](quality.md#drop-reasons). Two of them matter most here:
+`settled in thread: <author>` (`apply_settled_thread_suppression` — same path
+and 4+ shared tokens, with no line test) and `duplicate of chunk finding`
+(`apply_sweep_dedup`, which runs after the quality gate so a sub-floor chunk
+finding cannot suppress its higher-confidence sweep duplicate and then die at
+the gate itself).
 
 `settled in thread` is line-independent on purpose: `apply_line_align` has
 already demoted a file-level finding to line 0 by the time it runs, so a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prxref"
-version = "0.11.1"
+version = "0.12.0"
 description = "Fast automated AI code review for Bitbucket, GitLab, and GitHub"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/prxref/__init__.py
+++ b/src/prxref/__init__.py
@@ -1,3 +1,3 @@
 """prxref — fast automated AI code review for Bitbucket, GitLab, and GitHub."""
 
-__version__ = "0.11.1"
+__version__ = "0.12.0"

--- a/src/prxref/chunk_context.py
+++ b/src/prxref/chunk_context.py
@@ -1,0 +1,447 @@
+"""Extra prompt context for one worker chunk: dependency pins and definitions.
+
+Two blocks answer the two questions a diff-only prompt cannot: which VERSION of
+a third-party library the changed code runs against, and what a referenced
+identifier actually IS when its definition sits outside the rendered hunk.
+
+The module is pure. It performs no I/O of its own: every caller passes a
+``read(path) -> str | None`` callable that resolves a repository-relative path
+at the PR head, and a read that fails is simply a read that returned ``None``.
+Everything here degrades to an empty block rather than raising, because a
+review must never fail over missing context.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+import tomllib
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass
+
+# Caps are constants, not configuration: they bound prompt growth, and an
+# operator who wants a different prompt shape has no lever here worth exposing.
+MAX_DEFINITION_ENTRIES = 40
+MAX_LINES_PER_DEFINITION = 6
+MAX_DEFINITION_CHARS = 8000
+MAX_FILE_BYTES = 512 * 1024
+
+DEPENDENCY_HEADER = "### Dependency versions"
+DEFINITIONS_HEADER = "### Definitions referenced by this chunk"
+
+_JS_SUFFIXES = (".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".mts", ".cts")
+
+_JS_KEYWORDS = frozenset({
+    "abstract", "any", "as", "async", "await", "boolean", "break", "case",
+    "catch", "class", "const", "constructor", "continue", "debugger",
+    "declare", "default", "delete", "do", "else", "enum", "export", "extends",
+    "false", "finally", "for", "from", "function", "get", "if", "implements",
+    "import", "in", "infer", "instanceof", "interface", "is", "keyof", "let",
+    "n", "namespace", "never", "new", "null", "number", "object", "of",
+    "package", "private", "protected", "public", "readonly", "require",
+    "return", "satisfies", "set", "static", "string", "super", "switch",
+    "symbol", "this", "throw", "true", "try", "type", "typeof", "undefined",
+    "union", "unknown", "var", "void", "while", "with", "yield",
+})
+
+_PY_KEYWORDS = frozenset({
+    "and", "as", "assert", "async", "await", "break", "class", "continue",
+    "def", "del", "elif", "else", "except", "False", "finally", "for", "from",
+    "global", "if", "import", "in", "is", "lambda", "None", "nonlocal", "not",
+    "or", "pass", "raise", "return", "self", "True", "try", "while", "with",
+    "yield", "int", "str", "float", "bool", "list", "dict", "set", "tuple",
+    "print", "len", "range", "type", "object",
+})
+
+_IDENT_RE = re.compile(r"[A-Za-z_$][A-Za-z0-9_$]*")
+
+_JS_FROM_RE = re.compile(r"""\bfrom\s+['"]([^'"]+)['"]""")
+_JS_BARE_IMPORT_RE = re.compile(r"""^\s*import\s+['"]([^'"]+)['"]""")
+_JS_REQUIRE_RE = re.compile(r"""\brequire\(\s*['"]([^'"]+)['"]\s*\)""")
+_JS_DYNAMIC_IMPORT_RE = re.compile(r"""\bimport\(\s*['"]([^'"]+)['"]\s*\)""")
+
+_PY_IMPORT_RE = re.compile(r"^\s*import\s+([A-Za-z_][\w.]*(?:\s*,\s*[A-Za-z_][\w.]*)*)")
+_PY_FROM_RE = re.compile(r"^\s*from\s+([A-Za-z_][\w.]*)\s+import\b")
+
+_RUST_USE_RE = re.compile(r"^\s*use\s+([A-Za-z_][A-Za-z0-9_]*)\s*::")
+_RUST_INTERNAL = frozenset({"crate", "self", "super", "std", "core", "alloc"})
+
+_JS_DEF_RE = re.compile(
+    r"^\s*(?:export\s+)?(?:default\s+)?"
+    r"(?:async\s+function|function|const|let|var|class|type|interface|enum)"
+    r"\s+([A-Za-z_$][A-Za-z0-9_$]*)"
+)
+_PY_DEF_RE = re.compile(r"^\s*(?:async\s+)?(?:def|class)\s+([A-Za-z_][A-Za-z0-9_]*)")
+_PY_ASSIGN_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)\s*(?::[^=]+)?=(?!=)")
+
+_MANIFESTS = {
+    "js": "package.json",
+    "python": "pyproject.toml",
+    "go": "go.mod",
+    "rust": "Cargo.toml",
+}
+
+
+@dataclass(frozen=True)
+class ChunkFile:
+    """One changed file reduced to what prompt context needs.
+
+    ``added`` holds the TEXT of the chunk's ``+`` lines; ``hunk_lines`` holds
+    every new-file line number the chunk's hunks cover, so a definition inside
+    a rendered hunk is never repeated as out-of-hunk context.
+    """
+
+    path: str
+    added: tuple[str, ...] = ()
+    hunk_lines: frozenset[int] = frozenset()
+
+
+def chunk_files(chunk: Iterable[object]) -> list[ChunkFile]:
+    """Reduce a chunk of ``triage.FileDiff`` records to :class:`ChunkFile`.
+
+    Duck-typed on ``path`` / ``hunks`` / ``lines`` so the pure functions below
+    stay independent of the parser's dataclasses, and so unit tests can build
+    :class:`ChunkFile` values directly.
+    """
+    out: list[ChunkFile] = []
+    for f in chunk:
+        path = getattr(f, "path", "") or ""
+        if not path:
+            continue
+        added: list[str] = []
+        covered: set[int] = set()
+        for hunk in getattr(f, "hunks", None) or []:
+            for line in getattr(hunk, "lines", None) or []:
+                kind = getattr(line, "kind", " ")
+                new_line = getattr(line, "new_line", None)
+                if new_line is not None:
+                    covered.add(new_line)
+                if kind == "+":
+                    added.append(getattr(line, "text", ""))
+        out.append(ChunkFile(path=path, added=tuple(added), hunk_lines=frozenset(covered)))
+    return out
+
+
+def _language(path: str) -> str:
+    lower = path.lower()
+    if lower.endswith(_JS_SUFFIXES):
+        return "js"
+    if lower.endswith((".py", ".pyi")):
+        return "python"
+    if lower.endswith(".go"):
+        return "go"
+    if lower.endswith(".rs"):
+        return "rust"
+    return ""
+
+
+def _js_package(specifier: str) -> str:
+    if not specifier or specifier.startswith((".", "/")) or ":" in specifier:
+        return ""
+    parts = specifier.split("/")
+    if specifier.startswith("@"):
+        return "/".join(parts[:2]) if len(parts) >= 2 else ""
+    return parts[0]
+
+
+def imported_packages(path: str, added: Sequence[str]) -> set[str]:
+    """External package names imported by a file's added lines.
+
+    Relative and ``node:`` specifiers, Python stdlib modules, and relative
+    Python imports are excluded. Go and Rust are best effort: Go returns
+    nothing (its import paths are module paths, not package names), Rust
+    returns the crate root of an external ``use name::…``.
+    """
+    language = _language(path)
+    names: set[str] = set()
+    if language == "js":
+        for text in added:
+            for regex in (
+                _JS_FROM_RE, _JS_BARE_IMPORT_RE, _JS_REQUIRE_RE, _JS_DYNAMIC_IMPORT_RE,
+            ):
+                for spec in regex.findall(text):
+                    name = _js_package(spec)
+                    if name:
+                        names.add(name)
+    elif language == "python":
+        stdlib = getattr(sys, "stdlib_module_names", frozenset())
+        for text in added:
+            candidates: list[str] = []
+            match = _PY_FROM_RE.match(text)
+            if match:
+                candidates.append(match.group(1))
+            else:
+                match = _PY_IMPORT_RE.match(text)
+                if match:
+                    candidates.extend(p.strip() for p in match.group(1).split(","))
+            for candidate in candidates:
+                top = candidate.split(".")[0]
+                if top and top not in stdlib:
+                    names.add(top)
+    elif language == "rust":
+        for text in added:
+            match = _RUST_USE_RE.match(text)
+            if match and match.group(1) not in _RUST_INTERNAL:
+                names.add(match.group(1))
+    return names
+
+
+def _ancestor_dirs(path: str) -> list[str]:
+    parts = path.split("/")[:-1]
+    dirs = []
+    while parts:
+        dirs.append("/".join(parts))
+        parts = parts[:-1]
+    dirs.append("")
+    return dirs
+
+
+def _nearest_manifest(path: str, manifest: str, read) -> str | None:
+    for directory in _ancestor_dirs(path):
+        candidate = f"{directory}/{manifest}" if directory else manifest
+        text = read(candidate)
+        if text:
+            return text
+    return None
+
+
+def _parse_package_json(text: str) -> dict[str, str]:
+    data = json.loads(text)
+    out: dict[str, str] = {}
+    for section in ("dependencies", "devDependencies"):
+        block = data.get(section)
+        if isinstance(block, dict):
+            for name, version in block.items():
+                if isinstance(name, str) and isinstance(version, str):
+                    out.setdefault(name, version)
+    return out
+
+
+_PEP508_NAME_RE = re.compile(r"^\s*([A-Za-z0-9._-]+)\s*(\[[^\]]*\])?\s*(.*)$")
+
+
+def _parse_pyproject(text: str) -> dict[str, str]:
+    data = tomllib.loads(text)
+    out: dict[str, str] = {}
+    project = data.get("project")
+    if isinstance(project, dict):
+        for spec in project.get("dependencies") or []:
+            if not isinstance(spec, str):
+                continue
+            match = _PEP508_NAME_RE.match(spec.split(";")[0])
+            if match:
+                out.setdefault(match.group(1), (match.group(3) or "*").strip() or "*")
+    poetry = (data.get("tool") or {}).get("poetry") if isinstance(data.get("tool"), dict) else None
+    if isinstance(poetry, dict):
+        block = poetry.get("dependencies")
+        if isinstance(block, dict):
+            for name, version in block.items():
+                if not isinstance(name, str):
+                    continue
+                if isinstance(version, str):
+                    out.setdefault(name, version)
+                elif isinstance(version, dict) and isinstance(version.get("version"), str):
+                    out.setdefault(name, version["version"])
+    return out
+
+
+_GO_REQUIRE_RE = re.compile(r"^\s*(?:require\s+)?([^\s]+)\s+(v[^\s/]+)")
+
+
+def _parse_go_mod(text: str) -> dict[str, str]:
+    out: dict[str, str] = {}
+    in_block = False
+    for raw in text.splitlines():
+        line = raw.split("//")[0].strip()
+        if not line:
+            continue
+        if line.startswith("require (") or (in_block is False and line == "require ("):
+            in_block = True
+            continue
+        if in_block and line == ")":
+            in_block = False
+            continue
+        if not in_block and not line.startswith("require "):
+            continue
+        match = _GO_REQUIRE_RE.match(line)
+        if match:
+            out.setdefault(match.group(1), match.group(2))
+    return out
+
+
+def _parse_cargo_toml(text: str) -> dict[str, str]:
+    data = tomllib.loads(text)
+    out: dict[str, str] = {}
+    for section in ("dependencies", "dev-dependencies"):
+        block = data.get(section)
+        if not isinstance(block, dict):
+            continue
+        for name, version in block.items():
+            if not isinstance(name, str):
+                continue
+            if isinstance(version, str):
+                out.setdefault(name, version)
+            elif isinstance(version, dict) and isinstance(version.get("version"), str):
+                out.setdefault(name, version["version"])
+    return out
+
+
+_PARSERS = {
+    "js": _parse_package_json,
+    "python": _parse_pyproject,
+    "go": _parse_go_mod,
+    "rust": _parse_cargo_toml,
+}
+
+
+def _normalized(name: str) -> str:
+    return name.replace("-", "_").lower()
+
+
+def dependency_versions(
+    files: Sequence[ChunkFile],
+    read: Callable[[str], str | None],
+) -> list[str]:
+    """``name@version`` lines for the third-party packages this chunk imports.
+
+    For each changed file the nearest manifest — ``package.json``,
+    ``pyproject.toml``, ``go.mod`` or ``Cargo.toml`` — is located by walking up
+    from the file's directory to the repository root via ``read``. Only
+    packages actually imported on the chunk's added lines are reported. The
+    result is sorted and deduplicated; an unreadable or unparseable manifest
+    contributes nothing.
+    """
+    lines: set[str] = set()
+    for entry in files:
+        language = _language(entry.path)
+        manifest = _MANIFESTS.get(language)
+        if not manifest:
+            continue
+        wanted = imported_packages(entry.path, entry.added)
+        if not wanted:
+            continue
+        text = _nearest_manifest(entry.path, manifest, read)
+        if not text:
+            continue
+        try:
+            pins = _PARSERS[language](text)
+        except Exception:  # noqa: BLE001 - a broken manifest is not a review failure
+            continue
+        lookup = {_normalized(name): (name, version) for name, version in pins.items()}
+        for name in wanted:
+            hit = lookup.get(_normalized(name))
+            if hit:
+                lines.add(f"{hit[0]}@{hit[1]}")
+    return sorted(lines)
+
+
+def _definition_regexes(language: str) -> tuple[re.Pattern[str], ...]:
+    if language == "js":
+        return (_JS_DEF_RE,)
+    if language == "python":
+        return (_PY_DEF_RE, _PY_ASSIGN_RE)
+    return ()
+
+
+def _keywords(language: str) -> frozenset[str]:
+    if language == "python":
+        return _PY_KEYWORDS
+    return _JS_KEYWORDS
+
+
+def _entry_text(lines: Sequence[str], index: int, max_lines: int) -> str:
+    first = lines[index]
+    depth = sum(first.count(c) for c in "([{") - sum(first.count(c) for c in ")]}")
+    out = [first.rstrip()]
+    cursor = index + 1
+    while depth > 0 and len(out) < max_lines and cursor < len(lines):
+        nxt = lines[cursor]
+        depth += sum(nxt.count(c) for c in "([{") - sum(nxt.count(c) for c in ")]}")
+        out.append(nxt.rstrip())
+        cursor += 1
+    return "\n".join(out)
+
+
+def referenced_definitions(
+    chunk_files: Sequence[ChunkFile],
+    read: Callable[[str], str | None],
+    *,
+    max_entries: int = MAX_DEFINITION_ENTRIES,
+    max_lines_per_entry: int = MAX_LINES_PER_DEFINITION,
+    max_chars: int = MAX_DEFINITION_CHARS,
+) -> list[str]:
+    """``<path>:<line>: <definition>`` lines for symbols the chunk references.
+
+    An identifier used on an added line, not defined inside the chunk's own
+    hunks, and defined elsewhere in the SAME served file yields one entry: the
+    defining line plus continuation lines up to a balanced bracket or
+    ``max_lines_per_entry``. Order is deterministic (path, then line). Files
+    larger than 512 KiB are skipped. When the entry or character cap trims the
+    list, a final ``… N more definitions omitted`` line says so.
+    """
+    collected: list[tuple[str, int, str]] = []
+    for entry in chunk_files:
+        language = _language(entry.path)
+        regexes = _definition_regexes(language)
+        if not regexes:
+            continue
+        content = read(entry.path)
+        if not content or len(content.encode("utf-8", "ignore")) > MAX_FILE_BYTES:
+            continue
+        keywords = _keywords(language)
+        referenced = {
+            name
+            for text in entry.added
+            for name in _IDENT_RE.findall(text)
+            if name not in keywords
+        }
+        for text in entry.added:
+            for regex in regexes:
+                match = regex.match(text)
+                if match:
+                    referenced.discard(match.group(1))
+        if not referenced:
+            continue
+        lines = content.splitlines()
+        seen: set[str] = set()
+        for idx, text in enumerate(lines):
+            number = idx + 1
+            if number in entry.hunk_lines:
+                continue
+            for regex in regexes:
+                match = regex.match(text)
+                if not match:
+                    continue
+                name = match.group(1)
+                if name in referenced and name not in seen:
+                    seen.add(name)
+                    collected.append(
+                        (entry.path, number, _entry_text(lines, idx, max_lines_per_entry))
+                    )
+                break
+
+    collected.sort(key=lambda item: (item[0], item[1]))
+    out: list[str] = []
+    used = 0
+    for path, number, text in collected:
+        rendered = f"{path}:{number}: {text}"
+        if len(out) >= max_entries or used + len(rendered) > max_chars:
+            out.append(f"… {len(collected) - len(out)} more definitions omitted")
+            break
+        out.append(rendered)
+        used += len(rendered)
+    return out
+
+
+def render_context_blocks(dep_lines: Sequence[str], def_lines: Sequence[str]) -> str:
+    """Render the two prompt blocks, omitting each when it has no lines.
+
+    Returns the empty string when both are empty, so the prompt slot leaves no
+    stray header behind.
+    """
+    blocks: list[str] = []
+    if dep_lines:
+        blocks.append(DEPENDENCY_HEADER + "\n\n" + "\n".join(dep_lines))
+    if def_lines:
+        blocks.append(DEFINITIONS_HEADER + "\n\n" + "\n".join(def_lines))
+    return "\n\n".join(blocks)

--- a/src/prxref/cli.py
+++ b/src/prxref/cli.py
@@ -26,11 +26,17 @@ has no exit code and is unaffected by the knob.
 ``PRXREF_DRY_RUN=1`` suppresses every write to the forge on both paths — the
 one-shot review and the webhook daemon — and ``--no-post`` does the same for a
 single invocation.
+
+``--format {text,json}`` controls ``review``'s stdout shape. ``json`` (default
+``text``) emits exactly one JSON object and nothing else on stdout. In text
+mode, ``--no-post`` or ``-v`` additionally prints every active finding's
+location, title, and body, followed by any dropped findings and their reason.
 """
 from __future__ import annotations
 
 import argparse
 import importlib
+import json
 import logging
 import sys
 import time
@@ -83,6 +89,15 @@ def _build_parser() -> argparse.ArgumentParser:
         "--verbose",
         action="store_true",
         help="print timing, token, and findings breakdown to stdout",
+    )
+    rev.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help=(
+            "output format for review results (default text); json emits "
+            "exactly one JSON object on stdout"
+        ),
     )
 
     srv = sub.add_parser("serve", help="run webhook listener daemon")
@@ -156,6 +171,98 @@ def _print_summary(
     dropped = len(dropped) if isinstance(dropped, list) else 0
     print(f"counts: {_fmt_counts(result)} (dropped: {dropped})", file=target)
     print(f"elapsed: {elapsed_s:.1f}s tokens: {_fmt_tokens(result)}", file=target)
+
+
+def _fmt_finding_line(f: Any) -> str:
+    """Render one active finding as ``<severity> <file>:<line> <title> (confidence 0.NN)``."""
+    severity = getattr(f, "severity", None) or ""
+    location = f"{getattr(f, 'file', '')}:{getattr(f, 'line', 0)}"
+    title = getattr(f, "title", None) or ""
+    confidence = getattr(f, "confidence", None) or 0.0
+    return f"{severity} {location} {title} (confidence {confidence:.2f})"
+
+
+def _fmt_indented_body(body: str) -> str:
+    """Indent every line of a finding's body by two spaces."""
+    return "\n".join(f"  {line}" for line in (body or "").splitlines())
+
+
+def _fmt_dropped_line(f: Any) -> str:
+    """Render one dropped finding as ``  <file>:<line> <title> -- <drop_reason>``."""
+    location = f"{getattr(f, 'file', '')}:{getattr(f, 'line', 0)}"
+    title = getattr(f, "title", None) or ""
+    reason = getattr(f, "drop_reason", None) or ""
+    return f"  {location} {title} -- {reason}"
+
+
+def _print_findings(result: Any, *, out=None) -> None:
+    """Print each active finding's body, then any dropped findings and why.
+
+    Text-mode only, gated by the caller on ``--no-post`` or ``-v``: the
+    frozen CLI contract (issue 08) makes finding bodies reachable from stdout
+    without importing ``prxref.cli._run_review`` directly.
+    """
+    target = sys.stdout if out is None else out
+    if not isinstance(result, dict):
+        return
+    for f in result.get("findings_active") or []:
+        print(_fmt_finding_line(f), file=target)
+        body = _fmt_indented_body(getattr(f, "body", None))
+        if body:
+            print(body, file=target)
+    dropped = result.get("findings_dropped") or []
+    if dropped:
+        print("dropped:", file=target)
+        for f in dropped:
+            print(_fmt_dropped_line(f), file=target)
+
+
+def _finding_json(f: Any, *, drop_reason: str | None) -> dict:
+    """Build one JSON finding row explicitly (``Finding`` is a dataclass, not
+    JSON-serializable by default)."""
+    return {
+        "file": f.file,
+        "line": f.line,
+        "severity": f.severity,
+        "confidence": f.confidence,
+        "title": f.title,
+        "body": f.body,
+        "drop_reason": drop_reason,
+    }
+
+
+def _build_json_result(result: Any) -> dict:
+    """Build the single JSON payload for ``--format json``.
+
+    Tolerates an error-shaped or partial result (a dict missing keys, as an
+    incomplete or failed run may return): every key defaults to ``None`` and
+    ``findings`` defaults to ``[]`` rather than raising. ``sampling`` is
+    forwarded only when the result already carries it — a sibling feature's
+    key, not one this CLI invents.
+    """
+    if not isinstance(result, dict):
+        result = {}
+    findings = [
+        _finding_json(f, drop_reason=None) for f in result.get("findings_active") or []
+    ]
+    findings.extend(
+        _finding_json(f, drop_reason=getattr(f, "drop_reason", None))
+        for f in result.get("findings_dropped") or []
+    )
+    payload = {
+        "verdict": result.get("verdict"),
+        "findings": findings,
+        "chunk_count": result.get("chunk_count"),
+        "chunks_reviewed": result.get("chunks_reviewed"),
+        "chunks_failed": result.get("chunks_failed"),
+        "elapsed_ms": result.get("elapsed_ms"),
+        "input_tokens": result.get("input_tokens"),
+        "output_tokens": result.get("output_tokens"),
+        "posted": result.get("posted"),
+    }
+    if "sampling" in result:
+        payload["sampling"] = result["sampling"]
+    return payload
 
 
 def _run_review(
@@ -306,7 +413,12 @@ def _cmd_review(args: argparse.Namespace) -> int:
         return 0
 
     elapsed = time.perf_counter() - t0
-    _print_summary(result, elapsed, verbose=args.verbose)
+    if args.format == "json":
+        print(json.dumps(_build_json_result(result)))
+    else:
+        _print_summary(result, elapsed, verbose=args.verbose)
+        if args.no_post or args.verbose:
+            _print_findings(result)
     code, note = _fail_on_exit(result, fail_on)
     if note:
         print(note, file=sys.stderr)

--- a/src/prxref/forges/base.py
+++ b/src/prxref/forges/base.py
@@ -137,6 +137,16 @@ class Forge(Protocol):
         """List existing threads so re-reviews skip already-discussed findings."""
         ...
 
+    def get_file_content(self, ref: PRRef, path: str, *, sha: str) -> str | None:
+        """Return the text of ``path`` at commit ``sha``.
+
+        Optional: callers resolve it with ``getattr(forge, "get_file_content",
+        None)``, so a Forge without it is still valid. Return ``None`` when
+        the file is missing, binary, too large, or cannot be fetched for any
+        other reason — this method never raises.
+        """
+        ...
+
 
 def detect_forge(url: str) -> PRRef | None:
     """Try each registered forge's URL parser in order.

--- a/src/prxref/forges/bitbucket.py
+++ b/src/prxref/forges/bitbucket.py
@@ -5,7 +5,7 @@ import logging
 import os
 import re
 from collections.abc import Iterator, Sequence
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -30,6 +30,10 @@ _PAGE_SIZE = 100
 # 500 comments. 50 puts the ceiling far past any real PR, and running out of
 # budget is now a refusal to post rather than an invisible short read.
 _MAX_PAGES = 50
+# get_file_content is best-effort context, not the review itself: a body past
+# this size (or one that looks binary) is worth skipping rather than shipping
+# hundreds of KB into a worker prompt.
+_MAX_FILE_CONTENT_BYTES = 512 * 1024
 
 _BB_URL_RE = re.compile(
     r"^https?://bitbucket\.org/(?P<owner>[^/]+)/(?P<repo>[^/]+)/(?:pull-requests|pullrequests|pullrequest)/(?P<number>\d+)(?:/.*)?$",
@@ -379,6 +383,41 @@ class ForgeImpl:
             )
 
         return threads
+
+    def get_file_content(self, ref: PRRef, path: str, *, sha: str) -> str | None:
+        """Return the text of ``path`` at commit ``sha``, best-effort.
+
+        Hits the repository-level ``/src`` endpoint directly rather than a
+        pull-request-scoped one — this is a commit-addressed file read, not a
+        PR resource. Never raises.
+        """
+        if not sha:
+            return None
+        headers, auth = self._get_auth()
+        url = (
+            f"{_API_BASE}/repositories/{ref.owner}/{ref.repo}/src/{sha}/"
+            f"{quote(path, safe='/')}"
+        )
+        try:
+            resp = self._session.get(
+                url, headers=headers, auth=auth, timeout=_REQUEST_TIMEOUT
+            )
+        except requests.RequestException as e:
+            logger.debug("get_file_content failed for %s@%s: %s", path, sha, e)
+            return None
+        if not resp.ok:
+            logger.debug(
+                "get_file_content got HTTP %s for %s@%s", resp.status_code, path, sha
+            )
+            return None
+        content = resp.content
+        if len(content) > _MAX_FILE_CONTENT_BYTES:
+            logger.debug("get_file_content body over 512 KiB for %s@%s", path, sha)
+            return None
+        if b"\x00" in content:
+            logger.debug("get_file_content body looked binary for %s@%s", path, sha)
+            return None
+        return content.decode("utf-8", errors="replace")
 
 
 def _is_deleted(comment: dict) -> bool:

--- a/src/prxref/forges/bitbucket_server.py
+++ b/src/prxref/forges/bitbucket_server.py
@@ -5,7 +5,7 @@ import logging
 import os
 import re
 from collections.abc import Iterator, Sequence
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -40,6 +40,11 @@ _BBS_URL_RE = re.compile(
     r"/pull-requests/(?P<number>\d+)(?:/.*)?$",
     re.IGNORECASE,
 )
+
+# get_file_content is best-effort context, not the review itself: a body past
+# this size (or one that looks binary) is worth skipping rather than shipping
+# hundreds of KB into a worker prompt.
+_MAX_FILE_CONTENT_BYTES = 512 * 1024
 
 # Data Center serves its REST API at /rest/api/<version> — 1.0 today, plus the
 # /latest alias — hanging directly off any deployment context path. A PR's REST
@@ -481,6 +486,45 @@ class ForgeImpl:
             )
 
         return threads
+
+    def get_file_content(self, ref: PRRef, path: str, *, sha: str) -> str | None:
+        """Return the text of ``path`` at commit ``sha``, best-effort.
+
+        Hits the repository-level ``/raw`` endpoint directly rather than a
+        pull-request-scoped one — this is a commit-addressed file read, not a
+        PR resource. ``ref.owner`` already carries the ``~slug`` form for a
+        personal repository, so this builds the same project path
+        ``_pr_url`` does. Never raises.
+        """
+        if not sha:
+            return None
+        headers, auth = self._get_auth()
+        context = self._context_path(ref)
+        url = (
+            f"{self._scheme(ref)}://{ref.host}{context}/rest/api/1.0"
+            f"/projects/{ref.owner}/repos/{ref.repo}/raw/{quote(path, safe='/')}"
+        )
+        try:
+            resp = self._session.get(
+                url, headers=headers, auth=auth, params={"at": sha},
+                timeout=_REQUEST_TIMEOUT,
+            )
+        except requests.RequestException as e:
+            logger.debug("get_file_content failed for %s@%s: %s", path, sha, e)
+            return None
+        if not resp.ok:
+            logger.debug(
+                "get_file_content got HTTP %s for %s@%s", resp.status_code, path, sha
+            )
+            return None
+        content = resp.content
+        if len(content) > _MAX_FILE_CONTENT_BYTES:
+            logger.debug("get_file_content body over 512 KiB for %s@%s", path, sha)
+            return None
+        if b"\x00" in content:
+            logger.debug("get_file_content body looked binary for %s@%s", path, sha)
+            return None
+        return content.decode("utf-8", errors="replace")
 
 
 def _is_resolved(comment: dict) -> bool:

--- a/src/prxref/forges/github.py
+++ b/src/prxref/forges/github.py
@@ -6,6 +6,7 @@ import os
 import re
 from collections.abc import Iterator, Sequence
 from typing import Any
+from urllib.parse import quote
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -40,6 +41,10 @@ _MAX_PAGES = 50
 # it is still bounded: GitHub's validation errors enumerate every unmatched
 # subschema and run long enough to bury the log line that carries them.
 _ERROR_DETAIL_CHARS = 400
+# get_file_content is best-effort context, not the review itself: a body past
+# this size (or one that looks binary) is worth skipping rather than shipping
+# hundreds of KB into a worker prompt.
+_MAX_FILE_CONTENT_BYTES = 512 * 1024
 
 
 def _response_detail(resp: requests.Response) -> str:
@@ -334,6 +339,47 @@ class ForgeImpl:
             )
 
         return threads
+
+    def get_file_content(self, ref: PRRef, path: str, *, sha: str) -> str | None:
+        """Return the text of ``path`` at commit ``sha``, best-effort.
+
+        Requests the raw media type so a 2xx response is the file's bytes
+        rather than a base64-wrapped JSON envelope. A JSON body coming back
+        anyway means the raw Accept was not honoured, or ``path`` names a
+        directory or a file over GitHub's 1 MB raw-content ceiling — both
+        read as "no content" here. Never raises.
+        """
+        if not sha:
+            return None
+        url = (
+            f"{self._api_base(ref)}/repos/{ref.owner}/{ref.repo}/contents/"
+            f"{quote(path, safe='/')}"
+        )
+        headers = self._headers(ref.host, {"Accept": "application/vnd.github.raw+json"})
+        try:
+            resp = self.session.get(url, headers=headers, params={"ref": sha})
+        except requests.RequestException as e:
+            logger.debug("get_file_content failed for %s@%s: %s", path, sha, e)
+            return None
+        if not resp.ok:
+            logger.debug(
+                "get_file_content got HTTP %s for %s@%s", resp.status_code, path, sha
+            )
+            return None
+        if "json" in resp.headers.get("Content-Type", "").lower():
+            logger.debug(
+                "get_file_content got a JSON body for %s@%s (raw Accept not "
+                "honoured, a directory, or over the 1 MB ceiling)", path, sha,
+            )
+            return None
+        content = resp.content
+        if len(content) > _MAX_FILE_CONTENT_BYTES:
+            logger.debug("get_file_content body over 512 KiB for %s@%s", path, sha)
+            return None
+        if b"\x00" in content:
+            logger.debug("get_file_content body looked binary for %s@%s", path, sha)
+            return None
+        return content.decode("utf-8", errors="replace")
 
     def prune_inline_comments(self, ref: PRRef) -> int:
         """Delete prxref-attributed inline comments; returns the count removed.

--- a/src/prxref/forges/gitlab.py
+++ b/src/prxref/forges/gitlab.py
@@ -36,6 +36,10 @@ _MAX_PAGES = 50
 # page requests shifts every later window back by one. Ascending order appends
 # at the END, past the cursor, so a walk in progress cannot step over anything.
 _NOTE_ORDER = {"order_by": "created_at", "sort": "asc"}
+# get_file_content is best-effort context, not the review itself: a body past
+# this size (or one that looks binary) is worth skipping rather than shipping
+# hundreds of KB into a worker prompt.
+_MAX_FILE_CONTENT_BYTES = 512 * 1024
 
 _GL_URL_RE = re.compile(
     r"^https?://(?P<host>[^/]+)/(?P<path>.+?)/-/merge_requests/(?P<number>\d+)(?:/.*)?$",
@@ -482,3 +486,36 @@ class ForgeImpl:
             )
 
         return threads
+
+    def get_file_content(self, ref: PRRef, path: str, *, sha: str) -> str | None:
+        """Return the text of ``path`` at commit ``sha``, best-effort.
+
+        The path is percent-encoded including its slashes, the same
+        double-encoding GitLab's repository files API requires everywhere
+        else a file path is a URL segment. Never raises.
+        """
+        if not sha:
+            return None
+        headers = self._get_auth_headers()
+        base = self._api_base(ref)
+        url = f"{base}/repository/files/{quote(path, safe='')}/raw"
+        try:
+            resp = self._session.get(
+                url, headers=headers, params={"ref": sha}, timeout=_REQUEST_TIMEOUT
+            )
+        except requests.RequestException as e:
+            logger.debug("get_file_content failed for %s@%s: %s", path, sha, e)
+            return None
+        if not resp.ok:
+            logger.debug(
+                "get_file_content got HTTP %s for %s@%s", resp.status_code, path, sha
+            )
+            return None
+        content = resp.content
+        if len(content) > _MAX_FILE_CONTENT_BYTES:
+            logger.debug("get_file_content body over 512 KiB for %s@%s", path, sha)
+            return None
+        if b"\x00" in content:
+            logger.debug("get_file_content body looked binary for %s@%s", path, sha)
+            return None
+        return content.decode("utf-8", errors="replace")

--- a/src/prxref/formatter.py
+++ b/src/prxref/formatter.py
@@ -76,6 +76,7 @@ def _findings_table(findings: list[Finding]) -> str:
             -f.confidence,
             f.file,
             f.line,
+            f.title,
         ),
     )
     rows = [
@@ -97,7 +98,8 @@ def _dropped_section(findings_dropped: list[Finding]) -> str:
         return ""
     tally = Counter(f.drop_reason or "unspecified" for f in findings_dropped)
     tally_lines = "\n".join(
-        f"- {count} × {reason}" for reason, count in tally.most_common()
+        f"- {count} × {reason}"
+        for reason, count in sorted(tally.items(), key=lambda kv: (-kv[1], kv[0]))
     )
     return (
         "<details>\n"

--- a/src/prxref/heuristics.py
+++ b/src/prxref/heuristics.py
@@ -1,0 +1,130 @@
+"""Deterministic, non-LLM heuristics that manufacture Findings directly.
+
+Every other Finding producer in the pipeline (a chunk worker, the systemic
+sweep) is an LLM call whose output the quality passes filter or rewrite —
+none of them originates a Finding on its own. A heuristic here is the
+opposite: pure, computed once over the parsed diff's ``FileDiff`` list, no
+model in the loop, so its output can be concatenated onto the LLM-sourced
+findings list before the quality passes run and survive them the same way a
+model finding would.
+"""
+from __future__ import annotations
+
+from pathlib import PurePosixPath
+
+from .triage import FileDiff, Finding
+
+# Release-machinery basenames that are unambiguous on their own: version
+# manifests, a bare VERSION file, Python's convention-named version modules,
+# and the release-please manifest. Case-sensitive — real ecosystem tooling
+# (npm, cargo, setuptools, release-please) always emits these exact names.
+_MACHINERY_BASENAMES = frozenset({
+    "package.json",
+    "pyproject.toml",
+    "Cargo.toml",
+    "setup.py",
+    "setup.cfg",
+    "VERSION",
+    "version.py",
+    "__version__.py",
+    ".release-please-manifest.json",
+})
+
+# Lockfiles across ecosystems. This list is this module's own — it does not
+# import ``systemic._LOCKFILE_BASENAMES``, which is npm-family only and
+# private to that module — but is kept consistent with it on the basenames
+# they share (package-lock.json, npm-shrinkwrap.json, pnpm-lock.yaml,
+# yarn.lock, bun.lockb, bun.lock).
+_LOCKFILE_BASENAMES = frozenset({
+    "package-lock.json",
+    "npm-shrinkwrap.json",
+    "pnpm-lock.yaml",
+    "yarn.lock",
+    "bun.lockb",
+    "bun.lock",
+    "uv.lock",
+    "poetry.lock",
+    "Pipfile.lock",
+    "Cargo.lock",
+    "Gemfile.lock",
+    "go.sum",
+    "composer.lock",
+})
+
+# Case-insensitive basename prefixes: CHANGELOG.md, changelog.rst,
+# HISTORY.txt, RELEASE_NOTES.md all match regardless of extension or case.
+_PREFIX_BASENAMES = ("changelog", "history", "release_notes")
+
+# The release-shaped ratio bar, 80%, held as an exact rational (4/5) rather
+# than a float: the boundary is checked by cross-multiplication
+# (``machinery * _RATIO_DEN >= total * _RATIO_NUM``) so no floating-point
+# representation can nudge a file set across or off the line.
+_RATIO_NUM = 4
+_RATIO_DEN = 5
+
+# A PR must touch at least this many files to be release-shaped at all — a
+# single-file diff is never release-shaped regardless of ratio.
+_MIN_FILES_FOR_SHAPE = 2
+
+_BODY_SUFFIX = " (deterministic check, no model)"
+
+
+def _is_release_machinery(path: str) -> bool:
+    """True when ``path`` is release machinery under the frozen contract.
+
+    Matching is basename-only, with one exception: any path with a
+    ``.changeset`` directory component is machinery regardless of its own
+    filename, since a changeset's filename is arbitrary (commonly a random
+    two-word slug) and only its parent directory identifies it.
+    """
+    parts = PurePosixPath(path).parts
+    if ".changeset" in parts[:-1]:
+        return True
+    basename = parts[-1] if parts else path
+    if basename in _MACHINERY_BASENAMES or basename in _LOCKFILE_BASENAMES:
+        return True
+    if basename.endswith(".gemspec"):
+        return True
+    lower = basename.lower()
+    return any(lower.startswith(prefix) for prefix in _PREFIX_BASENAMES)
+
+
+def release_shape_findings(files: list[FileDiff]) -> list[Finding]:
+    """Flag a release-shaped PR that also touches non-machinery source.
+
+    A PR is release-shaped when it changes at least two files
+    (:data:`_MIN_FILES_FOR_SHAPE`) and at least 80% of them
+    (:data:`_RATIO_NUM` / :data:`_RATIO_DEN`, an exact rational comparison —
+    no float) are release machinery: version manifests, changelogs,
+    lockfiles, ``.changeset/`` entries, and the release-please manifest.
+    Removed files count toward the total like any other changed file.
+
+    When a release-shaped PR also changes one or more non-machinery files,
+    returns exactly one file-level (``line=0``) warning naming every
+    offending path — sorted, anchored on the first — with a body listing
+    each offending path and ending with " (deterministic check, no
+    model)". Otherwise returns ``[]``. Pure and deterministic: no LLM call,
+    no I/O, no randomness.
+    """
+    total = len(files)
+    if total < _MIN_FILES_FOR_SHAPE:
+        return []
+
+    offenders = sorted(f.path for f in files if not _is_release_machinery(f.path))
+    machinery = total - len(offenders)
+
+    if machinery * _RATIO_DEN < total * _RATIO_NUM:
+        return []
+    if not offenders:
+        return []
+
+    body = "\n".join(offenders) + _BODY_SUFFIX
+    finding = Finding(
+        file=offenders[0],
+        line=0,
+        severity="warning",
+        confidence=1.0,
+        title=f"Release-shaped PR touches source: {len(offenders)} non-release file(s)",
+        body=body,
+    )
+    return [finding]

--- a/src/prxref/llm_backends.py
+++ b/src/prxref/llm_backends.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import logging
 import math
 import os
+import threading
 import time
 
 import requests
@@ -53,10 +54,66 @@ _READ_CHUNK_BYTES = 8192
 # truncated answer is a 200, so it must be caught HERE for the chain to
 # advance — the reviewer only sees what survives the chain.
 _TRUNCATION_FINISH_REASONS = frozenset({"length", "max_tokens"})
+# A model that answers 4xx with one of these phrases is gone for the rest of
+# the run, not merely rate-limited or transiently unhappy — deprovisioned,
+# renamed, or never enabled for this integrator. Shared by both backends so a
+# deprovisioned model reads identically whichever client hits it.
+_UNAVAILABLE_PHRASES = (
+    "not available",
+    "not supported",
+    "does not exist",
+    "model_not_found",
+    "unknown model",
+    "no such model",
+    "deprecated",
+)
 
 
 class LLMError(Exception):
     """Every model in the fallback chain failed; the message carries per-model reasons."""
+
+
+def _looks_permanently_unavailable(text: str) -> bool:
+    """Case-insensitive match of ``text`` against the unavailable-phrase vocabulary."""
+    lowered = text.lower()
+    return any(phrase in lowered for phrase in _UNAVAILABLE_PHRASES)
+
+
+def _openai_error_message(resp: requests.Response) -> str:
+    """Best-effort extraction of a 4xx body's error text for phrase matching.
+
+    Prefers the OpenAI-style ``error.message``, falls back to a string
+    ``error`` field, and finally the raw response text when the body does
+    not parse as JSON or carries neither shape.
+    """
+    try:
+        body = resp.json()
+    except ValueError:
+        return getattr(resp, "text", "") or ""
+    if isinstance(body, dict):
+        error = body.get("error")
+        if isinstance(error, dict):
+            message = error.get("message")
+            if isinstance(message, str):
+                return message
+        elif isinstance(error, str):
+            return error
+    return getattr(resp, "text", "") or ""
+
+
+def _mark_unavailable(model: str, unavailable: set[str], lock: threading.Lock) -> bool:
+    """Add ``model`` to ``unavailable`` under ``lock``; ``True`` only for the adding thread.
+
+    Guards the once-per-model "skipping for the rest of the run" WARNING
+    against a race: both backends run on one client instance shared across a
+    ``ThreadPoolExecutor``, so two chunk workers can observe the same
+    not-yet-marked model at the same moment.
+    """
+    with lock:
+        if model in unavailable:
+            return False
+        unavailable.add(model)
+        return True
 
 
 class OpenAICompatClient(LLMClient):
@@ -79,6 +136,10 @@ class OpenAICompatClient(LLMClient):
     and passes a seed only when one is configured. The choice's
     ``finish_reason`` is carried through verbatim so the reviewer can name
     truncation as the cause of an unparseable response.
+    A model whose 4xx body names it as permanently gone (deprovisioned,
+    renamed, never enabled) is cached in-memory for the client's lifetime:
+    every later ``invoke()`` skips it outright — no request, no log — and
+    the one time it is marked, a single WARNING records why.
     """
 
     def __init__(
@@ -102,6 +163,13 @@ class OpenAICompatClient(LLMClient):
         self.reasoning_effort = reasoning_effort or None
         self.temperature = temperature
         self.seed = seed
+        # Run-lifetime memory of models a 4xx body named as permanently gone
+        # (deprovisioned, renamed, never enabled) so a chunk fan-out backed by
+        # one shared client stops re-trying and re-logging a dead model on
+        # every chunk plus the sweep. The lock guards concurrent workers
+        # racing to be the one that logs the once-per-model WARNING.
+        self._unavailable: set[str] = set()
+        self._unavailable_lock = threading.Lock()
 
     def _post_within_deadline(
         self,
@@ -182,6 +250,9 @@ class OpenAICompatClient(LLMClient):
         failures: list[str] = []
         last_truncated: InvokeResult | None = None
         for attempt, model in enumerate(self.models, start=1):
+            if model in self._unavailable:
+                failures.append(f"{model}: skipped (unavailable)")
+                continue
             t0 = time.perf_counter()
             logger.info(
                 "llm attempt %d/%d: model=%s deadline=%.0fs",
@@ -217,6 +288,15 @@ class OpenAICompatClient(LLMClient):
                     attempt, len(self.models), model, resp.status_code, elapsed_ms,
                 )
                 failures.append(f"{model}: HTTP {resp.status_code}")
+                if 400 <= resp.status_code < 500:
+                    message = _openai_error_message(resp)
+                    if _looks_permanently_unavailable(message):
+                        if _mark_unavailable(model, self._unavailable, self._unavailable_lock):
+                            logger.warning(
+                                "model=%s marked unavailable (%s), skipping for the rest of "
+                                "the run",
+                                model, message,
+                            )
                 continue
             try:
                 body = resp.json()
@@ -296,6 +376,12 @@ class LiteLLMClient(LLMClient):
     ``""``. ``temperature`` and ``seed`` are omitted entirely when ``None``,
     never defaulted; the factory resolves temperature's configured default
     of 0.0 before this client is built.
+    A model litellm reports as permanently gone (a 4xx-shaped exception
+    naming it deprovisioned, renamed, or never enabled) is cached in-memory
+    for the client's lifetime, mirroring :class:`OpenAICompatClient`: it is
+    filtered out of both ``model`` and ``fallbacks`` on every later
+    ``invoke()``, and if every configured model is unavailable, ``invoke()``
+    raises :class:`LLMError` without calling litellm at all.
     """
 
     def __init__(
@@ -319,6 +405,10 @@ class LiteLLMClient(LLMClient):
         self.temperature = temperature
         self.seed = seed
         self._completion = litellm.completion
+        # Same run-lifetime memory as OpenAICompatClient (see its __init__),
+        # keyed on litellm's own exception shape instead of a status code.
+        self._unavailable: set[str] = set()
+        self._unavailable_lock = threading.Lock()
 
     def invoke(
         self,
@@ -329,10 +419,21 @@ class LiteLLMClient(LLMClient):
         json_mode: bool = False,
         timeout_s: float | None = None,
     ) -> InvokeResult:
-        """One litellm.completion call with the native fallback chain attached."""
+        """One litellm.completion call with the native fallback chain attached.
+
+        Models already marked unavailable are filtered out of both ``model``
+        and ``fallbacks`` before the call; if none are left, ``invoke()``
+        raises :class:`LLMError` without calling litellm.
+        """
         request_timeout = self.default_timeout if timeout_s is None else timeout_s
+        available = [m for m in self.models if m not in self._unavailable]
+        if not available:
+            raise LLMError(
+                "all models failed: "
+                + "; ".join(f"{m}: skipped (unavailable)" for m in self.models)
+            )
         kwargs: dict = {
-            "model": self.models[0],
+            "model": available[0],
             "messages": [
                 {"role": "system", "content": system},
                 {"role": "user", "content": user},
@@ -340,7 +441,7 @@ class LiteLLMClient(LLMClient):
             "max_tokens": max_tokens,
             "num_retries": 0,
             "timeout": request_timeout,
-            "fallbacks": self.models[1:],
+            "fallbacks": available[1:],
         }
         if json_mode:
             kwargs["response_format"] = {"type": "json_object"}
@@ -349,7 +450,11 @@ class LiteLLMClient(LLMClient):
         if self.seed is not None:
             kwargs["seed"] = self.seed
         t0 = time.perf_counter()
-        response = self._completion(**kwargs)
+        try:
+            response = self._completion(**kwargs)
+        except Exception as exc:
+            self._maybe_mark_unavailable(exc, kwargs["model"], available)
+            raise
         elapsed_ms = int((time.perf_counter() - t0) * 1000)
         choice = response.choices[0]
         text = choice.message.content or ""
@@ -358,12 +463,53 @@ class LiteLLMClient(LLMClient):
             text=text,
             input_tokens=getattr(usage, "prompt_tokens", 0) if usage else 0,
             output_tokens=getattr(usage, "completion_tokens", 0) if usage else 0,
-            model=getattr(response, "model", "") or self.models[0],
+            model=getattr(response, "model", "") or available[0],
             backend="litellm",
             elapsed_ms=elapsed_ms,
             # Absent on a provider that does not report one; never guessed.
             finish_reason=str(getattr(choice, "finish_reason", "") or ""),
         )
+
+    def _maybe_mark_unavailable(
+        self, exc: Exception, requested_model: str, available: list[str]
+    ) -> None:
+        """Cache ``requested_model`` (or the exception's own ``.model``) on a permanent 4xx.
+
+        litellm's own ``BadRequestError``/``NotFoundError`` usually carry a
+        ``.model`` naming which candidate in the internal fallback chain
+        actually failed; when that is missing or not one of the models this
+        call attempted, the model requested as primary is the best guess.
+        """
+        if not _litellm_error_signals_unavailable(exc):
+            return
+        failed_model = getattr(exc, "model", None)
+        if not isinstance(failed_model, str) or failed_model not in available:
+            failed_model = requested_model
+        if _mark_unavailable(failed_model, self._unavailable, self._unavailable_lock):
+            logger.warning(
+                "model=%s marked unavailable, skipping for the rest of the run",
+                failed_model,
+            )
+
+
+def _litellm_error_signals_unavailable(exc: Exception) -> bool:
+    """True when a raised litellm exception names a model as permanently gone.
+
+    Requires both a phrase match (the shared unavailable vocabulary, checked
+    against ``str(exc)`` and a ``.message`` attribute when litellm sets one)
+    AND a 4xx signal — litellm does not always set ``.status_code``, so the
+    exception class naming ``BadRequest``/``NotFound`` is the fallback
+    signal. A transient error (timeout, connection error, 5xx) must never be
+    cached, so both checks are required, not either.
+    """
+    text = " ".join(filter(None, [str(exc), str(getattr(exc, "message", "") or "")]))
+    if not _looks_permanently_unavailable(text):
+        return False
+    status_code = getattr(exc, "status_code", None)
+    if isinstance(status_code, int) and 400 <= status_code < 500:
+        return True
+    class_name = exc.__class__.__name__
+    return "BadRequest" in class_name or "NotFound" in class_name
 
 
 def _float_setting(

--- a/src/prxref/orchestrator.py
+++ b/src/prxref/orchestrator.py
@@ -88,6 +88,7 @@ from .quality import (
     apply_line_align,
     apply_location_validation,
     apply_quality_gate,
+    apply_removal_claim_check,
     apply_severity_consistency,
     apply_sweep_dedup,
     apply_thread_dedup,
@@ -465,6 +466,7 @@ def orchestrate_review(
             rewrites,
         )
     findings = consistent
+    findings = apply_removal_claim_check(findings, files)
     findings = apply_quality_gate(
         findings, confidence_floor=confidence_floor, max_errors=max_errors,
     )

--- a/src/prxref/orchestrator.py
+++ b/src/prxref/orchestrator.py
@@ -3,8 +3,12 @@
 Stage order (v1 — no Jira, no graph, no learnings, no investigator):
 
 1. ``forge.get_pr`` → PRData, ``forge.get_diff`` → raw diff,
-   ``parse_unified_diff`` → files. An empty or unchunkable diff
-   short-circuits to a summary-only run with verdict ``Approved``.
+   ``parse_unified_diff`` → files. An empty or unchunkable diff (every file
+   binary, or no files at all) short-circuits to a summary-only run with
+   verdict ``Approved`` — no chunk worker or sweep ever runs, but
+   ``heuristics.release_shape_findings`` still does, gated the same as on
+   the normal path, so a release-shaped diff with no reviewable text still
+   gets its deterministic finding instead of a silent approval.
 2. ``build_chunks`` risk-ranked chunking (≤ ``max_chunks``, each chunk
    sized to ``token_budget`` and capped at ``max_files_per_chunk`` files).
 3. Parallel worker fan-out: one ``reviewer.review_chunk(llm, files, pr)``
@@ -31,7 +35,11 @@ Stage order (v1 — no Jira, no graph, no learnings, no investigator):
    raw chunk + sweep findings first gain
    ``heuristics.release_shape_findings(files)`` (a pure, no-LLM finding
    about a PR that is ≥80% release machinery yet also touches source),
-   folded in BEFORE the passes so it is filtered like any other finding:
+   folded in BEFORE the passes so it is filtered like any other finding,
+   and spliced in at the chunk/sweep boundary — before the sweep's own
+   findings, never after — so it is always a CHUNK-side finding to
+   ``apply_sweep_dedup`` and can never be dropped as a duplicate of a
+   chunk worker's own restatement:
 
    ``apply_location_validation`` (a ``file`` naming no path of the parsed
    diff is dropped, not rendered) → ``apply_manifest_claim_check`` (a
@@ -420,11 +428,18 @@ def orchestrate_review(
         )
 
     if not chunks:
-        tracer.event("run", "ok", chunks_reviewed=0, findings=0)
+        # No chunk survived build_chunks — an empty diff, or every file
+        # binary — but the release-shape heuristic is pure and needs no
+        # chunk to fire on: computed here so a release PR whose only
+        # non-machinery file is binary still gets the deterministic finding
+        # instead of a silent Approved (issue #29 residual, concern #2).
+        release_shape = heuristics.release_shape_findings(files)
+        tracer.event("run", "ok", chunks_reviewed=0, findings=len(release_shape))
         return _summary_only_run(
             forge, ref, pr, files, post, t0,
             post_mode=post_mode, post_verdict=post_verdict, tracer=tracer,
-            sampling=sampling,
+            sampling=sampling, release_shape_findings=release_shape,
+            confidence_floor=confidence_floor, max_errors=max_errors,
         )
 
     # Pruned BEFORE the threads are listed, and both before the review units
@@ -509,8 +524,17 @@ def orchestrate_review(
     # A deterministic, non-LLM finding folded in before the quality passes so
     # it flows through every one of them exactly like a model finding (issue
     # #10): file-level (line=0) survives apply_line_align untouched, and
-    # warning/1.0 clears apply_quality_gate trivially.
-    findings = findings + heuristics.release_shape_findings(files)
+    # warning/1.0 clears apply_quality_gate trivially. Folded in AT the
+    # chunk/sweep boundary — before the sweep's own findings, not after —
+    # and sweep_start moves with it: apply_sweep_dedup only ever drops a
+    # SWEEP-side finding, so appending this after the sweep's findings would
+    # put it on the sweep side of that boundary, where a chunk worker's own
+    # finding sharing its file and normalized title could drop the
+    # deterministic finding as "duplicate of chunk finding" and keep the
+    # model's restatement instead.
+    release_shape = heuristics.release_shape_findings(files)
+    findings = findings[:sweep_start] + release_shape + findings[sweep_start:]
+    sweep_start += len(release_shape)
 
     findings = apply_location_validation(findings, [f.path for f in files])
     # BEFORE apply_line_align, deliberately: the manifest check compares the
@@ -1289,10 +1313,42 @@ def _summary_only_run(
     forge: Forge, ref: PRRef, pr: PRData, files, post: bool, t0: float,
     *, post_mode: str = "summary+inline", post_verdict: bool = True,
     tracer: Tracer | None = None, sampling: dict | None = None,
+    release_shape_findings: list[Finding] | None = None,
+    confidence_floor: float | None = None, max_errors: int | None = None,
 ) -> dict:
+    """The no-chunk exit: an empty diff, or every file binary.
+
+    No worker ever ran, but the release-shape heuristic
+    (:func:`heuristics.release_shape_findings`) is pure and needs no chunk
+    to fire on, so its findings — passed in by the caller, already computed
+    over the full file list — are put through the same location and
+    quality passes a chunk-sourced finding gets (:func:`apply_location_validation`,
+    :func:`apply_quality_gate`) before they reach ``findings_active`` /
+    ``verdict`` / the summary. An empty diff still yields
+    ``release_shape_findings=[]`` (fewer than 2 files can never be
+    release-shaped), so this degrades to exactly the prior empty-diff
+    behaviour: ``Approved``, no findings, no banner.
+    """
     tracer = tracer if tracer is not None else get_tracer()
     elapsed_ms = _elapsed_ms(t0)
     posted = False
+
+    findings = list(release_shape_findings or [])
+    if findings:
+        findings = apply_location_validation(findings, [f.path for f in files])
+        findings = apply_quality_gate(
+            findings, confidence_floor=confidence_floor, max_errors=max_errors,
+        )
+    findings_active = sorted(active(findings), key=finding_sort_key)
+    findings_dropped = sorted(
+        (f for f in findings if f.drop_reason is not None), key=finding_sort_key
+    )
+    verdict = (
+        "Request-Changes"
+        if any(f.severity == "error" for f in findings_active)
+        else "Approved"
+    )
+
     wanted = post and post_mode in POST_SUMMARY_MODES
     _trace_post_begin(
         tracer, wanted=wanted, mode=post_mode, kind="empty-diff summary",
@@ -1300,7 +1356,7 @@ def _summary_only_run(
     )
     if wanted:
         summary = _render_summary(
-            pr, files, "Approved", [], "unknown", 0, 0, elapsed_ms,
+            pr, files, verdict, findings_active, "unknown", 0, 0, elapsed_ms,
             chunks_reviewed=0, chunks_failed=0,
             include_verdict=post_verdict,
         )
@@ -1311,9 +1367,9 @@ def _summary_only_run(
             logger.error("post_summary failed: %s", e)
     _trace_post_end(tracer, wanted=wanted, posted=posted, mode=post_mode)
     return {
-        "verdict": "Approved",
-        "findings_active": [],
-        "findings_dropped": [],
+        "verdict": verdict,
+        "findings_active": findings_active,
+        "findings_dropped": findings_dropped,
         "chunk_count": 0,
         "chunks_reviewed": 0,
         "chunks_failed": 0,

--- a/src/prxref/orchestrator.py
+++ b/src/prxref/orchestrator.py
@@ -76,6 +76,7 @@ import logging
 import re
 import threading
 import time
+from collections import Counter
 from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
@@ -91,6 +92,8 @@ from .quality import (
     apply_severity_consistency,
     apply_sweep_dedup,
     apply_thread_dedup,
+    finding_rank_key,
+    finding_sort_key,
 )
 from .trace import Tracer, get_tracer
 from .triage import (
@@ -317,7 +320,11 @@ def orchestrate_review(
     """
     t0 = time.perf_counter()
     tracer = get_tracer(trace_file)
-    tracer.event("run", "start", forge=ref.forge, url=ref.url, number=ref.number)
+    sampling = _sampling(llm)
+    tracer.event(
+        "run", "start", forge=ref.forge, url=ref.url, number=ref.number,
+        sampling=sampling,
+    )
 
     try:
         with tracer.span("forge.get_pr"):
@@ -327,7 +334,7 @@ def orchestrate_review(
         tracer.event("run", "fail")
         return _error_run(
             forge, ref, post, 0, f"get_pr failed: {e}", t0,
-            post_mode=post_mode, tracer=tracer,
+            post_mode=post_mode, tracer=tracer, sampling=sampling,
         )
 
     try:
@@ -339,7 +346,7 @@ def orchestrate_review(
         tracer.event("run", "fail")
         return _error_run(
             forge, ref, post, 0, f"get_diff failed: {e}", t0,
-            post_mode=post_mode, tracer=tracer,
+            post_mode=post_mode, tracer=tracer, sampling=sampling,
         )
 
     # Wrapped like every neighbouring stage. These two were the only ones that
@@ -357,7 +364,7 @@ def orchestrate_review(
         tracer.event("run", "fail")
         return _error_run(
             forge, ref, post, 0, f"parse_unified_diff failed: {e}", t0,
-            post_mode=post_mode, tracer=tracer,
+            post_mode=post_mode, tracer=tracer, sampling=sampling,
         )
 
     try:
@@ -372,7 +379,7 @@ def orchestrate_review(
         tracer.event("run", "fail")
         return _error_run(
             forge, ref, post, 0, f"build_chunks failed: {e}", t0,
-            post_mode=post_mode, tracer=tracer,
+            post_mode=post_mode, tracer=tracer, sampling=sampling,
         )
 
     if not chunks:
@@ -380,6 +387,7 @@ def orchestrate_review(
         return _summary_only_run(
             forge, ref, pr, files, post, t0,
             post_mode=post_mode, post_verdict=post_verdict, tracer=tracer,
+            sampling=sampling,
         )
 
     results = _run_workers(
@@ -414,7 +422,7 @@ def orchestrate_review(
         return _error_run(
             forge, ref, post, len(chunks) + 1, reason, t0, tracer=tracer,
             model=model, input_tokens=input_tokens, output_tokens=output_tokens,
-            post_mode=post_mode,
+            post_mode=post_mode, sampling=sampling,
         )
 
     chunks_failed = sum(1 for r in results if r["error"])
@@ -465,17 +473,36 @@ def orchestrate_review(
             rewrites,
         )
     findings = consistent
+    # The sweep boundary is positional, and the gate now returns its findings
+    # in content order, so the boundary is re-derived from the identity of the
+    # sweep's own findings rather than carried across the gate as an index.
+    sweep_identities = Counter(
+        _origin_key(f) for f in findings[sweep_start:]
+    )
     findings = apply_quality_gate(
         findings, confidence_floor=confidence_floor, max_errors=max_errors,
     )
+    chunk_part: list[Finding] = []
+    sweep_part: list[Finding] = []
+    for f in findings:
+        key = _origin_key(f)
+        if sweep_identities[key] > 0:
+            sweep_identities[key] -= 1
+            sweep_part.append(f)
+        else:
+            chunk_part.append(f)
     # AFTER the gate, deliberately: the duplicate set is built from chunk
     # findings that survived it, so a sub-floor chunk finding cannot suppress
     # its higher-confidence sweep duplicate and then die at the gate itself —
     # that would lose the recall the sweep exists to add.
-    findings = apply_sweep_dedup(findings, sweep_start=sweep_start)
+    findings = apply_sweep_dedup(
+        chunk_part + sweep_part, sweep_start=len(chunk_part)
+    )
 
-    findings_active = active(findings)
-    findings_dropped = [f for f in findings if f.drop_reason is not None]
+    findings_active = sorted(active(findings), key=finding_sort_key)
+    findings_dropped = sorted(
+        (f for f in findings if f.drop_reason is not None), key=finding_sort_key
+    )
 
     verdict = (
         "Request-Changes"
@@ -519,7 +546,7 @@ def orchestrate_review(
     if post_inline_wanted and findings_active and (posted or not post_summary_wanted):
         ordered = sorted(
             findings_active,
-            key=lambda f: (_SEVERITY_RANK.get(f.severity, 3), -f.confidence),
+            key=lambda f: (_SEVERITY_RANK.get(f.severity, 3), *finding_rank_key(f)),
         )
         comments = [
             InlineComment(
@@ -584,6 +611,24 @@ def orchestrate_review(
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
         "posted": posted,
+        "sampling": _sampling(llm),
+    }
+
+
+def _origin_key(finding: Finding) -> tuple:
+    return (finding.file, finding.line, finding.title, finding.body)
+
+
+def _sampling(llm: object) -> dict:
+    """Report the sampling knobs a client had in force, duck-typed.
+
+    A client that exposes none of them still yields the same three keys, so a
+    run record never has to be read as "absent means default".
+    """
+    return {
+        "temperature": getattr(llm, "temperature", None),
+        "seed": getattr(llm, "seed", None),
+        "models": list(getattr(llm, "models", []) or []),
     }
 
 
@@ -1103,7 +1148,7 @@ def _trace_post_end(
 def _summary_only_run(
     forge: Forge, ref: PRRef, pr: PRData, files, post: bool, t0: float,
     *, post_mode: str = "summary+inline", post_verdict: bool = True,
-    tracer: Tracer | None = None,
+    tracer: Tracer | None = None, sampling: dict | None = None,
 ) -> dict:
     tracer = tracer if tracer is not None else get_tracer()
     elapsed_ms = _elapsed_ms(t0)
@@ -1136,6 +1181,7 @@ def _summary_only_run(
         "input_tokens": 0,
         "output_tokens": 0,
         "posted": posted,
+        "sampling": sampling if sampling is not None else _sampling(None),
     }
 
 
@@ -1151,6 +1197,7 @@ def _error_run(
     output_tokens: int = 0,
     post_mode: str = "summary+inline",
     tracer: Tracer | None = None,
+    sampling: dict | None = None,
 ) -> dict:
     tracer = tracer if tracer is not None else get_tracer()
     elapsed_ms = _elapsed_ms(t0)
@@ -1190,4 +1237,5 @@ def _error_run(
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
         "posted": posted,
+        "sampling": sampling if sampling is not None else _sampling(None),
     }

--- a/src/prxref/orchestrator.py
+++ b/src/prxref/orchestrator.py
@@ -80,7 +80,7 @@ from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
-from . import reviewer, systemic
+from . import heuristics, reviewer, systemic
 from .forges.base import ATTRIBUTION_MARKER, Forge, InlineComment, PRData, PRRef
 from .llm import LLMClient
 from .quality import (
@@ -449,6 +449,12 @@ def orchestrate_review(
     except Exception as e:  # noqa: BLE001
         logger.warning("list_threads failed (best-effort): %s", e)
         threads = []
+
+    # A deterministic, non-LLM finding folded in before the quality passes so
+    # it flows through every one of them exactly like a model finding (issue
+    # #10): file-level (line=0) survives apply_line_align untouched, and
+    # warning/1.0 clears apply_quality_gate trivially.
+    findings = findings + heuristics.release_shape_findings(files)
 
     findings = apply_location_validation(findings, [f.path for f in files])
     findings = apply_line_align(findings, added_lines_by_file(files), files=files)

--- a/src/prxref/orchestrator.py
+++ b/src/prxref/orchestrator.py
@@ -85,6 +85,7 @@ from .forges.base import ATTRIBUTION_MARKER, Forge, InlineComment, PRData, PRRef
 from .llm import LLMClient
 from .quality import (
     active,
+    apply_hedge_gate,
     apply_line_align,
     apply_location_validation,
     apply_quality_gate,
@@ -465,6 +466,7 @@ def orchestrate_review(
             rewrites,
         )
     findings = consistent
+    findings = apply_hedge_gate(findings)
     findings = apply_quality_gate(
         findings, confidence_floor=confidence_floor, max_errors=max_errors,
     )

--- a/src/prxref/orchestrator.py
+++ b/src/prxref/orchestrator.py
@@ -81,13 +81,21 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 from . import reviewer, systemic
-from .forges.base import ATTRIBUTION_MARKER, Forge, InlineComment, PRData, PRRef
+from .forges.base import (
+    ATTRIBUTION_MARKER,
+    Forge,
+    InlineComment,
+    PRData,
+    PRRef,
+    Thread,
+)
 from .llm import LLMClient
 from .quality import (
     active,
     apply_line_align,
     apply_location_validation,
     apply_quality_gate,
+    apply_settled_thread_suppression,
     apply_severity_consistency,
     apply_sweep_dedup,
     apply_thread_dedup,
@@ -382,6 +390,25 @@ def orchestrate_review(
             post_mode=post_mode, post_verdict=post_verdict, tracer=tracer,
         )
 
+    # Pruned BEFORE the threads are listed, and both before the review units
+    # run. The prune-then-list order is load-bearing: reading threads first
+    # would let this run's findings be suppressed as already-discussed against
+    # prxref's OWN stale comments, which the prune then deletes. Both moved
+    # ahead of the dispatch because the sweep needs the discussion in its
+    # prompt, and a review that never starts has nothing to say either way.
+    if post and post_mode in POST_INLINE_MODES:
+        _prune_stale_inline_comments(forge, ref)
+
+    # Fetched BEFORE the review units run, not after: the sweep needs the
+    # existing discussion in its own prompt, and the same list serves the
+    # post-hoc thread passes. Best-effort by contract — a forge that cannot
+    # list threads still gets a review.
+    try:
+        threads = forge.list_threads(ref)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("list_threads failed (best-effort): %s", e)
+        threads = []
+
     results = _run_workers(
         llm, chunks, pr, max_tokens=max_tokens, max_workers=max_workers,
         context_lines=context_lines, tracer=tracer,
@@ -395,7 +422,7 @@ def orchestrate_review(
     results.append(
         _run_sweep(
             llm, files, pr, max_tokens=max_tokens,
-            token_budget=token_budget, tracer=tracer,
+            token_budget=token_budget, tracer=tracer, threads=threads,
         )
     )
 
@@ -441,18 +468,10 @@ def orchestrate_review(
     if results[-1]["error"]:
         failed_chunks.append((results[-1]["error"], []))
 
-    if post and post_mode in POST_INLINE_MODES:
-        _prune_stale_inline_comments(forge, ref)
-
-    try:
-        threads = forge.list_threads(ref)
-    except Exception as e:  # noqa: BLE001
-        logger.warning("list_threads failed (best-effort): %s", e)
-        threads = []
-
     findings = apply_location_validation(findings, [f.path for f in files])
     findings = apply_line_align(findings, added_lines_by_file(files), files=files)
     findings = apply_thread_dedup(findings, threads)
+    findings = apply_settled_thread_suppression(findings, threads)
     consistent = apply_severity_consistency(findings)
     rewrites = sum(
         1
@@ -849,6 +868,7 @@ def _run_sweep(
     max_tokens: int | None = None,
     token_budget: int = DEFAULT_TOKEN_BUDGET,
     tracer: Tracer | None = None,
+    threads: Sequence[Thread] = (),
 ) -> dict:
     """Run the whole-PR systemic sweep as one worker-style review unit.
 
@@ -864,14 +884,20 @@ def _run_sweep(
     tracer = tracer if tracer is not None else get_tracer()
     t0 = time.perf_counter()
     digest = systemic.build_digest(files, token_budget)
+    digested = {f.path for f in files}
+    discussion = [t for t in threads if t.path in digested]
     logger.info(
-        "[sweep] start: %d files, digest %d chars", len(files), len(digest),
+        "[sweep] start: %d files, digest %d chars, %d thread(s)",
+        len(files), len(digest), len(discussion),
     )
-    tracer.event("sweep", "start", files=len(files), digest_chars=len(digest))
+    tracer.event(
+        "sweep", "start", files=len(files), digest_chars=len(digest),
+        threads=len(discussion),
+    )
     try:
         findings_raw, meta = reviewer.review_systemic(
             llm, digest, pr_title=pr.title, pr_description=pr.description,
-            max_tokens=max_tokens,
+            max_tokens=max_tokens, threads=discussion,
         )
     except Exception as e:  # noqa: BLE001
         logger.error("[sweep] raised: %s", e)

--- a/src/prxref/orchestrator.py
+++ b/src/prxref/orchestrator.py
@@ -706,7 +706,22 @@ def orchestrate_review(
 
 
 def _origin_key(finding: Finding) -> tuple:
-    return (finding.file, finding.line, finding.title, finding.body)
+    """Identity used to re-derive the chunk/sweep boundary across the gate.
+
+    ``severity`` and ``confidence`` are part of the key: without them a chunk
+    finding and a sweep finding that agree on file, line, title, and body
+    collide, ``finding_sort_key`` ties them, and the Counter walk hands the
+    first survivor to the sweep side — dropping the higher-confidence chunk
+    copy as a "duplicate of chunk finding".
+    """
+    return (
+        finding.file,
+        finding.line,
+        finding.title,
+        finding.body,
+        finding.severity,
+        finding.confidence,
+    )
 
 
 def _sampling(llm: object) -> dict:

--- a/src/prxref/orchestrator.py
+++ b/src/prxref/orchestrator.py
@@ -27,25 +27,45 @@ Stage order (v1 — no Jira, no graph, no learnings, no investigator):
    chunk results, and counts as one more review unit: ``chunk_count`` is
    ``len(chunks) + 1`` whenever the sweep ran, and a sweep failure is one
    failed chunk in the partial-review banner.
-5. Quality passes in order: location validation (a ``file`` naming no
-   path of the parsed diff is dropped, not rendered) →
-   ``apply_line_align`` → thread dedup
-   (existing threads fetched best-effort; failure means no threads) →
-   severity consistency (findings sharing a normalized title are raised
-   to the group's max severity — the sweep's corroborating title counts
-   toward its group) → ``apply_quality_gate(confidence_floor=,
-   max_errors=)`` → sweep dedup (``apply_sweep_dedup`` drops a sweep
-   finding that restates a chunk finding that SURVIVED the gate, on file
-   + normalized title; running it last is what keeps a sub-floor chunk
+5. Deterministic checks and quality passes, in exactly this order — the
+   raw chunk + sweep findings first gain
+   ``heuristics.release_shape_findings(files)`` (a pure, no-LLM finding
+   about a PR that is ≥80% release machinery yet also touches source),
+   folded in BEFORE the passes so it is filtered like any other finding:
+
+   ``apply_location_validation`` (a ``file`` naming no path of the parsed
+   diff is dropped, not rendered) → ``apply_manifest_claim_check`` (a
+   ``package.json`` claim whose dependency is not the key on the anchored
+   line, or whose asserted section disagrees with the actual one; it must
+   precede line align, which is what makes it read the model's RAW
+   anchor) → ``apply_line_align`` → ``apply_thread_dedup`` (existing
+   threads fetched best-effort BEFORE the workers run, and after the
+   stale-inline prune; failure means no threads) →
+   ``apply_settled_thread_suppression`` (a finding re-litigating a
+   subject an existing thread already argued out, line-independently) →
+   ``apply_severity_consistency`` (findings sharing a normalized title
+   are raised to the group's max severity — the sweep's corroborating
+   title counts toward its group) → ``apply_removal_claim_check`` (a
+   claim that a NAMED path was removed when the post-image still carries
+   it) → ``apply_hedge_gate`` (a finding whose own text conditions the
+   defect on something the worker never established) →
+   ``apply_quality_gate(confidence_floor=, max_errors=)``, which returns
+   its findings in content order, so the chunk/sweep boundary is
+   re-derived here from finding identity rather than carried across the
+   gate as an index → ``apply_sweep_dedup`` (drops a sweep finding that
+   restates a chunk finding that SURVIVED the gate, on file + normalized
+   title; running it after the gate is what keeps a sub-floor chunk
    finding from suppressing its higher-confidence sweep duplicate and
    then dying at the gate itself) → ``apply_containment_note`` (a throw
    / panic / crash / unhandled-rejection finding that never names its
    catch or its propagation target gets its body suffixed with
    ``" [containment boundary not stated]"``; textual only, runs last so
    it touches both the active and dropped copies of chunk and sweep
-   findings alike). Dropped findings
-   are retained in the result with ``drop_reason`` set, never silently
-   discarded.
+   findings alike). Dropped findings are retained in the result with
+   ``drop_reason`` set, never silently discarded, and both lists come out
+   sorted by ``finding_sort_key``. Every result — including an error or
+   summary-only exit — carries a ``sampling`` record naming the
+   temperature, seed, and model chain actually in force.
 6. Verdict: ``"Error"`` when every CHUNK review failed (a sweep success
    on a dead worker pool cannot carry the run); ``"Request-Changes"``
    iff any active error-severity finding survives;

--- a/src/prxref/orchestrator.py
+++ b/src/prxref/orchestrator.py
@@ -80,7 +80,7 @@ from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
-from . import reviewer, systemic
+from . import chunk_context, reviewer, systemic
 from .forges.base import ATTRIBUTION_MARKER, Forge, InlineComment, PRData, PRRef
 from .llm import LLMClient
 from .quality import (
@@ -385,6 +385,7 @@ def orchestrate_review(
     results = _run_workers(
         llm, chunks, pr, max_tokens=max_tokens, max_workers=max_workers,
         context_lines=context_lines, tracer=tracer,
+        reader=_make_file_reader(forge, ref, pr),
     )
 
     # One more worker-style unit, not inside the pool: the sweep digests the
@@ -647,10 +648,62 @@ def _inline_accounting(
 HEARTBEAT_SECONDS = 30.0
 
 
+def _make_file_reader(forge: Forge, ref: PRRef, pr: PRData):
+    """A cached ``read(path) -> str | None`` over the forge's optional reader.
+
+    Returns ``None`` when the forge has no ``get_file_content`` or the PR has
+    no head sha, which is the signal to skip context injection entirely.
+    Otherwise every path is fetched at most once per run at ``pr.source_sha``,
+    and any exception from the adapter degrades to ``None``.
+    """
+    reader = getattr(forge, "get_file_content", None)
+    sha = getattr(pr, "source_sha", "") or ""
+    if reader is None or not sha:
+        return None
+
+    cache: dict[tuple[str, str], str | None] = {}
+    lock = threading.Lock()
+
+    def read(path: str) -> str | None:
+        key = (path, sha)
+        with lock:
+            if key in cache:
+                return cache[key]
+        try:
+            value = reader(ref, path, sha=sha)
+        except Exception as e:  # noqa: BLE001 - context is never worth a failed review
+            logger.debug("get_file_content(%s) failed: %s", path, e)
+            value = None
+        if not isinstance(value, str):
+            value = None
+        with lock:
+            cache[key] = value
+        return value
+
+    return read
+
+
+def _context_blocks(chunk, reader, *, include_definitions: bool) -> str:
+    """Render the chunk's dependency and definition blocks; never raises."""
+    if reader is None:
+        return ""
+    try:
+        files = chunk_context.chunk_files(chunk)
+        deps = chunk_context.dependency_versions(files, reader)
+        defs = (
+            chunk_context.referenced_definitions(files, reader)
+            if include_definitions else []
+        )
+        return chunk_context.render_context_blocks(deps, defs)
+    except Exception as e:  # noqa: BLE001
+        logger.debug("chunk context unavailable: %s", e)
+        return ""
+
+
 def _run_workers(
     llm: LLMClient, chunks, pr: PRData, *, max_tokens: int | None = None,
     max_workers: int = MAX_WORKERS, context_lines: int | None = None,
-    tracer: Tracer | None = None,
+    tracer: Tracer | None = None, reader=None,
 ) -> list[dict]:
     # Never below 1: ThreadPoolExecutor rejects a zero-width pool, and a
     # library caller is not gated by config's range check.
@@ -684,7 +737,7 @@ def _run_workers(
         futures = [
             ex.submit(
                 _run_worker, i + 1, len(chunks), llm, chunk, pr,
-                max_tokens, context_lines, tracer,
+                max_tokens, context_lines, tracer, reader,
             )
             for i, chunk in enumerate(chunks)
         ]
@@ -729,6 +782,7 @@ _TIMEOUT_RETRY_CONTEXT_LINES = 0
 def _invoke_chunk(
     llm: LLMClient, chunk, pr: PRData,
     max_tokens: int | None, context_lines: int | None,
+    reader=None, *, include_definitions: bool = True,
 ) -> dict:
     """One normalized :func:`reviewer.review_chunk` call; never raises.
 
@@ -736,11 +790,19 @@ def _invoke_chunk(
     ``error`` always a string — for both the original attempt and the
     timeout retry in :func:`_run_worker`. Legacy dict-shaped stubs are
     accepted exactly as before.
+
+    ``reader`` is the optional cached file reader from
+    :func:`_make_file_reader`; when present the chunk's dependency and
+    definition context blocks are built here, so both the original attempt and
+    the retry carry them. ``include_definitions`` is false on the timeout
+    retry, whose whole purpose is a smaller prompt.
     """
+    blocks = _context_blocks(chunk, reader, include_definitions=include_definitions)
     try:
         res = reviewer.review_chunk(
             llm, chunk, pr_title=pr.title, pr_description=pr.description,
             max_tokens=max_tokens, context_lines=context_lines,
+            context_blocks=blocks,
         )
     except Exception as e:  # noqa: BLE001
         return {
@@ -780,7 +842,7 @@ def _invoke_chunk(
 def _run_worker(
     index: int, total: int, llm: LLMClient, chunk, pr: PRData,
     max_tokens: int | None = None, context_lines: int | None = None,
-    tracer: Tracer | None = None,
+    tracer: Tracer | None = None, reader=None,
 ) -> dict:
     tracer = tracer if tracer is not None else get_tracer()
     t0 = time.perf_counter()
@@ -795,7 +857,7 @@ def _run_worker(
         "chunk", "start", index=index, total=total,
         files=[f.path for f in chunk],
     )
-    res = _invoke_chunk(llm, chunk, pr, max_tokens, context_lines)
+    res = _invoke_chunk(llm, chunk, pr, max_tokens, context_lines, reader)
     if (
         res["error"]
         and _is_timeout_error(res["error"])
@@ -813,7 +875,13 @@ def _run_worker(
         tracer.event(
             "chunk", "retry", index=index, total=total, reason="timeout",
         )
-        res = _invoke_chunk(llm, chunk, pr, max_tokens, _TIMEOUT_RETRY_CONTEXT_LINES)
+        # The dependency block is a handful of tokens and survives; the
+        # definitions block is the bulky one and is dropped, because shrinking
+        # the prompt is the entire point of this retry.
+        res = _invoke_chunk(
+            llm, chunk, pr, max_tokens, _TIMEOUT_RETRY_CONTEXT_LINES, reader,
+            include_definitions=False,
+        )
 
     error = res["error"]
     if error:

--- a/src/prxref/orchestrator.py
+++ b/src/prxref/orchestrator.py
@@ -38,7 +38,12 @@ Stage order (v1 — no Jira, no graph, no learnings, no investigator):
    finding that restates a chunk finding that SURVIVED the gate, on file
    + normalized title; running it last is what keeps a sub-floor chunk
    finding from suppressing its higher-confidence sweep duplicate and
-   then dying at the gate itself). Dropped findings
+   then dying at the gate itself) → ``apply_containment_note`` (a throw
+   / panic / crash / unhandled-rejection finding that never names its
+   catch or its propagation target gets its body suffixed with
+   ``" [containment boundary not stated]"``; textual only, runs last so
+   it touches both the active and dropped copies of chunk and sweep
+   findings alike). Dropped findings
    are retained in the result with ``drop_reason`` set, never silently
    discarded.
 6. Verdict: ``"Error"`` when every CHUNK review failed (a sweep success
@@ -85,6 +90,7 @@ from .forges.base import ATTRIBUTION_MARKER, Forge, InlineComment, PRData, PRRef
 from .llm import LLMClient
 from .quality import (
     active,
+    apply_containment_note,
     apply_line_align,
     apply_location_validation,
     apply_quality_gate,
@@ -473,6 +479,11 @@ def orchestrate_review(
     # its higher-confidence sweep duplicate and then die at the gate itself —
     # that would lose the recall the sweep exists to add.
     findings = apply_sweep_dedup(findings, sweep_start=sweep_start)
+    # Last, deliberately: it only decorates body text (never drop_reason or
+    # severity), so it must run after every pass that keys off title/body
+    # content, and running last means both the posted comment body and the
+    # dropped-audit copy carry the same suffixed text.
+    findings = apply_containment_note(findings)
 
     findings_active = active(findings)
     findings_dropped = [f for f in findings if f.drop_reason is not None]

--- a/src/prxref/orchestrator.py
+++ b/src/prxref/orchestrator.py
@@ -87,6 +87,7 @@ from .quality import (
     active,
     apply_line_align,
     apply_location_validation,
+    apply_manifest_claim_check,
     apply_quality_gate,
     apply_severity_consistency,
     apply_sweep_dedup,
@@ -451,6 +452,10 @@ def orchestrate_review(
         threads = []
 
     findings = apply_location_validation(findings, [f.path for f in files])
+    # BEFORE apply_line_align, deliberately: the manifest check compares the
+    # model's raw anchor against the key and section it claims, and realignment
+    # can move a correctly anchored claim onto a neighbouring entry first.
+    findings = apply_manifest_claim_check(findings, files)
     findings = apply_line_align(findings, added_lines_by_file(files), files=files)
     findings = apply_thread_dedup(findings, threads)
     consistent = apply_severity_consistency(findings)

--- a/src/prxref/prompts/systemic.md
+++ b/src/prxref/prompts/systemic.md
@@ -10,9 +10,12 @@ Per-chunk reviewers each see one slice of the diff and reliably miss classes tha
 - A migration (DDL) that creates or alters a table without row level security or policies: a `CREATE TABLE` with no `ENABLE ROW LEVEL SECURITY` and no `CREATE POLICY` anywhere in the same migration file is itself the finding. Migration files appear in the digest with their full added content, so the absence of those statements is a fact you can assert, not a guess.
 - A destructive operation (drop, delete, overwrite, force-push style cleanup) with no guard or confirmation.
 - A recurring timer or poll (`setInterval`, `setTimeout`, `while (true)`) with no attempt cap, deadline, or termination on its failure path — e.g. a 404 response that resets status and re-queues the poll forever.
+- A removed guard: a deleted numeric limit constant (`MAX_*_LENGTH`, `*_SIZE`, `*_BYTES`, `*_TIMEOUT`) or a deleted validator/sanitiser definition (`isValid*`, `validate*`, `sanitize*`, `check*`, `assert*`, `escape*`) on a path that consumes remote or third-party input. The digest shows these as `-` lines; the code that remains says nothing about the bound that is gone, so the deletion itself is the finding.
 - Repo-config drift: two lockfiles for one package manager root — a lockfile newly added while another lockfile or a `packageManager` pin also appears in the PR. The digest states this collision on a `! repo-config:` line.
 
 Nothing else. Per-file bugs inside one chunk are the chunk workers' job; repeating them here only duplicates their findings, which are deduplicated away.
+
+Do not raise a subject the reviewers already argued out under `### Existing discussion` — that decision was made with more context than the digest carries. If you raise it anyway, say in the body why the discussion's conclusion is wrong.
 
 ## Severity Vocabulary
 

--- a/src/prxref/prompts/systemic.md
+++ b/src/prxref/prompts/systemic.md
@@ -30,7 +30,7 @@ There is no downstream investigation pass that will confirm your suspicions. Eve
 
 ## Style
 
-Terse. Title under 80 characters, imperative. Body: what breaks or risks, plus the digest evidence, in 1-4 sentences. No praise, no restating what the diff does, no style-guide nits that change neither behavior nor risk.
+Terse. Title under 80 characters, imperative. Body: what breaks or risks, plus the digest evidence, in 1-4 sentences. No praise, no restating what the diff does, no style-guide nits that change neither behavior nor risk. A finding that asserts a throw, panic, crash, or unhandled rejection must name its containment boundary: the enclosing catch, or state that it is uncaught and name the caller it propagates to.
 
 ## Review Context
 

--- a/src/prxref/prompts/worker.md
+++ b/src/prxref/prompts/worker.md
@@ -20,7 +20,7 @@ There is no downstream investigation pass that will confirm your suspicions. If 
 
 ## Style
 
-Terse. Title under 80 characters, imperative. Body: what breaks or risks, plus the diff evidence, in 1-4 sentences. No praise, no restating what the diff does, no style-guide nits that change neither behavior nor risk.
+Terse. Title under 80 characters, imperative. Body: what breaks or risks, plus the diff evidence, in 1-4 sentences. No praise, no restating what the diff does, no style-guide nits that change neither behavior nor risk. A finding that asserts a throw, panic, crash, or unhandled rejection must name its containment boundary: the enclosing catch, or state that it is uncaught and name the caller it propagates to.
 
 ## Review Context
 

--- a/src/prxref/prompts/worker.md
+++ b/src/prxref/prompts/worker.md
@@ -16,7 +16,7 @@ Each finding carries a confidence from 0.0 to 1.0 — how certain you are from t
 
 ## No Speculation
 
-There is no downstream investigation pass that will confirm your suspicions. If you suspect an issue but the diff lacks the evidence to support it, do not emit it and do not escalate it — either find the evidence in the diff or drop the concern. The `escalations` array exists in the output schema for forward compatibility only: always emit it as an empty list.
+There is no downstream investigation pass that will confirm your suspicions. If you suspect an issue but the diff lacks the evidence to support it, do not emit it and do not escalate it — either find the evidence in the diff or drop the concern. The `escalations` array exists in the output schema for forward compatibility only: always emit it as an empty list. A finding whose truth depends on a precondition you could not establish from the diff ("if X is still mounted", "unless the migration already ran", "if they are members of the root workspaces") must not be reported as a defect: either phrase it as a question with `confidence` at or below 0.5, or omit it.
 
 ## Style
 

--- a/src/prxref/prompts/worker.md
+++ b/src/prxref/prompts/worker.md
@@ -1,4 +1,4 @@
-You are a senior code reviewer. You review one chunk of a pull-request diff per call. You see only the diff text — no repository checkout, no call graph, no history. Review what the diff shows; do not speculate about code you cannot see.
+You are a senior code reviewer. You review one chunk of a pull-request diff per call. You see the diff text plus any context blocks supplied below it — no repository checkout, no call graph, no history. Review what the diff and those blocks show; do not speculate about code you cannot see.
 
 ## Mission
 
@@ -13,6 +13,10 @@ Verify every claim against the diff itself. Every finding must cite a file and l
 ## Confidence
 
 Each finding carries a confidence from 0.0 to 1.0 — how certain you are from this diff alone. Findings below the quality floor (default 0.6) are dropped downstream. 0.5 means "plausible but unverified". Reserve 0.9+ for defects provable from the diff text alone.
+
+A finding that depends on a third-party library's runtime semantics must cap confidence at 0.5 and be phrased as a question when that library version is not listed under a "Dependency versions" heading below. Different majors behave differently; without the pin you are guessing which one this code runs against.
+
+If a finding turns on the semantics of a named symbol whose definition is not shown — neither in the diff nor under a "Definitions referenced by this chunk" heading below — cap confidence at 0.5 and phrase it as a question. The identifier's name is not evidence of its behavior.
 
 ## No Speculation
 
@@ -38,6 +42,8 @@ The input stays under roughly 30k tokens; the diff below is the complete chunk.
 ```diff
 {diff}
 ```
+
+{context_blocks}
 
 ## Output Format
 

--- a/src/prxref/quality.py
+++ b/src/prxref/quality.py
@@ -1,11 +1,16 @@
 """Deterministic quality passes over worker findings.
 
-Five passes run before posting:
+Six passes run before posting:
 1. ``apply_location_validation``: drop findings whose ``file`` names no
    path of the parsed diff — an empty, non-path, or invented location is
    retained with ``drop_reason`` for the audit instead of rendering a
    bullet anchored to nothing.
-2. ``apply_line_align``: a line explicitly cited in the finding's own
+2. ``apply_manifest_claim_check``: for findings on a ``package.json``,
+   drop a claim whose named dependency is not the key on the anchored
+   line (``anchor mismatch:``) or sits under a different dependency
+   section than the claim asserts (``section mismatch:``). It runs
+   BEFORE ``apply_line_align`` so it reads the model's raw anchor.
+3. ``apply_line_align``: a line explicitly cited in the finding's own
    title or body (``line 553``, ``at line 553``, an own-file
    ``path:line``) outranks a drifted ``line`` field whenever the cited
    line lands on an added line — or a context line within tolerance of
@@ -21,15 +26,15 @@ Five passes run before posting:
    an anchor survives only when it ties the file's best evidence match
    or sits within tolerance of it, and a blank or pure-punctuation
    anchor never survives while any token-bearing added line exists.
-3. ``apply_thread_dedup``: drop findings that duplicate an already-open
+4. ``apply_thread_dedup``: drop findings that duplicate an already-open
    or existing thread on the PR (path + line-window + shared distinctive tokens).
-4. ``apply_severity_consistency``: findings sharing one normalized title —
+5. ``apply_severity_consistency``: findings sharing one normalized title —
    within a file or across sibling files — are all raised to the group's
    maximum severity, so per-chunk workers cannot disagree about how
    serious the same pattern is. Findings phrased differently but bound
    by a shared rare code token, with a shared problem class or file,
    join the same group (issue #30).
-5. ``apply_quality_gate``: drop findings below the confidence floor, cap
+6. ``apply_quality_gate``: drop findings below the confidence floor, cap
    errors per review, and enforce the {error, warning, outofscope} severity
    vocabulary.
 
@@ -45,6 +50,7 @@ import re
 from collections import Counter
 from collections.abc import Sequence
 from dataclasses import replace
+from pathlib import PurePosixPath
 
 from .forges.base import Thread
 from .triage import DiffLine, FileDiff, Finding, Hunk
@@ -90,6 +96,193 @@ def apply_location_validation(
             result.append(f)
             continue
         result.append(replace(f, drop_reason=f"malformed location: {f.file!r}"))
+    return result
+
+
+MANIFEST_BASENAME: str = "package.json"
+
+DEPENDENCY_SECTIONS: tuple[str, ...] = (
+    "dependencies",
+    "devDependencies",
+    "peerDependencies",
+    "optionalDependencies",
+)
+
+# Keys that name a manifest SECTION or the package itself rather than a
+# dependency, so they can never be the "claimed package" of a finding.
+_MANIFEST_NON_PACKAGE_KEYS: frozenset[str] = frozenset(
+    [s.lower() for s in DEPENDENCY_SECTIONS] + ["scripts", "engines", "name", "version"]
+)
+
+# Evidence tokens a manifest section header contributes (including the
+# camelCase split of the compound forms), which must not decide a
+# package.json realign — see ``_realign_member``.
+_MANIFEST_SECTION_TOKENS: frozenset[str] = frozenset(
+    {"dependencies", "devdependencies", "peerdependencies",
+     "optionaldependencies", "peer", "optional"}
+)
+
+_NPM_NAME_RE = re.compile(
+    r"(?:@[a-z0-9\-~][a-z0-9._~\-]*/)?[a-z0-9\-~][a-z0-9._~\-]*"
+)
+
+_JSON_KEY_RE = re.compile(r'"([^"\n]+)"\s*:')
+
+_SECTION_OPEN_RE = re.compile(
+    r'"(dependencies|devDependencies|peerDependencies|optionalDependencies)"'
+    r"\s*:\s*\{"
+)
+
+_CLAIMED_SECTION_PATTERNS: tuple[tuple[str, str], ...] = (
+    ("devdependenc", "devDependencies"),
+    ("dev dependenc", "devDependencies"),
+    ("peerdependenc", "peerDependencies"),
+    ("peer dependenc", "peerDependencies"),
+    ("optionaldependenc", "optionalDependencies"),
+    ("optional dependenc", "optionalDependencies"),
+    ("runtime dependenc", "dependencies"),
+    ("production dependenc", "dependencies"),
+    ("under `dependencies`", "dependencies"),
+    ("in dependencies", "dependencies"),
+    ("to dependencies", "dependencies"),
+)
+
+
+def _manifest_keys(hunks: Sequence[Hunk]) -> set[str]:
+    """Every JSON key present on a post-image line of the file's hunks."""
+    keys: set[str] = set()
+    for h in hunks:
+        for ln in h.lines:
+            if ln.kind == "-":
+                continue
+            keys.update(_JSON_KEY_RE.findall(ln.text))
+    return keys
+
+
+def _line_json_key(ln: DiffLine) -> str | None:
+    """The dependency key declared on a manifest line, if any.
+
+    A section header or a bare brace declares no dependency, so both
+    answer None and leave the anchor-key check with nothing to compare.
+    """
+    m = _JSON_KEY_RE.search(ln.text)
+    if m is None or m.group(1).lower() in _MANIFEST_NON_PACKAGE_KEYS:
+        return None
+    return m.group(1)
+
+
+def _claimed_package(text: str, keys: set[str]) -> str | None:
+    """The first npm package name in ``text`` that is a key of the file."""
+    for m in _NPM_NAME_RE.finditer(_CITATION_RE.sub(" ", text.lower())):
+        name = m.group(0)
+        if len(name) < 2 or name in _MANIFEST_NON_PACKAGE_KEYS:
+            continue
+        for key in keys:
+            if key.lower() == name:
+                return key
+    return None
+
+
+def _claimed_section(text: str) -> str | None:
+    """The dependency section a claim asserts, by earliest phrasing."""
+    lowered = text.lower()
+    best: tuple[int, str] | None = None
+    for needle, section in _CLAIMED_SECTION_PATTERNS:
+        idx = lowered.find(needle)
+        if idx >= 0 and (best is None or idx < best[0]):
+            best = (idx, section)
+    return best[1] if best else None
+
+
+def _enclosing_section(hunks: Sequence[Hunk], line: int) -> str | None:
+    """The dependency section header above ``line`` in the post-image."""
+    for h in hunks:
+        body = [ln for ln in h.lines if ln.kind != "-"]
+        for i, ln in enumerate(body):
+            if ln.new_line != line:
+                continue
+            for prev in reversed(body[: i + 1]):
+                m = _SECTION_OPEN_RE.search(prev.text)
+                if m is not None:
+                    return m.group(1)
+            return None
+    return None
+
+
+def apply_manifest_claim_check(
+    findings: Sequence[Finding],
+    files: Sequence[FileDiff],
+) -> list[Finding]:
+    """Drop package.json findings that misname their key or their section.
+
+    A worker reading a manifest diff can name a real dependency and then
+    anchor the comment on an unrelated neighbouring entry, or read an
+    entry as a runtime dependency when the enclosing block is
+    ``devDependencies``. Both are checkable against the diff itself: the
+    claim names a package, the anchored line declares a key, and the
+    nearest section header above that line names the block it lives in.
+
+    A finding is dropped with ``drop_reason="anchor mismatch: claims
+    <claimed> but line <n> is <anchor>"`` when the anchored line declares
+    a different dependency, and with ``drop_reason="section mismatch:
+    claims <claimed> but <key> is under <actual>"`` when the anchor is
+    right but the asserted section is not. Findings on other files, on a
+    package.json whose claim names no key of the diff, and findings that
+    already carry a ``drop_reason`` pass through untouched. Order is
+    preserved.
+
+    Run this BEFORE :func:`apply_line_align`: it must read the model's
+    raw anchor, because realignment can move a correctly anchored claim
+    onto the very line this pass exists to catch.
+    """
+    hunks_by_file = {
+        f.path: f.hunks
+        for f in files
+        if PurePosixPath(f.path).name == MANIFEST_BASENAME
+    }
+    result: list[Finding] = []
+    for f in findings:
+        hunks = hunks_by_file.get(f.file)
+        if f.drop_reason is not None or not hunks:
+            result.append(f)
+            continue
+        claim = f"{f.title}\n{f.body}"
+        keys = _manifest_keys(hunks)
+        claimed = _claimed_package(f.title, keys) or _claimed_package(f.body, keys)
+        if claimed is None:
+            result.append(f)
+            continue
+        anchor_ln = next(
+            (ln for h in hunks for ln in h.lines
+             if ln.kind != "-" and ln.new_line == f.line),
+            None,
+        )
+        anchor_key = _line_json_key(anchor_ln) if anchor_ln is not None else None
+        if anchor_key is not None and anchor_key != claimed:
+            result.append(replace(
+                f,
+                drop_reason=(
+                    f"anchor mismatch: claims {claimed} but "
+                    f"line {f.line} is {anchor_key}"
+                ),
+            ))
+            continue
+        claimed_section = _claimed_section(claim)
+        actual_section = _enclosing_section(hunks, f.line)
+        if (
+            claimed_section is not None
+            and actual_section is not None
+            and claimed_section != actual_section
+        ):
+            result.append(replace(
+                f,
+                drop_reason=(
+                    f"section mismatch: claims {claimed_section} but "
+                    f"{claimed} is under {actual_section}"
+                ),
+            ))
+            continue
+        result.append(f)
     return result
 
 
@@ -190,8 +383,15 @@ def _realign_member(
     cannot collide with path words) and compound identifiers split into
     their snake/camel parts (so ``wp_ajax_nopriv_avatar_upload`` can
     answer a claim about "nopriv avatar upload").
+
+    On a ``package.json`` the manifest section words are dropped from the
+    evidence, because every dependency claim mentions one and the long
+    ``dependencies`` token would otherwise outrank the package name and
+    resolve the anchor onto a section header instead of the entry.
     """
     ftoks = _evidence_tokens(f"{finding.title} {finding.body}")
+    if PurePosixPath(finding.file).name == MANIFEST_BASENAME:
+        ftoks -= _MANIFEST_SECTION_TOKENS
     if not ftoks:
         return finding.line
     anchor = _hunk_containing(hunks, finding.line)

--- a/src/prxref/quality.py
+++ b/src/prxref/quality.py
@@ -1,6 +1,12 @@
 """Deterministic quality passes over worker findings.
 
-Six passes run before posting:
+Eleven passes run before posting, in the order ``orchestrate_review``
+applies them. A twelfth deterministic check, the release-shaped-PR
+heuristic, is not a pass at all: ``heuristics.release_shape_findings``
+ADDS a finding before pass 1 and it then flows through every pass below
+exactly like a model finding. Every ``drop_reason`` prefix these passes
+emit is tabulated for operators in ``docs/quality.md``.
+
 1. ``apply_location_validation``: drop findings whose ``file`` names no
    path of the parsed diff — an empty, non-path, or invented location is
    retained with ``drop_reason`` for the audit instead of rendering a
@@ -27,37 +33,47 @@ Six passes run before posting:
    or sits within tolerance of it, and a blank or pure-punctuation
    anchor never survives while any token-bearing added line exists.
 4. ``apply_thread_dedup``: drop findings that duplicate an already-open
-   or existing thread on the PR (path + line-window + shared distinctive tokens).
-4. ``apply_settled_thread_suppression``: drop findings that re-litigate a
+   or existing thread on the PR (path + line-window + shared distinctive
+   tokens), with ``drop_reason`` ``duplicate of existing thread``.
+5. ``apply_settled_thread_suppression``: drop findings that re-litigate a
    subject an existing thread already argued out — same path plus shared
    distinctive tokens, with NO line test, because line alignment has already
-   demoted a file-level finding to line 0 by this point.
-
-5. ``apply_severity_consistency``: findings sharing one normalized title —
+   demoted a file-level finding to line 0 by this point
+   (``settled in thread: <author>``).
+6. ``apply_severity_consistency``: findings sharing one normalized title —
    within a file or across sibling files — are all raised to the group's
    maximum severity, so per-chunk workers cannot disagree about how
    serious the same pattern is. Findings phrased differently but bound
    by a shared rare code token, with a shared problem class or file,
    join the same group (issue #30).
-
-5. ``apply_removal_claim_check``: drop findings claiming a path was
+7. ``apply_removal_claim_check``: drop findings claiming a path was
    removed or deleted when every path the claim names is still present in
    the diff's post-image — the false positive a ``copy from``/``copy to``
    header produces when a worker reads a copy as a move (issue #03).
-
-5. ``apply_hedge_gate``: drop findings whose title or body conditions the
+   Only a claim that NAMES a diff path is judged, so a finding about a
+   removed guard or constant is untouched.
+8. ``apply_hedge_gate``: drop findings whose title or body conditions the
    defect on a precondition the worker never established from the diff
    ("If X still leases a client", "unless the backfill already ran"),
    with ``drop_reason`` ``hedged: "<matched span>"``.
-6. ``apply_quality_gate``: drop findings below the confidence floor, cap
-   errors per review, and enforce the {error, warning, outofscope} severity
-   vocabulary.
-6. ``apply_containment_note``: a finding that asserts a throw, panic,
-   crash, or unhandled rejection and never names where it is caught or
-   where it propagates to has its body suffixed with
-   ``" [containment boundary not stated]"`` — a purely textual decoration,
-   run on active and dropped findings alike, that never changes
-   ``drop_reason`` or severity.
+9. ``apply_quality_gate``: drop findings below the confidence floor
+   (``confidence 0.40 below floor 0.60``), cap errors per review
+   (``error cap exceeded (max N)``), and enforce the
+   {error, warning, outofscope} severity vocabulary
+   (``invalid severity: '<value>'``). It RETURNS its findings sorted by
+   ``finding_sort_key``, so the caller re-derives the chunk/sweep
+   boundary from finding identity rather than carrying an index across it.
+10. ``apply_sweep_dedup``: drop a sweep finding that restates a chunk
+    finding which SURVIVED the gate, on file + normalized title
+    (``duplicate of chunk finding``). It runs after the gate so a
+    sub-floor chunk finding cannot suppress its higher-confidence sweep
+    duplicate and then die at the gate itself.
+11. ``apply_containment_note``: a finding that asserts a throw, panic,
+    crash, or unhandled rejection and never names where it is caught or
+    where it propagates to has its body suffixed with
+    ``" [containment boundary not stated]"`` — a purely textual
+    decoration, run on active and dropped findings alike, that never
+    changes ``drop_reason`` or severity.
 
 Every dropped finding retains its identity with ``drop_reason`` populated,
 so review runstores and logs can explain every filter decision. Use

--- a/src/prxref/quality.py
+++ b/src/prxref/quality.py
@@ -23,13 +23,17 @@ Five passes run before posting:
    anchor never survives while any token-bearing added line exists.
 3. ``apply_thread_dedup``: drop findings that duplicate an already-open
    or existing thread on the PR (path + line-window + shared distinctive tokens).
-4. ``apply_severity_consistency``: findings sharing one normalized title —
+4. ``apply_settled_thread_suppression``: drop findings that re-litigate a
+   subject an existing thread already argued out — same path plus shared
+   distinctive tokens, with NO line test, because line alignment has already
+   demoted a file-level finding to line 0 by this point.
+5. ``apply_severity_consistency``: findings sharing one normalized title —
    within a file or across sibling files — are all raised to the group's
    maximum severity, so per-chunk workers cannot disagree about how
    serious the same pattern is. Findings phrased differently but bound
    by a shared rare code token, with a shared problem class or file,
    join the same group (issue #30).
-5. ``apply_quality_gate``: drop findings below the confidence floor, cap
+6. ``apply_quality_gate``: drop findings below the confidence floor, cap
    errors per review, and enforce the {error, warning, outofscope} severity
    vocabulary.
 
@@ -548,6 +552,58 @@ def apply_thread_dedup(
             min_shared_for_distant=min_shared_for_distant,
         ):
             result.append(replace(f, drop_reason="duplicate of existing thread"))
+        else:
+            result.append(f)
+    return result
+
+
+SETTLED_MIN_SHARED_TOKENS = 4
+
+
+def _normalised_path(path: str) -> str:
+    return path[2:] if path.startswith("./") else path
+
+
+def apply_settled_thread_suppression(
+    findings: Sequence[Finding],
+    threads: Sequence[Thread],
+    min_shared_tokens: int = SETTLED_MIN_SHARED_TOKENS,
+) -> list[Finding]:
+    """Drop findings that re-litigate a subject already argued out in a thread.
+
+    Line-INDEPENDENT, which is the whole point:
+    :func:`apply_thread_dedup` needs the thread and the finding to sit near
+    each other, and :func:`apply_line_align` has already demoted a
+    non-anchorable finding to line 0 by the time either runs. A settled
+    discussion is about a SUBJECT, not a line, so the test here is same path
+    plus at least ``min_shared_tokens`` distinct shared content tokens between
+    the finding's title+body and the thread's snippet.
+
+    ``resolved`` does not gate it: a resolved thread is still a decision the
+    reviewers made with more context than the review has. Order-preserving,
+    pure, and already-dropped findings pass through untouched so the reason
+    an earlier pass gave survives.
+    """
+    if not threads:
+        return list(findings)
+
+    result: list[Finding] = []
+    for f in findings:
+        if f.drop_reason is not None:
+            result.append(f)
+            continue
+        finding_tokens = _tokens(f"{f.title} {f.body}")
+        author = ""
+        if finding_tokens:
+            for t in threads:
+                if _normalised_path(t.path) != _normalised_path(f.file):
+                    continue
+                body_tokens = _tokens(t.body_snippet or "")
+                if len(finding_tokens & body_tokens) >= min_shared_tokens:
+                    author = t.author or "unknown"
+                    break
+        if author:
+            result.append(replace(f, drop_reason=f"settled in thread: {author}"))
         else:
             result.append(f)
     return result

--- a/src/prxref/quality.py
+++ b/src/prxref/quality.py
@@ -1,6 +1,6 @@
 """Deterministic quality passes over worker findings.
 
-Five passes run before posting:
+Six passes run before posting:
 1. ``apply_location_validation``: drop findings whose ``file`` names no
    path of the parsed diff — an empty, non-path, or invented location is
    retained with ``drop_reason`` for the audit instead of rendering a
@@ -29,7 +29,11 @@ Five passes run before posting:
    serious the same pattern is. Findings phrased differently but bound
    by a shared rare code token, with a shared problem class or file,
    join the same group (issue #30).
-5. ``apply_quality_gate``: drop findings below the confidence floor, cap
+5. ``apply_hedge_gate``: drop findings whose title or body conditions the
+   defect on a precondition the worker never established from the diff
+   ("If X still leases a client", "unless the backfill already ran"),
+   with ``drop_reason`` ``hedged: "<matched span>"``.
+6. ``apply_quality_gate``: drop findings below the confidence floor, cap
    errors per review, and enforce the {error, warning, outofscope} severity
    vocabulary.
 
@@ -60,6 +64,64 @@ DEFAULT_MAX_ERRORS: int = 10
 # evidence. 5 also sits below the smallest drift the issue #19 audit measured
 # on real reviews (10 lines), so no observed-failure distance survives.
 DEFAULT_LINE_TOLERANCE: int = 5
+
+# A period that is not followed by whitespace is member access, a filename, or
+# a version — not a sentence break — so the hedge rules may span it.
+_NO_SENTENCE_BREAK = r"(?:[^.;]|\.(?!\s))"
+
+HEDGE_RULES: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "if-still",
+        re.compile(
+            rf"\bif\b{_NO_SENTENCE_BREAK}{{0,80}}?\b(?:still|already|remains?)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "modal-still",
+        re.compile(r"\b(?:may|might|could|likely|probably)\s+still\b", re.IGNORECASE),
+    ),
+    (
+        "assuming",
+        re.compile(
+            r"(?:^|[.;]\s+|,\s*)(?:assuming|presumably|apparently|seemingly)\b(?!-)",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "unless-already",
+        re.compile(
+            rf"\bunless\b{_NO_SENTENCE_BREAK}{{0,60}}?\balready\b", re.IGNORECASE
+        ),
+    ),
+    (
+        "not-verified",
+        re.compile(
+            r"\b(?:I (?:can(?:no|')?t|cannot) (?:verify|tell|confirm|determine)"
+            r"|unable to (?:verify|tell|confirm|determine)"
+            r"|not visible in the diff"
+            r"|not shown in the diff"
+            r"|cannot be confirmed from the diff)",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "only-caller",
+        re.compile(
+            r"\bif this is the only (?:caller|call site|usage|consumer)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "membership",
+        re.compile(
+            r"\bif (?:they|it|this|those|these) (?:are|is) (?:members?|part) of\b",
+            re.IGNORECASE,
+        ),
+    ),
+)
+
+_HEDGE_SPAN_MAX: int = 80
 
 
 def active(findings: Sequence[Finding]) -> list[Finding]:
@@ -861,6 +923,42 @@ def _resolve_max_errors(explicit: int | None) -> int:
             except ValueError:
                 pass
     return DEFAULT_MAX_ERRORS
+
+
+def _hedge_span(text: str) -> str | None:
+    for _name, pattern in HEDGE_RULES:
+        m = pattern.search(text)
+        if m is None:
+            continue
+        span = m.group(0).strip(" \t\n,;.")
+        return span[:_HEDGE_SPAN_MAX]
+    return None
+
+
+def apply_hedge_gate(findings: Sequence[Finding]) -> list[Finding]:
+    """Drop findings whose own text conditions the defect on an unverified fact.
+
+    A hedged finding ("If figmaProxy.prepare still leases a client", "If they
+    are members of the root workspaces globs") states a precondition the
+    worker had the whole diff to check and did not. Each rule in
+    ``HEDGE_RULES`` is anchored on an epistemic marker rather than a bare
+    ``if``/``may``/``unless``, which appear throughout legitimate findings.
+
+    Pure and order-preserving: already-dropped findings pass through
+    untouched, and a match sets ``drop_reason`` to ``hedged: "<span>"``
+    naming the matched text so the drop is auditable in the run record.
+    """
+    out: list[Finding] = []
+    for f in findings:
+        if f.drop_reason is not None:
+            out.append(f)
+            continue
+        span = _hedge_span(f.title or "") or _hedge_span(f.body or "")
+        if span is None:
+            out.append(f)
+            continue
+        out.append(replace(f, drop_reason=f'hedged: "{span}"'))
+    return out
 
 
 def apply_quality_gate(

--- a/src/prxref/quality.py
+++ b/src/prxref/quality.py
@@ -1,6 +1,6 @@
 """Deterministic quality passes over worker findings.
 
-Five passes run before posting:
+Six passes run before posting:
 1. ``apply_location_validation``: drop findings whose ``file`` names no
    path of the parsed diff — an empty, non-path, or invented location is
    retained with ``drop_reason`` for the audit instead of rendering a
@@ -32,6 +32,12 @@ Five passes run before posting:
 5. ``apply_quality_gate``: drop findings below the confidence floor, cap
    errors per review, and enforce the {error, warning, outofscope} severity
    vocabulary.
+6. ``apply_containment_note``: a finding that asserts a throw, panic,
+   crash, or unhandled rejection and never names where it is caught or
+   where it propagates to has its body suffixed with
+   ``" [containment boundary not stated]"`` — a purely textual decoration,
+   run on active and dropped findings alike, that never changes
+   ``drop_reason`` or severity.
 
 Every dropped finding retains its identity with ``drop_reason`` populated,
 so review runstores and logs can explain every filter decision. Use
@@ -614,6 +620,51 @@ def apply_sweep_dedup(
             result.append(f)
     return result
 
+
+_THROW_CLASS_RE = re.compile(
+    r"\bthrows?\b|\bthrowing\b|\bpanics?\b|\bcrash(es|ed)?\b"
+    r"|unhandled rejection|uncaught exception|\braises?\b",
+    re.IGNORECASE,
+)
+
+_CONTAINMENT_BOUNDARY_RE = re.compile(
+    r"\bcaught\b|\buncaught\b|propagat|catch block|catch\s*\(|try/catch"
+    r"|try-catch|\bswallow|handled by|bubbles? up"
+    r"|rejects the promise returned to",
+    re.IGNORECASE,
+)
+
+CONTAINMENT_NOTE_SUFFIX: str = " [containment boundary not stated]"
+
+
+def apply_containment_note(findings: Sequence[Finding]) -> list[Finding]:
+    """Suffix an un-boundaried throw-class finding's body with a note.
+
+    A finding whose title or body asserts a throw, panic, crash, or
+    unhandled rejection (:data:`_THROW_CLASS_RE`) but whose body never
+    names where that exception is caught or where it propagates to
+    (:data:`_CONTAINMENT_BOUNDARY_RE`) has its body suffixed with
+    :data:`CONTAINMENT_NOTE_SUFFIX`, once — a body already carrying the
+    suffix is left unchanged, so the pass is idempotent under repeated
+    application. Purely textual: order-preserving, runs on active and
+    dropped findings alike (it only decorates the text every downstream
+    consumer, including the dropped-findings audit, already carries),
+    and never touches ``drop_reason`` or ``severity``. Findings that do
+    not match, or already name a boundary, pass through as the same
+    instance.
+    """
+    result: list[Finding] = []
+    for f in findings:
+        claim = f"{f.title} {f.body}"
+        if (
+            f.body.endswith(CONTAINMENT_NOTE_SUFFIX)
+            or not _THROW_CLASS_RE.search(claim)
+            or _CONTAINMENT_BOUNDARY_RE.search(f.body)
+        ):
+            result.append(f)
+        else:
+            result.append(replace(f, body=f.body + CONTAINMENT_NOTE_SUFFIX))
+    return result
 
 
 def _problem_classes(title: str) -> set[str]:

--- a/src/prxref/quality.py
+++ b/src/prxref/quality.py
@@ -46,9 +46,9 @@ emit is tabulated for operators in ``docs/quality.md``.
    serious the same pattern is. Findings phrased differently but bound
    by a shared rare code token, with a shared problem class or file,
    join the same group (issue #30).
-7. ``apply_removal_claim_check``: drop findings claiming a path was
-   removed or deleted when every path the claim names is still present in
-   the diff's post-image — the false positive a ``copy from``/``copy to``
+7. ``apply_removal_claim_check``: drop findings whose removal verb governs
+   a path — ``removed src/app.py``, ``src/app.py was removed`` — when every
+   path the claim names is still present in the diff's post-image — the false positive a ``copy from``/``copy to``
    header produces when a worker reads a copy as a move (issue #03).
    Only a claim that NAMES a diff path is judged, so a finding about a
    removed guard or constant is untouched.
@@ -108,11 +108,16 @@ DEFAULT_LINE_TOLERANCE: int = 5
 # a version — not a sentence break — so the hedge rules may span it.
 _NO_SENTENCE_BREAK = r"(?:[^.;]|\.(?!\s))"
 
+# A comma ends the ``if`` clause, so the hedge word has to appear before it to
+# be hedging the CONDITION rather than asserting a defect in the independent
+# clause that follows ("If save() raises, the transaction remains open").
+_NO_CLAUSE_BREAK = r"(?:[^.;,]|\.(?!\s))"
+
 HEDGE_RULES: tuple[tuple[str, re.Pattern[str]], ...] = (
     (
         "if-still",
         re.compile(
-            rf"\bif\b{_NO_SENTENCE_BREAK}{{0,80}}?\b(?:still|already|remains?)\b",
+            rf"\bif\b{_NO_CLAUSE_BREAK}{{0,80}}?\b(?:still|already|remains?)\b",
             re.IGNORECASE,
         ),
     ),
@@ -1317,6 +1322,62 @@ def _claimed_paths(finding: Finding, candidates: Sequence[str]) -> list[str]:
     return [path for _, path in hits]
 
 
+# Words that end a removal verb's object: a preposition or a conjunction after
+# the verb means the following path is the place something was removed FROM, or
+# a new clause, not the thing removed ("the removed null check in src/app.py").
+_OBJECT_STOP = (
+    r"in|from|by|to|at|on|of|for|with|into|onto|via|and|or|but|so"
+    r"|because|that|which|when|while|after|before|since"
+)
+# Up to three determiner/qualifier tokens may sit between the verb and its
+# object ("removed the ServiceNow package.json"), none of them a stop word.
+_OBJECT_FILLER = rf"(?:(?!(?:{_OBJECT_STOP})\b)[\w.'-]+\s+){{0,3}}"
+_REMOVAL_VERB_PRE = r"(?:removed|deleted|deletion of|removal of)"
+_REMOVAL_VERB_POST = (
+    r"(?:(?:was|were|has been|have been|is|are|gets|got)\s+(?:removed|deleted)"
+    r"|no longer exists?)"
+)
+
+
+def _path_forms(path: str) -> list[str]:
+    """How a body may spell one diff path: full, parent/basename, basename."""
+    norm = path.replace("\\", "/").lower()
+    forms = [norm]
+    if "/" in norm:
+        forms.append(_tail(norm, 2))
+        forms.append(_tail(norm, 1))
+    return forms
+
+
+def _governed_claimed_paths(
+    finding: Finding, candidates: Sequence[str]
+) -> list[str]:
+    """Diff paths a removal verb GOVERNS in the finding's own text.
+
+    A bare ``removed`` somewhere in a body and a path somewhere else in it
+    are not a removal claim: "the removed null check in ``src/app.py``"
+    says the check went, not the file. A path counts only when the verb
+    takes it as its object (``removed the file src/app.py``) or when the
+    path is the subject of the removal (``src/app.py was removed``, ``…no
+    longer exists``), with no sentence break between the two.
+    """
+    text = f"{finding.title} {finding.body}".replace("\\", "/").lower()
+    hits: list[tuple[int, str]] = []
+    for path in candidates:
+        alternation = "|".join(re.escape(form) for form in _path_forms(path))
+        anchored = rf"(?<![\w/-])`?(?:{alternation})`?(?![\w/-])"
+        pattern = re.compile(
+            rf"{_REMOVAL_VERB_PRE}\s+(?:the\s+)?(?:file\s+)?"
+            rf"{_OBJECT_FILLER}{anchored}"
+            rf"|{anchored}\s+{_REMOVAL_VERB_POST}"
+        )
+        m = pattern.search(text)
+        if m is not None:
+            hits.append((m.start(), path))
+    hits.sort()
+    return [path for _, path in hits]
+
+
 def apply_removal_claim_check(
     findings: Sequence[Finding], files: Sequence[FileDiff]
 ) -> list[Finding]:
@@ -1324,7 +1385,10 @@ def apply_removal_claim_check(
 
     A finding whose title or body asserts a file was removed, deleted, or
     no longer exists is dropped when every path it names is still present
-    after the PR lands. A copy's source is present unless a separate
+    after the PR lands. The removal verb has to GOVERN one of those paths:
+    "the removed null check in ``src/app.py``" removes a check, not the
+    file, so a bare removal word plus an unrelated path mention is left
+    active. A copy's source is present unless a separate
     section removes it, so a ``copy from``/``copy to`` header read as a
     move produces exactly this false positive. When any named path really
     is absent from the post-image, the claim is left active — the pass
@@ -1343,19 +1407,21 @@ def apply_removal_claim_check(
         if not _REMOVAL_CLAIM_RE.search(f"{f.title} {f.body}"):
             out.append(f)
             continue
-        # Only a claim that NAMES a path is judged. Falling back to the
-        # finding's anchor file would drop every finding whose body merely
-        # says something was "removed" — a guard, a constant, a validator —
-        # on a file the PR still leaves in place, which is precisely the
-        # guard-removal class the systemic sweep exists to report.
+        # Only a claim whose removal verb GOVERNS a path is judged. Falling
+        # back to the finding's anchor file, or to any path merely mentioned
+        # somewhere in the body, would drop every finding that says something
+        # was "removed" — a guard, a constant, a validator — on a file the PR
+        # still leaves in place, which is precisely the guard-removal class
+        # the systemic sweep exists to report.
+        governed = _governed_claimed_paths(f, candidates)
         named = _claimed_paths(f, candidates)
-        if named and all(path in present for path in named):
+        if governed and all(path in present for path in named):
             out.append(
                 replace(
                     f,
                     drop_reason=(
                         "claims removal of a path present in the "
-                        f"post-image: {named[0]}"
+                        f"post-image: {governed[0]}"
                     ),
                 )
             )

--- a/src/prxref/quality.py
+++ b/src/prxref/quality.py
@@ -1,6 +1,6 @@
 """Deterministic quality passes over worker findings.
 
-Five passes run before posting:
+Six passes run before posting:
 1. ``apply_location_validation``: drop findings whose ``file`` names no
    path of the parsed diff — an empty, non-path, or invented location is
    retained with ``drop_reason`` for the audit instead of rendering a
@@ -29,7 +29,11 @@ Five passes run before posting:
    serious the same pattern is. Findings phrased differently but bound
    by a shared rare code token, with a shared problem class or file,
    join the same group (issue #30).
-5. ``apply_quality_gate``: drop findings below the confidence floor, cap
+5. ``apply_removal_claim_check``: drop findings claiming a path was
+   removed or deleted when every path the claim names is still present in
+   the diff's post-image — the false positive a ``copy from``/``copy to``
+   header produces when a worker reads a copy as a move (issue #03).
+6. ``apply_quality_gate``: drop findings below the confidence floor, cap
    errors per review, and enforce the {error, warning, outofscope} severity
    vocabulary.
 
@@ -836,6 +840,106 @@ def apply_severity_consistency(findings: Sequence[Finding]) -> list[Finding]:
                 continue
         result.append(f)
     return result
+
+
+_REMOVAL_CLAIM_RE = re.compile(
+    r"\b(?:removed|deleted|dropped the file|no longer exists|was removed"
+    r"|is removed|has been removed|deletion of)\b",
+    re.IGNORECASE,
+)
+
+
+def _post_image_paths(files: Sequence[FileDiff]) -> set[str]:
+    """Every path the diff leaves present after the PR lands.
+
+    A file section with any status other than ``removed`` leaves its path
+    in place, and a ``copied`` section leaves its SOURCE in place too — a
+    copy reads the original without touching it, so only a separate
+    ``removed`` section can take that source away.
+    """
+    present: set[str] = set()
+    for f in files:
+        if f.status != "removed":
+            present.add(f.path)
+        if f.status == "copied" and f.old_path:
+            present.add(f.old_path)
+    return present
+
+
+def _diff_path_candidates(files: Sequence[FileDiff]) -> list[str]:
+    """Every path a finding could name: each section's path plus copy/rename sources."""
+    seen: list[str] = []
+    for f in files:
+        for path in (f.path, f.old_path if f.status in {"copied", "renamed"} else None):
+            if path and path not in seen:
+                seen.append(path)
+    return seen
+
+
+def _tail(path: str, parts: int) -> str:
+    return "/".join(path.replace("\\", "/").split("/")[-parts:])
+
+
+def _claimed_paths(finding: Finding, candidates: Sequence[str]) -> list[str]:
+    """Diff paths the finding's title+body name, in order of first mention.
+
+    A path counts as named by its full form or by its
+    basename-with-parent-directory (``servicenow/package.json``), which is
+    how a worker usually refers to a file inside a monorepo package.
+    """
+    text = f"{finding.title} {finding.body}".replace("\\", "/").lower()
+    hits: list[tuple[int, str]] = []
+    for path in candidates:
+        norm = path.replace("\\", "/").lower()
+        at = text.find(norm)
+        if at < 0 and "/" in norm:
+            at = text.find(_tail(norm, 2))
+        if at >= 0:
+            hits.append((at, path))
+    hits.sort()
+    return [path for _, path in hits]
+
+
+def apply_removal_claim_check(
+    findings: Sequence[Finding], files: Sequence[FileDiff]
+) -> list[Finding]:
+    """Drop removal claims the diff's post-image contradicts.
+
+    A finding whose title or body asserts a file was removed, deleted, or
+    no longer exists is dropped when every path it names is still present
+    after the PR lands. A copy's source is present unless a separate
+    section removes it, so a ``copy from``/``copy to`` header read as a
+    move produces exactly this false positive. When any named path really
+    is absent from the post-image, the claim is left active — the pass
+    never blanket-drops removal language.
+
+    Input order is preserved and findings already carrying a
+    ``drop_reason`` pass through untouched.
+    """
+    present = _post_image_paths(files)
+    candidates = _diff_path_candidates(files)
+    out: list[Finding] = []
+    for f in findings:
+        if f.drop_reason is not None:
+            out.append(f)
+            continue
+        if not _REMOVAL_CLAIM_RE.search(f"{f.title} {f.body}"):
+            out.append(f)
+            continue
+        named = _claimed_paths(f, candidates) or ([f.file] if f.file else [])
+        if named and all(path in present for path in named):
+            out.append(
+                replace(
+                    f,
+                    drop_reason=(
+                        "claims removal of a path present in the "
+                        f"post-image: {named[0]}"
+                    ),
+                )
+            )
+            continue
+        out.append(f)
+    return out
 
 
 def _resolve_confidence_floor(explicit: float | None) -> float:

--- a/src/prxref/quality.py
+++ b/src/prxref/quality.py
@@ -571,6 +571,35 @@ def normalize_title(title: str) -> str:
     return " ".join(trimmed.split())
 
 
+def finding_sort_key(finding: Finding) -> tuple[str, int, str]:
+    """Content-derived ordering key for a finding: ``(file, line, title)``.
+
+    Every pass that emits or presents a list of findings sorts by this key so
+    the output of a review depends on WHAT was found, never on the order the
+    workers happened to return it in.
+    """
+    return (
+        finding.file or "",
+        finding.line if finding.line is not None else -1,
+        finding.title or "",
+    )
+
+
+def finding_rank_key(finding: Finding) -> tuple[float, str, int, str]:
+    """Tie-break key for caps: ``(-confidence, file, line, normalized title)``.
+
+    Confidence decides first; everything after it exists only so that two
+    equally confident findings are ranked by content rather than by arrival.
+    """
+    file, line, _ = finding_sort_key(finding)
+    return (
+        -float(finding.confidence or 0.0),
+        file,
+        line,
+        normalize_title(finding.title or ""),
+    )
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -875,8 +904,11 @@ def apply_quality_gate(
     1. Severity vocabulary: non-empty lowercase must be in {error, warning, note};
        case-mismatches are normalized; invalid severities are dropped.
     2. Confidence floor: drop findings below the threshold (default 0.6).
-    3. Error cap: among surviving errors, keep the top N by confidence and drop
-       the rest.
+    3. Error cap: among surviving errors, keep the top N ranked by
+       :func:`finding_rank_key` and drop the rest, so ties are broken by
+       content rather than by arrival order.
+
+    The returned list is sorted by :func:`finding_sort_key`.
     """
     floor = _resolve_confidence_floor(confidence_floor)
     cap = _resolve_max_errors(max_errors)
@@ -916,8 +948,7 @@ def apply_quality_gate(
     if len(active_error_indices) > cap:
         ranked = sorted(
             active_error_indices,
-            key=lambda idx: (float(staged[idx].confidence or 0.0)),
-            reverse=True,
+            key=lambda idx: finding_rank_key(staged[idx]),
         )
         for dropped_idx in ranked[cap:]:
             staged[dropped_idx] = replace(
@@ -925,4 +956,4 @@ def apply_quality_gate(
                 drop_reason=f"error cap exceeded (max {cap})",
             )
 
-    return staged
+    return sorted(staged, key=finding_sort_key)

--- a/src/prxref/reviewer.py
+++ b/src/prxref/reviewer.py
@@ -120,6 +120,7 @@ def _render_prompt(
     pr_description: str,
     repo_hint: str,
     context_lines: int | None = None,
+    context_blocks: str = "",
 ) -> tuple[str, str]:
     template = load_prompt("worker.md")
     head, marker, tail = template.partition(_CONTEXT_MARKER)
@@ -133,6 +134,8 @@ def _render_prompt(
         "{pr_description}", pr_description.strip() or "(none)"
     ).replace(
         "{repo_hint}", repo_hint.strip() or "(unspecified)"
+    ).replace(
+        "{context_blocks}", context_blocks.strip()
     ).replace(
         "{diff}", render_chunk(chunk, context_lines) or "(empty chunk)"
     )
@@ -291,6 +294,7 @@ def review_chunk(
     repo_hint: str = "",
     max_tokens: int | None = None,
     context_lines: int | None = None,
+    context_blocks: str = "",
 ) -> tuple[list[Finding], dict]:
     """Review one chunk with a single LLM call.
 
@@ -323,6 +327,11 @@ def review_chunk(
     unaffected here too. The forge's diff is the only source of context —
     rendering can trim what was received, never add what it did not. The
     orchestrator always passes this keyword as well.
+
+    ``context_blocks`` is pre-rendered supplementary context — dependency pins
+    and out-of-hunk definitions built by :mod:`prxref.chunk_context` — placed
+    after the diff, inside the ``user`` half of the prompt. The empty default
+    renders nothing at all, leaving no stray header for direct callers.
     """
     system, user = _render_prompt(
         chunk=chunk,
@@ -330,6 +339,7 @@ def review_chunk(
         pr_description=pr_description,
         repo_hint=repo_hint,
         context_lines=context_lines,
+        context_blocks=context_blocks,
     )
     budget = MAX_TOKENS if max_tokens is None else max_tokens
     return _invoke_and_parse(

--- a/src/prxref/reviewer.py
+++ b/src/prxref/reviewer.py
@@ -7,7 +7,10 @@ onto :class:`prxref.triage.Finding` records. Unparseable or malformed
 responses degrade to ``([], [])`` with a logged warning; this layer
 never raises. :func:`review_systemic` is the same contract over the
 whole-PR digest built by :mod:`prxref.systemic`, for the second-order
-classes no single chunk seat can see.
+classes no single chunk seat can see. Both ``prompts/worker.md`` and
+``prompts/systemic.md`` require a throw/panic/crash/unhandled-rejection
+finding to name its containment boundary; :func:`prxref.quality.apply_containment_note`
+enforces that deterministically on any finding that skips it.
 
 When a response is unparseable *because* the model ran out of completion
 budget (``finish_reason == "length"``), the reported error names the budget

--- a/src/prxref/reviewer.py
+++ b/src/prxref/reviewer.py
@@ -7,7 +7,18 @@ onto :class:`prxref.triage.Finding` records. Unparseable or malformed
 responses degrade to ``([], [])`` with a logged warning; this layer
 never raises. :func:`review_systemic` is the same contract over the
 whole-PR digest built by :mod:`prxref.systemic`, for the second-order
-classes no single chunk seat can see. Both ``prompts/worker.md`` and
+classes no single chunk seat can see.
+
+Both calls take optional supplementary context, and both degrade to the
+pre-existing prompt when it is absent: :func:`review_chunk` takes
+``context_blocks`` (the dependency-version and referenced-definition
+blocks the orchestrator builds from an optional forge
+``get_file_content``), and :func:`review_systemic` takes ``threads`` (the
+PR's existing review discussion, rendered by
+:func:`_render_discussion_block` under the ``DISCUSSION_MAX_*`` caps) so
+the sweep stops re-raising subjects the team already argued out.
+
+Both ``prompts/worker.md`` and
 ``prompts/systemic.md`` require a throw/panic/crash/unhandled-rejection
 finding to name its containment boundary; :func:`prxref.quality.apply_containment_note`
 enforces that deterministically on any finding that skips it.

--- a/src/prxref/reviewer.py
+++ b/src/prxref/reviewer.py
@@ -19,9 +19,11 @@ from __future__ import annotations
 
 import logging
 import time
+from collections.abc import Sequence
 from importlib import resources
 from typing import Any
 
+from .forges.base import Thread
 from .llm import LLMClient
 from .parser import loads_lenient
 from .triage import FileDiff, Finding, trim_hunk_context
@@ -34,6 +36,13 @@ DEFAULT_CONFIDENCE = 0.5
 _CONTEXT_MARKER = "## Review Context"
 
 _MAX_TOKENS_ENV = "PRXREF_LLM_MAX_TOKENS"
+
+# Caps on the ``### Existing discussion`` block appended to the sweep prompt.
+# The sweep's measured input is 1878-3585 tokens, so the discussion is held to
+# roughly 300 tokens: it informs the sweep, it never rivals the digest.
+DISCUSSION_MAX_THREADS = 15
+DISCUSSION_MAX_SNIPPET_CHARS = 200
+DISCUSSION_MAX_CHARS = 1200
 
 # Every spelling that means "I stopped because I ran out of output budget".
 # ``length`` is the OpenAI vocabulary that litellm normalises to; a plain
@@ -139,11 +148,45 @@ def _render_prompt(
     return head.strip(), user.strip()
 
 
+def _render_discussion_block(threads: Sequence[Thread]) -> str:
+    """The ``### Existing discussion`` block for the sweep user prompt.
+
+    One ``- <path>: <author>: <snippet>`` line per thread, snippets truncated
+    to :data:`DISCUSSION_MAX_SNIPPET_CHARS`, the block capped at
+    :data:`DISCUSSION_MAX_THREADS` threads and
+    :data:`DISCUSSION_MAX_CHARS` characters so the discussion cannot rival the
+    digest for prompt budget. Returns ``""`` when there is nothing to say, so
+    an absent discussion prints no header at all.
+    """
+    lines: list[str] = []
+    used = 0
+    shown = 0
+    for t in threads[:DISCUSSION_MAX_THREADS]:
+        snippet = " ".join((t.body_snippet or "").split())
+        if not snippet:
+            continue
+        if len(snippet) > DISCUSSION_MAX_SNIPPET_CHARS:
+            snippet = snippet[:DISCUSSION_MAX_SNIPPET_CHARS].rstrip() + "…"
+        line = f"- {t.path}: {t.author or 'unknown'}: {snippet}"
+        if used + len(line) + 1 > DISCUSSION_MAX_CHARS:
+            break
+        lines.append(line)
+        used += len(line) + 1
+        shown += 1
+    if not lines:
+        return ""
+    omitted = len([t for t in threads if (t.body_snippet or "").strip()]) - shown
+    if omitted > 0:
+        lines.append(f"… {omitted} more threads omitted")
+    return "### Existing discussion\n\n" + "\n".join(lines)
+
+
 def _render_systemic_prompt(
     digest: str,
     pr_title: str,
     pr_description: str,
     repo_hint: str,
+    threads: Sequence[Thread] = (),
 ) -> tuple[str, str]:
     template = load_prompt("systemic.md")
     head, marker, tail = template.partition(_CONTEXT_MARKER)
@@ -160,7 +203,11 @@ def _render_systemic_prompt(
     ).replace(
         "{digest}", digest.strip() or "(empty digest)"
     )
-    return head.strip(), user.strip()
+    discussion = _render_discussion_block(threads)
+    user = user.strip()
+    if discussion:
+        user = f"{user}\n\n{discussion}"
+    return head.strip(), user
 
 
 def _as_int(value: Any, default: int = 0) -> int:
@@ -345,6 +392,7 @@ def review_systemic(
     pr_description: str = "",
     repo_hint: str = "",
     max_tokens: int | None = None,
+    threads: Sequence[Thread] = (),
 ) -> tuple[list[Finding], dict]:
     """Review the whole-PR systemic digest with a single LLM call.
 
@@ -366,6 +414,7 @@ def review_systemic(
         pr_title=pr_title,
         pr_description=pr_description,
         repo_hint=repo_hint,
+        threads=threads,
     )
     budget = MAX_TOKENS if max_tokens is None else max_tokens
     return _invoke_and_parse(llm, system, user, budget=budget, label="systemic sweep")

--- a/src/prxref/reviewer.py
+++ b/src/prxref/reviewer.py
@@ -87,6 +87,9 @@ def _render_file(f: FileDiff, context_lines: int | None = None) -> str:
     if f.status == "renamed" and f.old_path and f.new_path:
         out.append(f"rename from {f.old_path}")
         out.append(f"rename to {f.new_path}")
+    if f.status == "copied" and f.old_path and f.new_path:
+        out.append(f"copy from {f.old_path}")
+        out.append(f"copy to {f.new_path}")
     if f.is_binary:
         out.append(f"Binary files a/{old} and b/{new} differ")
         return "\n".join(out)

--- a/src/prxref/systemic.py
+++ b/src/prxref/systemic.py
@@ -82,7 +82,7 @@ _FULL_CONTENT_NOTE = "[full content omitted: {reason}]"
 # is the miss that motivates this: without the buckets, the first 40
 # console.log lines consume the cap and the credential line is counted as
 # omitted. Within each bucket, diff order is preserved.
-_MUST_SEE_CLASSES = frozenset({"entry-point", "secret", "auth-check"})
+_MUST_SEE_CLASSES = frozenset({"entry-point", "secret", "auth-check", "guard-removal"})
 
 # Lockfile basenames whose coexistence in one diff signals repo-config drift.
 _LOCKFILE_BASENAMES = frozenset({
@@ -147,6 +147,27 @@ _DIGEST_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
         ),
     ),
     (
+        # Removal-only (see :func:`match_class`): a numeric limit constant or
+        # a validator/guard definition that the PR DELETES. Nothing about the
+        # remaining code marks the absence, so the deleted line is the only
+        # evidence the sweep will ever get.
+        "guard-removal",
+        re.compile(
+            r"\b(?:[A-Z][A-Z0-9_]*)?"
+            r"(?:MAX|MIN|LIMIT|LENGTH|SIZE|BYTES|TIMEOUT|CAP)"
+            r"[A-Z0-9_]*\s*(?::\s*[A-Za-z_][\w.\[\], ]*)?\s*=\s*[0-9][0-9_]*"
+            r"|\b(?:function|def|fn|func)\s+"
+            r"(?:is[A-Z]\w*|isValid\w*|isSupported\w*|assert\w*|check\w*"
+            r"|validate\w*|sanitiz\w*|escape\w*|guard\w*)\s*\("
+            r"|\bconst\s+"
+            r"(?:is[A-Z]\w*|isValid\w*|isSupported\w*|assert\w*|check\w*"
+            r"|validate\w*|sanitiz\w*|escape\w*|guard\w*)\s*=\s*(?:async\s*)?\("
+            r"|^\s*(?:\w+\s+)*"
+            r"(?:is[A-Z]\w*|isValid\w*|isSupported\w*|assert\w*|check\w*"
+            r"|validate\w*|sanitiz\w*|escape\w*|guard\w*)\s*\([^)]*\)\s*\{"
+        ),
+    ),
+    (
         "error-swallow",
         re.compile(
             r"\bcatch\s*(?:\(|\{)"
@@ -196,15 +217,22 @@ _DIGEST_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
 _PATTERN_BY_NAME = dict(_DIGEST_PATTERNS)
 
 
-def match_class(text: str) -> str | None:
+def match_class(text: str, *, kind: str = "+") -> str | None:
     """The first pattern class ``text`` matches, or ``None``.
 
-    Applied to one diff body line with its ``+``/``-``/space prefix stripped.
-    Classes are mutually exclusive per line by report order only; a line that
-    matches several is reported under the first, which keeps the digest one
-    line per diff line.
+    Applied to one diff body line with its ``+``/``-``/space prefix stripped;
+    ``kind`` is that prefix. Classes are mutually exclusive per line by report
+    order only; a line that matches several is reported under the first, which
+    keeps the digest one line per diff line.
+
+    ``guard-removal`` is the one kind-sensitive class: a limit constant or a
+    validator definition is only a systemic signal when the PR DELETES it, so
+    it is offered for ``kind == "-"`` lines only. Every other class ignores
+    ``kind``.
     """
     for name, pattern in _DIGEST_PATTERNS:
+        if name == "guard-removal" and kind != "-":
+            continue
         if pattern.search(text):
             return name
     return None
@@ -221,7 +249,7 @@ def _matched_lines(f: FileDiff) -> list[DiffLine]:
     rest: list[DiffLine] = []
     for h in f.hunks:
         for ln in h.lines:
-            cls = match_class(ln.text)
+            cls = match_class(ln.text, kind=ln.kind)
             if ln.kind == " " or cls is None:
                 continue
             if cls in _MUST_SEE_CLASSES:
@@ -254,7 +282,7 @@ def _full_content_lines(f: FileDiff) -> list[DiffLine]:
         for ln in h.lines:
             if ln.kind == " ":
                 continue
-            if ln.kind == "-" and match_class(ln.text) is None:
+            if ln.kind == "-" and match_class(ln.text, kind=ln.kind) is None:
                 continue
             out.append(ln)
     return out

--- a/src/prxref/triage.py
+++ b/src/prxref/triage.py
@@ -75,7 +75,7 @@ class FileDiff:
     path: str
     old_path: str | None
     new_path: str | None
-    status: str = "modified"  # added | modified | removed | renamed
+    status: str = "modified"  # added | modified | removed | renamed | copied
     is_binary: bool = False
     hunks: list[Hunk] = field(default_factory=list)
 
@@ -180,7 +180,7 @@ def _parse_hunk_body(diff_lines: list[str], i: int, hunk: Hunk) -> int:
 def parse_unified_diff(diff: str) -> list[FileDiff]:
     """Parse a raw unified diff into per-file FileDiff records.
 
-    Handles added/deleted/renamed files (via /dev/null operands and git
+    Handles added/deleted/renamed/copied files (via /dev/null operands and git
     extended headers), binary files (marked ``is_binary``, no hunks), and
     hunks whose body lines themselves begin with ``+``/``-``/``@@``.
     Non-git fragments lacking a ``---``/``+++`` header are ignored.
@@ -191,6 +191,7 @@ def parse_unified_diff(diff: str) -> list[FileDiff]:
     pending_old: str | None = None
     have_pending_old = False
     cur: FileDiff | None = None
+    copy_hint = False
     rename_hint = False
     added_hint = False
     removed_hint = False
@@ -199,7 +200,9 @@ def parse_unified_diff(diff: str) -> list[FileDiff]:
         nonlocal cur
         if cur is None:
             return
-        if rename_hint:
+        if copy_hint:
+            cur.status = "copied"
+        elif rename_hint:
             cur.status = "renamed"
         elif added_hint:
             cur.status = "added"
@@ -226,7 +229,7 @@ def parse_unified_diff(diff: str) -> list[FileDiff]:
             old = m.group(1) if m else None
             new = m.group(2) if m else None
             cur = FileDiff(path=new or old or "", old_path=old, new_path=new)
-            rename_hint = added_hint = removed_hint = False
+            copy_hint = rename_hint = added_hint = removed_hint = False
             i += 1
             continue
 
@@ -282,6 +285,24 @@ def parse_unified_diff(diff: str) -> list[FileDiff]:
             cur.new_path = line[len("rename to "):]
             cur.path = cur.new_path
             rename_hint = True
+            i += 1
+            continue
+        if line.startswith("copy from ") and cur is not None:
+            cur.old_path = _clean_path(line[len("copy from "):]) or cur.old_path
+            copy_hint = True
+            i += 1
+            continue
+        if line.startswith("copy to ") and cur is not None:
+            cleaned = _clean_path(line[len("copy to "):])
+            if cleaned:
+                cur.new_path = cleaned
+                cur.path = cleaned
+            copy_hint = True
+            i += 1
+            continue
+        if line.startswith("similarity index ") or line.startswith(
+            "dissimilarity index "
+        ):
             i += 1
             continue
         if line.startswith("new file mode"):

--- a/tests/test_chunk_context.py
+++ b/tests/test_chunk_context.py
@@ -1,0 +1,279 @@
+"""Unit tests for :mod:`prxref.chunk_context`.
+
+The module is pure — every test supplies its own ``read`` callable — so these
+pin the extraction, the manifest walk, and the caps without a forge, an LLM, or
+a filesystem anywhere in the loop.
+"""
+from __future__ import annotations
+
+from prxref.chunk_context import (
+    ChunkFile,
+    chunk_files,
+    dependency_versions,
+    imported_packages,
+    referenced_definitions,
+    render_context_blocks,
+)
+from prxref.triage import parse_unified_diff
+
+
+def reader(files: dict[str, str]):
+    def _read(path: str) -> str | None:
+        return files.get(path)
+    return _read
+
+
+class TestImportExtraction:
+    def test_js_forms_all_resolve_to_bare_package_names(self):
+        added = [
+            "import { Effect } from 'effect';",
+            "import 'side-effect-pkg';",
+            "const fs = require('graceful-fs');",
+            "const lazy = await import('lodash/merge');",
+            "import { x } from '@scope/pkg/deep';",
+        ]
+        assert imported_packages("src/a.ts", added) == {
+            "effect", "side-effect-pkg", "graceful-fs", "lodash", "@scope/pkg",
+        }
+
+    def test_relative_and_node_specifiers_are_ignored(self):
+        added = [
+            "import { a } from './local';",
+            "import { b } from '../up/there';",
+            "import fs from 'node:fs';",
+            "import x from '/abs/path';",
+        ]
+        assert imported_packages("src/a.ts", added) == set()
+
+    def test_python_stdlib_and_relative_imports_are_excluded(self):
+        added = [
+            "import json",
+            "import requests",
+            "from pathlib import Path",
+            "from .local import thing",
+            "from prxref.triage import FileDiff",
+            "import os, click",
+        ]
+        assert imported_packages("src/a.py", added) == {
+            "requests", "prxref", "click",
+        }
+
+    def test_rust_external_crates_only(self):
+        added = ["use serde::Serialize;", "use crate::thing::X;", "use std::io;"]
+        assert imported_packages("src/a.rs", added) == {"serde"}
+
+    def test_unknown_language_yields_nothing(self):
+        assert imported_packages("README.md", ["import x from 'y';"]) == set()
+
+
+class TestDependencyVersions:
+    def test_package_json_dependencies_and_dev_dependencies(self):
+        files = [ChunkFile("src/a.ts", ("import { E } from 'effect';",
+                                        "import { t } from 'vitest';"))]
+        read = reader({"package.json": (
+            '{"dependencies": {"effect": "4.0.0-rc.110", "unused": "1.0.0"},'
+            ' "devDependencies": {"vitest": "^2.1.0"}}'
+        )})
+        assert dependency_versions(files, read) == [
+            "effect@4.0.0-rc.110", "vitest@^2.1.0",
+        ]
+
+    def test_only_imported_packages_are_reported(self):
+        files = [ChunkFile("a.ts", ("import { E } from 'effect';",))]
+        read = reader({"package.json": '{"dependencies": {"left-pad": "1.0.0"}}'})
+        assert dependency_versions(files, read) == []
+
+    def test_pyproject_project_dependencies(self):
+        files = [ChunkFile("src/a.py", ("import requests",))]
+        read = reader({"pyproject.toml": (
+            '[project]\nname = "x"\ndependencies = ["requests>=2.31", "rich"]\n'
+        )})
+        assert dependency_versions(files, read) == ["requests@>=2.31"]
+
+    def test_pyproject_poetry_dependencies(self):
+        files = [ChunkFile("src/a.py", ("import httpx",))]
+        read = reader({"pyproject.toml": (
+            '[tool.poetry.dependencies]\nhttpx = "^0.27"\n'
+        )})
+        assert dependency_versions(files, read) == ["httpx@^0.27"]
+
+    def test_pyproject_name_normalization_across_dash_and_underscore(self):
+        files = [ChunkFile("a.py", ("import ruamel_yaml",))]
+        read = reader({"pyproject.toml": '[project]\ndependencies = ["ruamel-yaml==0.18"]\n'})
+        assert dependency_versions(files, read) == ["ruamel-yaml@==0.18"]
+
+    def test_go_mod_require_block(self):
+        files = [ChunkFile("cmd/a.go", ('import "github.com/pkg/errors"',))]
+        read = reader({"go.mod": (
+            "module x\n\nrequire (\n\tgithub.com/pkg/errors v0.9.1\n)\n"
+        )})
+        # Go package names are not import paths; extraction is deliberately
+        # out of scope, so the manifest parses but nothing is emitted.
+        assert dependency_versions(files, read) == []
+
+    def test_cargo_dependencies_table_and_inline_version(self):
+        files = [ChunkFile("src/a.rs", ("use serde::Serialize;", "use tokio::spawn;"))]
+        read = reader({"Cargo.toml": (
+            '[dependencies]\nserde = "1.0.203"\n'
+            'tokio = { version = "1.38", features = ["full"] }\n'
+        )})
+        assert dependency_versions(files, read) == ["serde@1.0.203", "tokio@1.38"]
+
+    def test_nearest_manifest_wins_over_the_repo_root(self):
+        files = [ChunkFile("packages/web/src/a.ts", ("import { E } from 'effect';",))]
+        read = reader({
+            "packages/web/package.json": '{"dependencies": {"effect": "4.0.0"}}',
+            "package.json": '{"dependencies": {"effect": "2.0.0"}}',
+        })
+        assert dependency_versions(files, read) == ["effect@4.0.0"]
+
+    def test_walk_stops_at_the_repo_root(self):
+        files = [ChunkFile("a/b/c.ts", ("import { E } from 'effect';",))]
+        seen: list[str] = []
+
+        def read(path: str) -> str | None:
+            seen.append(path)
+            return None
+
+        assert dependency_versions(files, read) == []
+        assert seen == ["a/b/package.json", "a/package.json", "package.json"]
+
+    def test_results_are_sorted_and_deduplicated(self):
+        files = [
+            ChunkFile("a.ts", ("import { E } from 'effect';",)),
+            ChunkFile("b.ts", ("import { E } from 'effect';", "import z from 'zod';")),
+        ]
+        read = reader({"package.json": '{"dependencies": {"effect": "4.0.0", "zod": "3.0"}}'})
+        assert dependency_versions(files, read) == ["effect@4.0.0", "zod@3.0"]
+
+    def test_a_malformed_manifest_contributes_nothing(self):
+        files = [ChunkFile("a.ts", ("import { E } from 'effect';",))]
+        assert dependency_versions(files, reader({"package.json": "{not json"})) == []
+
+
+def _ts_file(defline: str = "const Positive = check(") -> str:
+    body = [f"// filler {i}" for i in range(1, 10)]
+    body += [defline, "  isInt(),", ");"]
+    body += [f"// filler {i}" for i in range(13, 30)]
+    return "\n".join(body) + "\n"
+
+
+class TestReferencedDefinitions:
+    def test_multi_line_definition_is_captured_to_the_balanced_paren(self):
+        files = [ChunkFile("src/a.ts", ("  limit: Positive,",), frozenset({25, 26}))]
+        out = referenced_definitions(files, reader({"src/a.ts": _ts_file()}))
+        assert out == ["src/a.ts:10: const Positive = check(\n  isInt(),\n);"]
+
+    def test_a_definition_inside_the_hunk_is_not_emitted(self):
+        files = [ChunkFile("src/a.ts", ("  limit: Positive,",), frozenset(range(1, 30)))]
+        assert referenced_definitions(files, reader({"src/a.ts": _ts_file()})) == []
+
+    def test_an_identifier_defined_on_an_added_line_is_not_emitted(self):
+        added = ("const Positive = 5;", "  limit: Positive,")
+        files = [ChunkFile("src/a.ts", added, frozenset({25}))]
+        assert referenced_definitions(files, reader({"src/a.ts": _ts_file()})) == []
+
+    def test_python_def_class_and_column_zero_assignment(self):
+        source = (
+            "LIMIT = 10\n"
+            "\n"
+            "def helper(x):\n"
+            "    return x\n"
+            "\n"
+            "class Widget:\n"
+            "    pass\n"
+        ) + "".join(f"# pad {i}\n" for i in range(8, 40))
+        files = [ChunkFile("m.py", ("    return helper(LIMIT) or Widget()",), frozenset({50}))]
+        assert referenced_definitions(files, reader({"m.py": source})) == [
+            "m.py:1: LIMIT = 10",
+            "m.py:3: def helper(x):",
+            "m.py:6: class Widget:",
+        ]
+
+    def test_language_keywords_are_never_looked_up(self):
+        source = "const type = 1;\n" + "// pad\n" * 20
+        files = [ChunkFile("a.ts", ("  const x: type = 1;",), frozenset({30}))]
+        assert referenced_definitions(files, reader({"a.ts": source})) == []
+
+    def test_entries_are_ordered_by_path_then_line(self):
+        a = "const Alpha = 1;\n" + "// pad\n" * 20
+        b = "const Beta = 2;\nconst Gamma = 3;\n" + "// pad\n" * 20
+        files = [
+            ChunkFile("z/b.ts", ("Beta; Gamma;",), frozenset({40})),
+            ChunkFile("a/a.ts", ("Alpha;",), frozenset({40})),
+        ]
+        out = referenced_definitions(files, reader({"a/a.ts": a, "z/b.ts": b}))
+        assert out == [
+            "a/a.ts:1: const Alpha = 1;",
+            "z/b.ts:1: const Beta = 2;",
+            "z/b.ts:2: const Gamma = 3;",
+        ]
+
+    def test_max_lines_per_entry_truncates_an_unbalanced_definition(self):
+        source = "const Wide = f(\n" + "  a,\n" * 20 + ");\n"
+        files = [ChunkFile("a.ts", ("Wide;",), frozenset({99}))]
+        out = referenced_definitions(
+            files, reader({"a.ts": source}), max_lines_per_entry=3,
+        )
+        assert out == ["a.ts:1: const Wide = f(\n  a,\n  a,"]
+
+    def test_max_entries_appends_the_omitted_line(self):
+        source = "".join(f"const N{i} = {i};\n" for i in range(6)) + "// pad\n" * 10
+        added = (" ".join(f"N{i}" for i in range(6)),)
+        files = [ChunkFile("a.ts", added, frozenset({99}))]
+        out = referenced_definitions(files, reader({"a.ts": source}), max_entries=2)
+        assert out[:2] == ["a.ts:1: const N0 = 0;", "a.ts:2: const N1 = 1;"]
+        assert out[-1] == "… 4 more definitions omitted"
+
+    def test_max_chars_appends_the_omitted_line(self):
+        source = "".join(f"const N{i} = {i};\n" for i in range(4)) + "// pad\n" * 10
+        added = (" ".join(f"N{i}" for i in range(4)),)
+        files = [ChunkFile("a.ts", added, frozenset({99}))]
+        out = referenced_definitions(files, reader({"a.ts": source}), max_chars=40)
+        assert out[-1].endswith("more definitions omitted")
+
+    def test_a_file_over_512_kib_is_skipped(self):
+        source = "const Big = 1;\n" + "// pad\n" * 100_000
+        files = [ChunkFile("a.ts", ("Big;",), frozenset({999_999}))]
+        assert referenced_definitions(files, reader({"a.ts": source})) == []
+
+    def test_an_unreadable_file_is_skipped(self):
+        files = [ChunkFile("a.ts", ("Big;",), frozenset({9}))]
+        assert referenced_definitions(files, reader({})) == []
+
+
+class TestChunkFiles:
+    def test_added_lines_and_hunk_coverage_come_from_the_parsed_diff(self):
+        diff = (
+            "diff --git a/src/a.ts b/src/a.ts\n"
+            "--- a/src/a.ts\n"
+            "+++ b/src/a.ts\n"
+            "@@ -10,3 +10,4 @@\n"
+            " ctx one\n"
+            "+added line\n"
+            " ctx two\n"
+            " ctx three\n"
+        )
+        files = chunk_files(parse_unified_diff(diff))
+        assert len(files) == 1
+        assert files[0].path == "src/a.ts"
+        assert files[0].added == ("added line",)
+        assert files[0].hunk_lines == frozenset({10, 11, 12, 13})
+
+
+class TestRenderContextBlocks:
+    def test_both_blocks_render_with_headers(self):
+        out = render_context_blocks(["effect@4.0.0"], ["a.ts:1: const X = 1;"])
+        assert out.startswith("### Dependency versions\n\neffect@4.0.0")
+        assert "### Definitions referenced by this chunk\n\na.ts:1: const X = 1;" in out
+
+    def test_each_block_is_omitted_when_empty(self):
+        assert render_context_blocks(["effect@4.0.0"], []) == (
+            "### Dependency versions\n\neffect@4.0.0"
+        )
+        assert render_context_blocks([], ["a.ts:1: const X = 1;"]) == (
+            "### Definitions referenced by this chunk\n\na.ts:1: const X = 1;"
+        )
+
+    def test_both_empty_renders_nothing(self):
+        assert render_context_blocks([], []) == ""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 """Tests for prxref.cli: review subcommand, serve daemon, --version, and non-blocking exits."""
+import json
 import logging
 import os
 import subprocess
@@ -12,6 +13,7 @@ from prxref import __version__, cli
 from prxref.cli import main
 from prxref.forges.base import PRRef
 from prxref.llm import ConfigError
+from prxref.triage import Finding
 
 
 def _install_fake_module(monkeypatch, fullname: str, **attrs) -> types.ModuleType:
@@ -307,6 +309,138 @@ class TestReviewSubcommand:
         assert "verdict: Approved" in out
         assert "coverage: 1/2 chunks reviewed" in out
         assert "counts:" not in out
+
+    def test_format_json_on_error_shaped_result_still_emits_one_object(
+        self, fake_runtime, monkeypatch, capsys
+    ):
+        """``_run_review`` can return an incomplete/error-shaped result (as it
+        does today for a partial-coverage run — see the sibling text-mode
+        test above). ``--format json`` must still emit exactly one JSON
+        object, with missing keys defaulting to ``null`` and findings to
+        ``[]`` rather than raising (issue 08 FROZEN CLI CONTRACT)."""
+        test_ref = PRRef(
+            forge="github",
+            host="github.com",
+            owner="org",
+            repo="repo",
+            number=42,
+            url="https://github.com/org/repo/pull/42",
+        )
+        monkeypatch.setattr("prxref.cli.detect_forge", lambda url: test_ref)
+
+        def _partial_orchestrate(**kwargs):
+            return {"verdict": "Approved", "chunks_reviewed": 1, "chunks_failed": 1}
+
+        fake_runtime["set_orchestrate_side_effect"](_partial_orchestrate)
+
+        rc = main([
+            "review", "--pr-url", "https://github.com/org/repo/pull/42",
+            "--no-post", "--format", "json",
+        ])
+
+        assert rc == 0
+        out, _ = capsys.readouterr()
+        payload = json.loads(out.strip())
+        assert payload["verdict"] == "Approved"
+        assert payload["findings"] == []
+        assert payload["chunks_reviewed"] == 1
+        assert payload["chunks_failed"] == 1
+        assert payload["chunk_count"] is None
+        assert payload["input_tokens"] is None
+        assert payload["output_tokens"] is None
+        assert payload["posted"] is None
+        assert "sampling" not in payload
+
+    def test_no_post_text_mode_indents_every_line_of_a_multiline_body(
+        self, fake_runtime, monkeypatch, capsys
+    ):
+        """A multi-line finding body must have EVERY line indented two
+        spaces, not just the first (issue 08 FROZEN CLI CONTRACT)."""
+        test_ref = PRRef(
+            forge="github",
+            host="github.com",
+            owner="org",
+            repo="repo",
+            number=7,
+            url="https://github.com/org/repo/pull/7",
+        )
+        monkeypatch.setattr("prxref.cli.detect_forge", lambda url: test_ref)
+
+        multiline = Finding(
+            file="src/foo.py",
+            line=42,
+            severity="error",
+            confidence=0.92,
+            title="Off-by-one in loop bound",
+            body="first line\nsecond line\nthird line",
+            drop_reason=None,
+        )
+
+        def _multiline_orchestrate(**kwargs):
+            return {
+                "verdict": "Request-Changes",
+                "findings_active": [multiline],
+                "findings_dropped": [],
+                "chunk_count": 1,
+                "chunks_reviewed": 1,
+                "chunks_failed": 0,
+                "elapsed_ms": 10,
+                "input_tokens": 5,
+                "output_tokens": 5,
+                "posted": False,
+            }
+
+        fake_runtime["set_orchestrate_side_effect"](_multiline_orchestrate)
+
+        rc = main(["review", "--pr-url", "https://github.com/org/repo/pull/7", "--no-post"])
+        assert rc == 0
+        out, _ = capsys.readouterr()
+        assert "  first line\n  second line\n  third line" in out
+
+    def test_format_json_with_verbose_emits_only_one_json_object(
+        self, fake_runtime, monkeypatch, capsys
+    ):
+        """``--format json`` together with ``-v`` must still print exactly
+        one JSON object and nothing else on stdout — ``-v`` only expands
+        text-mode output, never json (issue 08 FROZEN CLI CONTRACT)."""
+        test_ref = PRRef(
+            forge="github",
+            host="github.com",
+            owner="org",
+            repo="repo",
+            number=7,
+            url="https://github.com/org/repo/pull/7",
+        )
+        monkeypatch.setattr("prxref.cli.detect_forge", lambda url: test_ref)
+
+        def _full_orchestrate(**kwargs):
+            return {
+                "verdict": "commented",
+                "findings_active": [],
+                "findings_dropped": [],
+                "chunk_count": 2,
+                "chunks_reviewed": 2,
+                "chunks_failed": 0,
+                "elapsed_ms": 500,
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "posted": False,
+            }
+
+        fake_runtime["set_orchestrate_side_effect"](_full_orchestrate)
+
+        rc = main([
+            "review", "--pr-url", "https://github.com/org/repo/pull/7",
+            "--no-post", "--format", "json", "-v",
+        ])
+
+        assert rc == 0
+        out, _ = capsys.readouterr()
+        lines = out.strip().splitlines()
+        assert len(lines) == 1
+        payload = json.loads(lines[0])
+        assert payload["verdict"] == "commented"
+        assert payload["findings"] == []
 
 
 class TestServeSubcommand:

--- a/tests/test_forge_bitbucket.py
+++ b/tests/test_forge_bitbucket.py
@@ -27,16 +27,18 @@ from prxref.forges.bitbucket import ForgeImpl, _make_retry_session
 MARKER = "<!-- prxref-summary -->"
 
 
-def _mock_response(status_code=200, json_data=None, text=""):
+def _mock_response(status_code=200, json_data=None, text="", content=None, headers=None):
     resp = MagicMock(spec=requests.Response)
     resp.status_code = status_code
     resp.ok = 200 <= status_code < 300
+    resp.headers = headers or {}
     if json_data is not None:
         resp.json.return_value = json_data
         resp.text = json.dumps(json_data)
     else:
         resp.text = text
         resp.json.side_effect = ValueError("No JSON")
+    resp.content = content if content is not None else resp.text.encode("utf-8")
     resp.raise_for_status.side_effect = (
         None if resp.ok else requests.HTTPError(response=resp)
     )
@@ -450,3 +452,87 @@ def test_only_read_verbs_are_retryable():
     # it consults the status list, so holding a POST back on 502 holds it back
     # on 429 too. That trade is deliberate; see the comment on the policy.
     assert retry.is_retry("POST", 429) is False
+
+
+# --- get_file_content ---------------------------------------------------------
+
+
+def test_get_file_content_returns_text_on_200():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(200, text="print('hi')\n")
+
+    result = ForgeImpl(session=session).get_file_content(
+        _ref(), "src/app.py", sha="deadbeef"
+    )
+
+    assert result == "print('hi')\n"
+    url = session.get.call_args[0][0]
+    assert url == "https://api.bitbucket.org/2.0/repositories/acme/api/src/deadbeef/src/app.py"
+
+
+def test_get_file_content_returns_none_on_404():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(404, json_data={"error": {"message": "Not found"}})
+
+    result = ForgeImpl(session=session).get_file_content(
+        _ref(), "missing.py", sha="deadbeef"
+    )
+
+    assert result is None
+
+
+def test_get_file_content_returns_none_when_the_request_raises():
+    session = MagicMock(spec=requests.Session)
+    session.get.side_effect = requests.ConnectionError("down")
+
+    result = ForgeImpl(session=session).get_file_content(
+        _ref(), "src/app.py", sha="deadbeef"
+    )
+
+    assert result is None
+
+
+def test_get_file_content_returns_none_on_binary_content():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(200, content=b"\x89PNG\x00\x01\x02")
+
+    result = ForgeImpl(session=session).get_file_content(
+        _ref(), "logo.png", sha="deadbeef"
+    )
+
+    assert result is None
+
+
+def test_get_file_content_returns_none_on_oversize_body():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(
+        200, content=b"a" * (bitbucket._MAX_FILE_CONTENT_BYTES + 1)
+    )
+
+    result = ForgeImpl(session=session).get_file_content(
+        _ref(), "big.txt", sha="deadbeef"
+    )
+
+    assert result is None
+
+
+def test_get_file_content_returns_none_on_empty_sha():
+    session = MagicMock(spec=requests.Session)
+
+    result = ForgeImpl(session=session).get_file_content(_ref(), "src/app.py", sha="")
+
+    assert result is None
+    session.get.assert_not_called()
+
+
+def test_get_file_content_never_logs_above_debug(caplog):
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(404, json_data={"error": {"message": "Not found"}})
+
+    with caplog.at_level(logging.DEBUG, logger="prxref.forges.bitbucket"):
+        result = ForgeImpl(session=session).get_file_content(
+            _ref(), "missing.py", sha="deadbeef"
+        )
+
+    assert result is None
+    assert all(record.levelno <= logging.DEBUG for record in caplog.records)

--- a/tests/test_forge_bitbucket_server.py
+++ b/tests/test_forge_bitbucket_server.py
@@ -17,16 +17,18 @@ from prxref.forges.bitbucket_server import ForgeImpl, _make_retry_session
 from prxref.triage import parse_unified_diff
 
 
-def _mock_response(status_code=200, json_data=None, text=""):
+def _mock_response(status_code=200, json_data=None, text="", content=None, headers=None):
     resp = MagicMock(spec=requests.Response)
     resp.status_code = status_code
     resp.ok = 200 <= status_code < 300
+    resp.headers = headers or {}
     if json_data is not None:
         resp.json.return_value = json_data
         resp.text = json.dumps(json_data)
     else:
         resp.text = text
         resp.json.side_effect = ValueError("No JSON")
+    resp.content = content if content is not None else resp.text.encode("utf-8")
     resp.raise_for_status.side_effect = (
         None if resp.ok else requests.HTTPError(response=resp)
     )
@@ -871,3 +873,111 @@ def test_only_read_verbs_are_retryable():
     # it consults the status list, so holding a POST back on 502 holds it back
     # on 429 too. That trade is deliberate; see the comment on the policy.
     assert retry.is_retry("POST", 429) is False
+
+
+# --- get_file_content ---------------------------------------------------------
+
+
+def test_get_file_content_returns_text_on_200():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(200, text="print('hi')\n")
+
+    result = ForgeImpl(session=session).get_file_content(
+        _ref(), "src/app.py", sha="deadbeef"
+    )
+
+    assert result == "print('hi')\n"
+    url = session.get.call_args[0][0]
+    assert url == (
+        "https://bitbucket.corp.example/rest/api/1.0/projects/PLAT/repos/api"
+        "/raw/src/app.py"
+    )
+    assert session.get.call_args[1]["params"] == {"at": "deadbeef"}
+
+
+def test_get_file_content_builds_the_personal_repo_url():
+    ref = ForgeImpl.parse_pr_url(
+        "https://bitbucket.corp.example/users/jdoe/repos/scratch/pull-requests/1"
+    )
+    assert ref is not None
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(200, text="content\n")
+
+    result = ForgeImpl(session=session).get_file_content(
+        ref, "notes.txt", sha="cafebabe"
+    )
+
+    assert result == "content\n"
+    url = session.get.call_args[0][0]
+    assert url == (
+        "https://bitbucket.corp.example/rest/api/1.0/projects/~jdoe/repos/scratch"
+        "/raw/notes.txt"
+    )
+
+
+def test_get_file_content_returns_none_on_404():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(404, json_data={"errors": [{"message": "not found"}]})
+
+    result = ForgeImpl(session=session).get_file_content(
+        _ref(), "missing.py", sha="deadbeef"
+    )
+
+    assert result is None
+
+
+def test_get_file_content_returns_none_when_the_request_raises():
+    session = MagicMock(spec=requests.Session)
+    session.get.side_effect = requests.ConnectionError("down")
+
+    result = ForgeImpl(session=session).get_file_content(
+        _ref(), "src/app.py", sha="deadbeef"
+    )
+
+    assert result is None
+
+
+def test_get_file_content_returns_none_on_binary_content():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(200, content=b"\x89PNG\x00\x01\x02")
+
+    result = ForgeImpl(session=session).get_file_content(
+        _ref(), "logo.png", sha="deadbeef"
+    )
+
+    assert result is None
+
+
+def test_get_file_content_returns_none_on_oversize_body():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(
+        200, content=b"a" * (bitbucket_server._MAX_FILE_CONTENT_BYTES + 1)
+    )
+
+    result = ForgeImpl(session=session).get_file_content(
+        _ref(), "big.txt", sha="deadbeef"
+    )
+
+    assert result is None
+
+
+def test_get_file_content_returns_none_on_empty_sha():
+    session = MagicMock(spec=requests.Session)
+
+    result = ForgeImpl(session=session).get_file_content(_ref(), "src/app.py", sha="")
+
+    assert result is None
+    session.get.assert_not_called()
+
+
+def test_get_file_content_never_logs_above_debug(caplog):
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(404, json_data={"errors": [{"message": "not found"}]})
+
+    with caplog.at_level(logging.DEBUG, logger="prxref.forges.bitbucket_server"):
+        result = ForgeImpl(session=session).get_file_content(
+            _ref(), "missing.py", sha="deadbeef"
+        )
+
+    assert result is None
+    assert all(record.levelno <= logging.DEBUG for record in caplog.records)

--- a/tests/test_forge_github.py
+++ b/tests/test_forge_github.py
@@ -29,16 +29,18 @@ MARKER = "<!-- prxref-summary -->"
 PAGE_SIZE = 100
 
 
-def _mock_response(status_code=200, json_data=None, text=""):
+def _mock_response(status_code=200, json_data=None, text="", content=None, headers=None):
     resp = MagicMock(spec=requests.Response)
     resp.status_code = status_code
     resp.ok = 200 <= status_code < 300
+    resp.headers = headers or {}
     if json_data is not None:
         resp.json.return_value = json_data
         resp.text = json.dumps(json_data)
     else:
         resp.text = text
         resp.json.side_effect = ValueError("No JSON")
+    resp.content = content if content is not None else resp.text.encode("utf-8")
     resp.raise_for_status.side_effect = (
         None if resp.ok else requests.HTTPError(response=resp)
     )
@@ -504,3 +506,126 @@ def test_only_read_verbs_are_retryable():
     # it consults the status list, so holding a POST back on 502 holds it back
     # on 429 too. That trade is deliberate; see the comment on the policy.
     assert retry.is_retry("POST", 429) is False
+
+
+# --- get_file_content ---------------------------------------------------------
+
+
+def test_get_file_content_returns_text_on_200():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(
+        200, text="print('hi')\n", headers={"Content-Type": "text/plain; charset=utf-8"}
+    )
+
+    result = ForgeImpl(session=session).get_file_content(
+        _ref(), "src/app.py", sha="deadbeef"
+    )
+
+    assert result == "print('hi')\n"
+    url = session.get.call_args[0][0]
+    assert url == "https://api.github.com/repos/acme/api/contents/src/app.py"
+    assert session.get.call_args[1]["params"] == {"ref": "deadbeef"}
+    assert (
+        session.get.call_args[1]["headers"]["Accept"]
+        == "application/vnd.github.raw+json"
+    )
+
+
+def test_get_file_content_returns_none_on_404():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(404, json_data={"message": "Not Found"})
+
+    result = ForgeImpl(session=session).get_file_content(
+        _ref(), "missing.py", sha="deadbeef"
+    )
+
+    assert result is None
+
+
+def test_get_file_content_returns_none_on_403():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(403, json_data={"message": "rate limited"})
+
+    result = ForgeImpl(session=session).get_file_content(
+        _ref(), "src/app.py", sha="deadbeef"
+    )
+
+    assert result is None
+
+
+def test_get_file_content_returns_none_when_the_request_raises():
+    session = MagicMock(spec=requests.Session)
+    session.get.side_effect = requests.ConnectionError("down")
+
+    result = ForgeImpl(session=session).get_file_content(
+        _ref(), "src/app.py", sha="deadbeef"
+    )
+
+    assert result is None
+
+
+def test_get_file_content_returns_none_on_a_json_body():
+    """A directory, or a file over the 1 MB raw ceiling, comes back as JSON
+    even though the raw Accept header was sent."""
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(
+        200,
+        json_data=[{"name": "app.py", "type": "file"}],
+        headers={"Content-Type": "application/json; charset=utf-8"},
+    )
+
+    result = ForgeImpl(session=session).get_file_content(
+        _ref(), "src", sha="deadbeef"
+    )
+
+    assert result is None
+
+
+def test_get_file_content_returns_none_on_binary_content():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(
+        200, content=b"\x89PNG\x00\x01\x02", headers={"Content-Type": "text/plain"}
+    )
+
+    result = ForgeImpl(session=session).get_file_content(
+        _ref(), "logo.png", sha="deadbeef"
+    )
+
+    assert result is None
+
+
+def test_get_file_content_returns_none_on_oversize_body():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(
+        200,
+        content=b"a" * (github._MAX_FILE_CONTENT_BYTES + 1),
+        headers={"Content-Type": "text/plain"},
+    )
+
+    result = ForgeImpl(session=session).get_file_content(
+        _ref(), "big.txt", sha="deadbeef"
+    )
+
+    assert result is None
+
+
+def test_get_file_content_returns_none_on_empty_sha():
+    session = MagicMock(spec=requests.Session)
+
+    result = ForgeImpl(session=session).get_file_content(_ref(), "src/app.py", sha="")
+
+    assert result is None
+    session.get.assert_not_called()
+
+
+def test_get_file_content_never_logs_above_debug(caplog):
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(404, json_data={"message": "Not Found"})
+
+    with caplog.at_level(logging.DEBUG, logger="prxref.forges.github"):
+        result = ForgeImpl(session=session).get_file_content(
+            _ref(), "missing.py", sha="deadbeef"
+        )
+
+    assert result is None
+    assert all(record.levelno <= logging.DEBUG for record in caplog.records)

--- a/tests/test_forge_gitlab.py
+++ b/tests/test_forge_gitlab.py
@@ -16,16 +16,18 @@ from prxref.forges.gitlab import ForgeImpl, _make_retry_session
 from prxref.triage import parse_unified_diff
 
 
-def _mock_response(status_code=200, json_data=None, text=""):
+def _mock_response(status_code=200, json_data=None, text="", content=None, headers=None):
     resp = MagicMock(spec=requests.Response)
     resp.status_code = status_code
     resp.ok = 200 <= status_code < 300
+    resp.headers = headers or {}
     if json_data is not None:
         resp.json.return_value = json_data
         resp.text = json.dumps(json_data)
     else:
         resp.text = text
         resp.json.side_effect = ValueError("No JSON")
+    resp.content = content if content is not None else resp.text.encode("utf-8")
     resp.raise_for_status.side_effect = (
         None if resp.ok else requests.HTTPError(response=resp)
     )
@@ -629,3 +631,102 @@ def test_only_read_verbs_are_retryable():
     # it consults the status list, so holding a POST back on 502 holds it back
     # on 429 too. That trade is deliberate; see the comment on the policy.
     assert retry.is_retry("POST", 429) is False
+
+
+# --- get_file_content ---------------------------------------------------------
+
+
+def _content_ref():
+    return PRRef(
+        "gitlab", "gitlab.com", "group", "repo", 3,
+        "https://gitlab.com/group/repo/-/merge_requests/3",
+    )
+
+
+def test_get_file_content_returns_text_on_200(monkeypatch):
+    monkeypatch.setenv("PRXREF_GITLAB_TOKEN", "test-token")
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(200, text="print('hi')\n")
+
+    result = ForgeImpl(session=session).get_file_content(
+        _content_ref(), "src/app.py", sha="deadbeef"
+    )
+
+    assert result == "print('hi')\n"
+    url = session.get.call_args[0][0]
+    assert url == (
+        "https://gitlab.com/api/v4/projects/group%2Frepo/repository/files/"
+        "src%2Fapp.py/raw"
+    )
+    assert session.get.call_args[1]["params"] == {"ref": "deadbeef"}
+    assert session.get.call_args[1]["headers"] == {"PRIVATE-TOKEN": "test-token"}
+
+
+def test_get_file_content_returns_none_on_404():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(404, json_data={"message": "404 File Not Found"})
+
+    result = ForgeImpl(session=session).get_file_content(
+        _content_ref(), "missing.py", sha="deadbeef"
+    )
+
+    assert result is None
+
+
+def test_get_file_content_returns_none_when_the_request_raises():
+    session = MagicMock(spec=requests.Session)
+    session.get.side_effect = requests.ConnectionError("down")
+
+    result = ForgeImpl(session=session).get_file_content(
+        _content_ref(), "src/app.py", sha="deadbeef"
+    )
+
+    assert result is None
+
+
+def test_get_file_content_returns_none_on_binary_content():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(200, content=b"\x89PNG\x00\x01\x02")
+
+    result = ForgeImpl(session=session).get_file_content(
+        _content_ref(), "logo.png", sha="deadbeef"
+    )
+
+    assert result is None
+
+
+def test_get_file_content_returns_none_on_oversize_body():
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(
+        200, content=b"a" * (gitlab._MAX_FILE_CONTENT_BYTES + 1)
+    )
+
+    result = ForgeImpl(session=session).get_file_content(
+        _content_ref(), "big.txt", sha="deadbeef"
+    )
+
+    assert result is None
+
+
+def test_get_file_content_returns_none_on_empty_sha():
+    session = MagicMock(spec=requests.Session)
+
+    result = ForgeImpl(session=session).get_file_content(
+        _content_ref(), "src/app.py", sha=""
+    )
+
+    assert result is None
+    session.get.assert_not_called()
+
+
+def test_get_file_content_never_logs_above_debug(caplog):
+    session = MagicMock(spec=requests.Session)
+    session.get.return_value = _mock_response(404, json_data={"message": "404 File Not Found"})
+
+    with caplog.at_level(logging.DEBUG, logger="prxref.forges.gitlab"):
+        result = ForgeImpl(session=session).get_file_content(
+            _content_ref(), "missing.py", sha="deadbeef"
+        )
+
+    assert result is None
+    assert all(record.levelno <= logging.DEBUG for record in caplog.records)

--- a/tests/test_heuristics.py
+++ b/tests/test_heuristics.py
@@ -1,0 +1,256 @@
+"""Unit tests for src/prxref/heuristics.py: the release-shaped-PR heuristic.
+
+Most tests here call ``_is_release_machinery`` / ``release_shape_findings``
+directly over hand-built ``FileDiff`` lists -- no orchestrator, no LLM, no
+diff parsing. One integration test at the bottom confirms the finding
+survives the real ``orchestrate_review`` quality-pass chain, reusing
+test_orchestrator's shared fixtures the way tests/test_issue_10_release_shaped_pr.py
+does.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from test_orchestrator import (  # noqa: E402  (shared fixtures, read not guessed)
+    REF,
+    FakeForge,
+    FakeLLM,
+    _contract_review_chunk,
+    _contract_review_systemic,
+)
+
+from prxref import orchestrator  # noqa: E402
+from prxref.heuristics import _is_release_machinery, release_shape_findings  # noqa: E402
+from prxref.orchestrator import orchestrate_review  # noqa: E402
+from prxref.triage import FileDiff  # noqa: E402
+
+
+def _fd(path: str, status: str = "modified") -> FileDiff:
+    """One minimal FileDiff for path-only matching -- hunks are irrelevant here."""
+    old = None if status == "added" else path
+    new = None if status == "removed" else path
+    return FileDiff(path=path, old_path=old, new_path=new, status=status)
+
+
+def _modified_file_diff(path: str) -> str:
+    """One small modified-file diff section: one hunk, one changed line."""
+    return (
+        f"diff --git a/{path} b/{path}\n"
+        f"--- a/{path}\n"
+        f"+++ b/{path}\n"
+        "@@ -1,1 +1,1 @@\n"
+        "-old value\n"
+        "+new value\n"
+    )
+
+
+class TestMachineryBasenames:
+    """Every basename class named in the frozen contract, matched on its own."""
+
+    @pytest.mark.parametrize("path", [
+        "package.json",
+        "pyproject.toml",
+        "Cargo.toml",
+        "setup.py",
+        "setup.cfg",
+        "VERSION",
+        "version.py",
+        "__version__.py",
+        "widget.gemspec",
+        "nested/dir/widget.gemspec",
+        ".release-please-manifest.json",
+    ])
+    def test_exact_and_suffix_basenames_are_machinery(self, path):
+        assert _is_release_machinery(path) is True
+
+    @pytest.mark.parametrize("path", [
+        "CHANGELOG.md", "changelog.md", "CHANGELOG", "CHANGELOG.rst",
+        "HISTORY.txt", "history.rst", "History.md",
+        "RELEASE_NOTES.md", "release_notes.txt", "Release_Notes.md",
+    ])
+    def test_changelog_history_release_notes_prefixes_case_insensitive(self, path):
+        assert _is_release_machinery(path) is True
+
+    @pytest.mark.parametrize("path", [
+        "package-lock.json", "npm-shrinkwrap.json", "pnpm-lock.yaml",
+        "yarn.lock", "bun.lockb", "bun.lock", "uv.lock", "poetry.lock",
+        "Pipfile.lock", "Cargo.lock", "Gemfile.lock", "go.sum", "composer.lock",
+    ])
+    def test_lockfile_basenames_are_machinery(self, path):
+        assert _is_release_machinery(path) is True
+
+    @pytest.mark.parametrize("path", [
+        ".changeset/brave-foxes.md",
+        ".changeset/README.md",
+        "packages/cli/.changeset/some-slug.md",
+    ])
+    def test_changeset_directory_component_is_machinery_regardless_of_filename(self, path):
+        assert _is_release_machinery(path) is True
+
+    @pytest.mark.parametrize("path", [
+        "src/app.py",
+        "README.md",
+        "notchangelog.md",  # does not start with the "changelog" prefix
+        "package.json.bak",  # basename mismatch: not exactly "package.json"
+        "changeset.md",  # ".changeset" is a filename here, not a directory
+    ])
+    def test_non_machinery_paths_are_not_machinery(self, path):
+        assert _is_release_machinery(path) is False
+
+
+class TestReleaseShapeRatio:
+    """The >= 2 files / >= 80% machinery contract, exact-rational throughout."""
+
+    def test_single_file_diff_never_release_shaped_even_if_pure_machinery(self):
+        assert release_shape_findings([_fd("package.json")]) == []
+
+    def test_ratio_exactly_80_percent_is_release_shaped(self):
+        # 4 machinery + 1 source = 5 files; 4/5 = 80% exactly (boundary
+        # inclusive per the contract's ">=").
+        files = [
+            _fd("package.json"), _fd("pyproject.toml"),
+            _fd("Cargo.toml"), _fd("setup.py"),
+            _fd("src/app.py"),
+        ]
+        findings = release_shape_findings(files)
+        assert len(findings) == 1
+        assert findings[0].file == "src/app.py"
+
+    def test_ratio_just_under_80_percent_is_not_release_shaped(self):
+        # 79/100: 79*5=395 < 100*4=400. Integers only, no float involved.
+        machinery = [_fd(f"pkg{i}/package.json") for i in range(79)]
+        source = [_fd(f"src/mod{i}.py") for i in range(21)]
+        assert release_shape_findings(machinery + source) == []
+
+    def test_no_float_drift_across_equivalent_80_percent_ratios(self):
+        """4/5 and 12/15 are the same ratio (80%) but different integers.
+
+        The contract requires ``machinery * 5 >= total * 4`` (exact
+        rational, cross-multiplied) rather than a computed
+        ``machinery / total >= 0.8`` float comparison, so both expressions
+        of the same ratio must classify identically -- a naive float
+        division is exactly the failure mode this guards against.
+        """
+        four_of_five = [
+            _fd("package.json"), _fd("pyproject.toml"),
+            _fd("Cargo.toml"), _fd("setup.py"),
+            _fd("src/app.py"),
+        ]
+        twelve_of_fifteen = (
+            [_fd(f"pkg{i}/package.json") for i in range(12)]
+            + [_fd(f"src/mod{i}.py") for i in range(3)]
+        )
+        assert len(release_shape_findings(four_of_five)) == 1
+        result = release_shape_findings(twelve_of_fifteen)
+        assert len(result) == 1
+        assert "3 non-release file" in result[0].title
+
+
+class TestRemovedFilesAndOffenderSorting:
+    def test_removed_non_machinery_file_counts_as_offender(self):
+        files = [
+            _fd("package.json"), _fd("pyproject.toml"), _fd("Cargo.toml"),
+            _fd("setup.py"), _fd("src/old_module.py", status="removed"),
+        ]
+        findings = release_shape_findings(files)
+        assert len(findings) == 1
+        assert findings[0].file == "src/old_module.py"
+        assert "1 non-release file" in findings[0].title
+
+    def test_removed_machinery_file_counts_toward_total(self):
+        # 4 machinery (one removed) / 5 total = 80%; exactly 1 offender.
+        files = [
+            _fd("package.json"), _fd("pyproject.toml"), _fd("Cargo.toml"),
+            _fd(".changeset/brave-foxes.md", status="removed"),
+            _fd("src/app.py"),
+        ]
+        findings = release_shape_findings(files)
+        assert len(findings) == 1
+        assert findings[0].file == "src/app.py"
+
+    def test_offenders_sorted_first_offender_anchors_finding_and_body(self):
+        files = [
+            _fd("package.json"), _fd("pyproject.toml"), _fd("Cargo.toml"),
+            _fd("setup.py"), _fd("setup.cfg"), _fd("VERSION"),
+            _fd("version.py"), _fd("__version__.py"), _fd("widget.gemspec"),
+            _fd("CHANGELOG.md"), _fd(".release-please-manifest.json"),
+            _fd("Gemfile.lock"),
+            _fd("src/z_module.py"), _fd("src/a_module.py"),
+        ]
+        # 12 machinery + 2 source = 14 files, 12/14 = 85.7% >= 80%.
+        findings = release_shape_findings(files)
+        assert len(findings) == 1
+        f = findings[0]
+        assert f.file == "src/a_module.py"
+        assert "src/a_module.py" in f.body
+        assert "src/z_module.py" in f.body
+        assert f.body.index("src/a_module.py") < f.body.index("src/z_module.py")
+        assert f.body.endswith(" (deterministic check, no model)")
+
+
+class TestFindingShape:
+    def test_finding_shape_matches_contract(self):
+        files = [
+            _fd("package.json"), _fd("pyproject.toml"), _fd("Cargo.toml"),
+            _fd("setup.py"), _fd("src/app.py"),
+        ]
+        findings = release_shape_findings(files)
+        assert len(findings) == 1
+        f = findings[0]
+        assert f.severity == "warning"
+        assert f.confidence == 1.0
+        assert f.line == 0
+        assert f.drop_reason is None
+        assert f.title == "Release-shaped PR touches source: 1 non-release file(s)"
+
+    def test_pure_release_pr_yields_no_finding(self):
+        files = [
+            _fd("package.json"), _fd("pyproject.toml"),
+            _fd("Cargo.toml"), _fd("setup.py"),
+        ]
+        assert release_shape_findings(files) == []
+
+    def test_ordinary_feature_pr_with_incidental_manifest_bump_yields_no_finding(self):
+        files = [_fd(f"src/mod{i}.py") for i in range(1, 6)] + [_fd("package.json")]
+        assert release_shape_findings(files) == []
+
+
+class TestOrchestratorIntegration:
+    """The finding must survive the full quality-pass chain and post as a
+    summary item under ``post=False`` -- not just exist as heuristics output."""
+
+    def test_release_shape_finding_survives_full_pass_chain(self, monkeypatch):
+        monkeypatch.setattr(orchestrator.reviewer, "review_chunk", _contract_review_chunk)
+        monkeypatch.setattr(
+            orchestrator.reviewer, "review_systemic", _contract_review_systemic,
+        )
+
+        diff = "\n".join(
+            _modified_file_diff(p)
+            for p in [
+                "package.json", "pyproject.toml", "Cargo.toml", "setup.py",
+                "src/app.py",
+            ]
+        )
+        forge = FakeForge(diff=diff)
+        llm = FakeLLM('{"findings":[],"escalations":[]}')
+
+        res = orchestrate_review(forge, REF, llm, post=False)
+
+        active = res["findings_active"]
+        release_findings = [
+            f for f in active
+            if f.title.startswith("Release-shaped PR touches source:")
+        ]
+        assert len(release_findings) == 1
+        f = release_findings[0]
+        assert f.file == "src/app.py"
+        assert f.line == 0
+        assert f.severity == "warning"
+        assert f.confidence == 1.0
+        assert f.drop_reason is None

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -272,8 +272,15 @@ class TestScenario1HappyPath:
 
             assert len(result["findings_dropped"]) == 3
             # The chunk's own sub-floor finding is retained with its reason...
-            assert "below floor" in result["findings_dropped"][0].drop_reason
-            assert result["findings_dropped"][0].title == "Missing audit log"
+            assert all(
+                "below floor" in f.drop_reason
+                for f in result["findings_dropped"]
+                if f.title == "Missing audit log"
+            )
+            assert sum(
+                f.title == "Missing audit log"
+                for f in result["findings_dropped"]
+            ) == 2
             # ...the sweep re-found both chunk findings (the mock serves every
             # request the same payload): its low-confidence copy died at the
             # gate like the chunk's, and its surviving copy of the posted

--- a/tests/test_issue_01_library_version_context.py
+++ b/tests/test_issue_01_library_version_context.py
@@ -1,0 +1,143 @@
+"""Issue 01 — the worker prompt is blind to third-party library versions.
+
+The chunk prompt carries only the diff, so a finding that turns on a
+library's runtime semantics is answered from whichever major version
+dominates training data. Tests A and B pin the frozen contract for the fix
+(a ``### Dependency versions`` block resolved from the nearest manifest at
+the PR head, plus a prompt rule about unversioned library claims); the
+controls pin what must keep working when the forge offers no file reader.
+"""
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from prxref.forges.base import PRRef
+from prxref.llm import InvokeResult
+from prxref.orchestrator import orchestrate_review
+from tests.test_orchestrator import FakeForge, make_pr
+
+REF = PRRef(
+    forge="fake", host="fake.test", owner="acme", repo="widget",
+    number=7, url="https://fake.test/acme/widget/pull/7",
+)
+
+PACKAGE_JSON = '{"name":"x","dependencies":{"effect":"4.0.0-rc.110"}}'
+
+TS_DIFF = (
+    "diff --git a/src/a.ts b/src/a.ts\n"
+    "new file mode 100644\n"
+    "--- /dev/null\n"
+    "+++ b/src/a.ts\n"
+    "@@ -0,0 +1,6 @@\n"
+    "+import { Effect } from 'effect';\n"
+    "+\n"
+    "+export const run = (p: () => Promise<number>) =>\n"
+    "+  Effect.runPromise(Effect.promise(p));\n"
+    "+\n"
+    "+export const label = 'data 1';\n"
+)
+
+
+class CapturingLLM:
+    """Records every ``(system, user)`` pair; always returns no findings."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+        self._lock = threading.Lock()
+
+    def invoke(self, system, user, *, max_tokens=4096, json_mode=False, timeout_s=60.0):
+        with self._lock:
+            self.calls.append((system, user))
+        return InvokeResult(
+            text='{"findings":[],"escalations":[]}',
+            input_tokens=100,
+            output_tokens=50,
+            model="test-model-1",
+            backend="fake",
+            elapsed_ms=1,
+        )
+
+    @property
+    def user_prompts(self) -> list[str]:
+        return [u for _, u in self.calls]
+
+
+class ContentForge(FakeForge):
+    """FakeForge plus the frozen optional ``get_file_content`` contract."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.content_calls: list[tuple[str, str]] = []
+
+    def get_file_content(self, ref: PRRef, path: str, *, sha: str) -> str | None:
+        self.content_calls.append((path, sha))
+        if path == "package.json" and sha == self.pr.source_sha:
+            return PACKAGE_JSON
+        return None
+
+
+@pytest.fixture
+def llm() -> CapturingLLM:
+    return CapturingLLM()
+
+
+def _run(forge, llm):
+    return orchestrate_review(forge, REF, llm, post=False)
+
+
+def test_a_dependency_versions_block_reaches_the_worker_prompt(llm):
+    forge = ContentForge(pr=make_pr("Wire Effect"), diff=TS_DIFF)
+    result = _run(forge, llm)
+
+    assert result["chunk_count"] >= 1
+    prompts = llm.user_prompts
+    assert prompts, "no LLM call was made"
+    assert any("### Dependency versions" in p for p in prompts), (
+        "no worker prompt carried a '### Dependency versions' block; "
+        "the chunk prompt is version-blind"
+    )
+    assert any("effect@4.0.0-rc.110" in p for p in prompts), (
+        "the resolved pin 'effect@4.0.0-rc.110' never reached the prompt"
+    )
+
+
+def test_b_prompt_rules_cover_unversioned_library_claims(llm):
+    forge = ContentForge(pr=make_pr("Wire Effect"), diff=TS_DIFF)
+    _run(forge, llm)
+
+    joined = "\n".join(s for s, _ in llm.calls) + "\n".join(llm.user_prompts)
+    assert "library version" in joined, (
+        "the worker prompt has no rule about findings that depend on a "
+        "third-party library version not present in context"
+    )
+
+
+def test_control_plain_forge_reviews_without_dependency_block(llm):
+    forge = FakeForge(pr=make_pr("Wire Effect"), diff=TS_DIFF)
+    assert not hasattr(forge, "get_file_content")
+
+    result = _run(forge, llm)
+
+    assert result["verdict"]
+    assert result["chunk_count"] >= 1
+    assert result["findings_active"] == []
+    prompts = llm.user_prompts
+    assert prompts
+    assert any("import { Effect } from 'effect';" in p for p in prompts), (
+        "the diff itself never reached the worker prompt"
+    )
+    assert not any("### Dependency versions" in p for p in prompts), (
+        "a forge with no get_file_content must not grow a dependency block"
+    )
+
+
+def test_control_file_content_is_asked_for_at_the_pr_head_sha(llm):
+    """Whatever the fix reads, it must read it at the PR head, never blindly."""
+    forge = ContentForge(pr=make_pr("Wire Effect"), diff=TS_DIFF)
+    _run(forge, llm)
+
+    assert all(sha == forge.pr.source_sha for _, sha in forge.content_calls), (
+        f"get_file_content called at a non-head sha: {forge.content_calls}"
+    )

--- a/tests/test_issue_02_symbol_definitions.py
+++ b/tests/test_issue_02_symbol_definitions.py
@@ -1,0 +1,193 @@
+"""Issue 02: the worker reasons from an identifier's NAME when its definition
+sits in the same file, outside the rendered hunk.
+
+The reviewer renders only the hunk (``reviewer.render_chunk`` →
+``triage.trim_hunk_context``), so a constant defined 76 lines above the change
+is never shown to the model. The fix adds an OPTIONAL forge method::
+
+    def get_file_content(self, ref: PRRef, path: str, *, sha: str) -> str | None
+
+resolved via ``getattr(forge, "get_file_content", None)``, and injects a
+``### Definitions referenced by this chunk`` block into the worker prompt for
+identifiers the chunk's ADDED lines reference but that are defined elsewhere in
+the same file.
+
+Tests A and B fail on 0.11.1; the two controls pass both before and after.
+"""
+from __future__ import annotations
+
+from prxref.forges.base import PRRef
+from prxref.llm import InvokeResult
+from tests.test_orchestrator import REF, FakeForge, FakeLLM, make_pr  # noqa: F401
+
+SCHEMA_PATH = "src/packages/bitbucket/src/schema.ts"
+CTRL_PATH = "src/packages/bitbucket/src/ctrl.ts"
+
+CLEAN_JSON = '{"findings": [], "escalations": []}'
+
+
+class CapturingLLM:
+    """Records every (system, user) pair; always returns a clean review."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    def invoke(self, system, user, *, max_tokens=4096, json_mode=False, timeout_s=60.0):
+        self.calls.append((system, user))
+        return InvokeResult(
+            text=CLEAN_JSON, input_tokens=1, output_tokens=1,
+            model="m", backend="b", elapsed_ms=1,
+        )
+
+    @property
+    def prompts(self) -> list[str]:
+        return [f"{s}\n{u}" for s, u in self.calls]
+
+
+def schema_post_image() -> list[str]:
+    """The POST-image of schema.ts: 100 lines, PositiveInt defined at line 18."""
+    lines = [f"// filler {i}" for i in range(1, 18)]           # 1..17
+    lines += [                                                  # 18..21
+        "const PositiveInt = Schema.Number.check(",
+        "  Schema.isInt(),",
+        "  Schema.isBetween({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER }),",
+        ");",
+    ]
+    lines += [f"// filler {i}" for i in range(22, 91)]           # 22..90
+    lines += [                                                   # 91..97
+        "export const PageParams = Schema.Struct({",
+        "  limit: PositiveInt,",
+        "  filter: Schema.String,",
+        "  start: PositiveInt,",
+        "  order: Schema.String,",
+        "});",
+        "// tail",
+    ]
+    lines += [f"// filler {i}" for i in range(98, 101)]          # 98..100
+    assert len(lines) == 100
+    assert lines[17].startswith("const PositiveInt")
+    assert lines[93] == "  start: PositiveInt,"
+    return lines
+
+
+# One added line at post-image line 94, three context lines on each side.
+# Old side: post lines 91,92,93,95,96,97 -> @@ -91,6 +91,7 @@.
+def schema_diff() -> str:
+    post = schema_post_image()
+    body = [
+        " " + post[90], " " + post[91], " " + post[92],
+        "+" + post[93],
+        " " + post[94], " " + post[95], " " + post[96],
+    ]
+    return (
+        f"diff --git a/{SCHEMA_PATH} b/{SCHEMA_PATH}\n"
+        f"--- a/{SCHEMA_PATH}\n"
+        f"+++ b/{SCHEMA_PATH}\n"
+        "@@ -91,6 +91,7 @@\n"
+        + "\n".join(body) + "\n"
+    )
+
+
+def ctrl_post_image() -> list[str]:
+    """Control post-image: ``Limit`` is defined INSIDE the added block."""
+    lines = [f"// head {i}" for i in range(1, 5)]                # 1..4
+    lines += [                                                   # 5..8
+        "const Limit = 5;",
+        "export const Opts = Schema.Struct({",
+        "  x: Limit,",
+        "});",
+    ]
+    lines += [f"// tail {i}" for i in range(9, 13)]              # 9..12
+    return lines
+
+
+def ctrl_diff() -> str:
+    post = ctrl_post_image()
+    body = [
+        " " + post[1], " " + post[2], " " + post[3],
+        "+" + post[4], "+" + post[5], "+" + post[6], "+" + post[7],
+        " " + post[8], " " + post[9], " " + post[10],
+    ]
+    return (
+        f"diff --git a/{CTRL_PATH} b/{CTRL_PATH}\n"
+        f"--- a/{CTRL_PATH}\n"
+        f"+++ b/{CTRL_PATH}\n"
+        "@@ -2,6 +2,10 @@\n"
+        + "\n".join(body) + "\n"
+    )
+
+
+class SourceForge(FakeForge):
+    """A forge that can serve post-image file content, the frozen contract."""
+
+    def __init__(self, files: dict[str, list[str]], **kwargs):
+        super().__init__(**kwargs)
+        self._files = files
+        self.content_calls: list[tuple[str, str]] = []
+
+    def get_file_content(self, ref: PRRef, path: str, *, sha: str) -> str | None:
+        self.content_calls.append((path, sha))
+        if sha != self.pr.source_sha:
+            return None
+        body = self._files.get(path)
+        return "\n".join(body) + "\n" if body is not None else None
+
+
+DEFS_HEADER = "### Definitions referenced by this chunk"
+
+
+def _run(forge, llm):
+    from prxref.orchestrator import orchestrate_review
+
+    return orchestrate_review(forge, REF, llm, post=False)
+
+
+class TestDefinitionInjection:
+    def test_out_of_hunk_definition_reaches_the_worker_prompt(self):
+        """Test A — the PositiveInt definition at schema.ts:18 must be shown."""
+        forge = SourceForge({SCHEMA_PATH: schema_post_image()}, diff=schema_diff())
+        llm = CapturingLLM()
+        res = _run(forge, llm)
+
+        assert res["chunks_reviewed"] >= 1
+        assert llm.calls, "the worker never ran"
+        joined = "\n\n".join(llm.prompts)
+        assert DEFS_HEADER in joined, (
+            "worker prompt carries no definitions block; the model only ever "
+            "sees the identifier NAME"
+        )
+        assert "schema.ts:18: const PositiveInt" in joined
+
+    def test_prompt_caps_confidence_on_unresolved_symbols(self):
+        """Test B — the prompt must carry the unshown-symbol rule."""
+        forge = SourceForge({SCHEMA_PATH: schema_post_image()}, diff=schema_diff())
+        llm = CapturingLLM()
+        _run(forge, llm)
+
+        assert llm.calls, "the worker never ran"
+        assert any("definition is not shown" in p for p in llm.prompts)
+
+
+class TestControls:
+    def test_forge_without_get_file_content_still_reviews(self):
+        """Control — the method is OPTIONAL; a plain forge must not break."""
+        forge = FakeForge(diff=schema_diff())
+        assert not hasattr(forge, "get_file_content")
+        llm = CapturingLLM()
+        res = _run(forge, llm)
+
+        assert res["verdict"] == "Approved"
+        assert res["chunks_failed"] == 0
+        assert res["chunks_reviewed"] >= 1
+        assert all(DEFS_HEADER not in p for p in llm.prompts)
+
+    def test_definition_inside_the_hunk_is_not_re_injected(self):
+        """Control — ``Limit`` is defined on an added line, so the fix must not
+        repeat it under the definitions header."""
+        forge = SourceForge({CTRL_PATH: ctrl_post_image()}, diff=ctrl_diff())
+        llm = CapturingLLM()
+        res = _run(forge, llm)
+
+        assert res["chunks_reviewed"] >= 1
+        assert "+const Limit = 5;" in "\n\n".join(llm.prompts)
+        assert all("ctrl.ts:5: const Limit" not in p for p in llm.prompts)

--- a/tests/test_issue_03_copy_header.py
+++ b/tests/test_issue_03_copy_header.py
@@ -1,0 +1,228 @@
+"""Regression tests for issue #03: copy/rename diff headers read as deletion.
+
+docs/issues/inbox-2026-09-04/prxref-issues/03-rename-copy-header-read-as-deletion.md
+reports that a Bitbucket Server ``copy from``/``copy to`` diff header (a
+monorepo package copied to a new location) got the copy's SOURCE path
+reported as removed, even though the same diff contains a separate section
+that modifies that source file — it is still present in the post-image.
+
+Two tests below reproduce the bug and must FAIL on the current tree:
+
+- ``test_copy_header_parses_to_copied_status_with_source_old_path`` (issue's
+  Test A): ``triage.parse_unified_diff`` has no "copied" status today, so a
+  ``copy from``/``copy to`` section is mis-parsed as "renamed" instead.
+- ``test_removal_claim_on_a_path_present_in_post_image_is_dropped`` (issue's
+  Test B): there is no quality pass that checks a "removed"/"deleted" claim
+  against the diff's post-image, so the false-positive finding from the
+  issue survives every gate and posts.
+
+Two controls must PASS both before and after the fix:
+
+- a claim about a file that really was deleted (``deleted file mode``, gone
+  from the post-image) must stay active — the new gate must not blanket-drop
+  every "removed" claim, only ones contradicted by the diff.
+- a plain ``rename from``/``rename to`` (no copy) must keep yielding
+  ``status == "renamed"`` — the fix must not regress ordinary renames.
+"""
+from __future__ import annotations
+
+import json
+
+from prxref.forges.base import PRRef
+from prxref.orchestrator import orchestrate_review
+from prxref.triage import parse_unified_diff
+from tests.test_orchestrator import FakeForge, FakeLLM, make_pr
+
+REF = PRRef(
+    forge="fake", host="fake.test", owner="acme", repo="widget",
+    number=11, url="https://fake.test/acme/widget/pull/11",
+)
+
+# The exact two sections from the issue: a Bitbucket Server `copy from` /
+# `copy to` header (src:// / dst:// operands, similarity index) creating
+# splunk/package.json from servicenow/package.json, followed by a second,
+# independent section that modifies the servicenow source file the copy
+# read from -- it is still present on the branch.
+COPY_AND_MODIFY_DIFF = (
+    "diff --git src://src/packages/servicenow/package.json"
+    " dst://src/packages/splunk/package.json\n"
+    "similarity index 53%\n"
+    "copy from src/packages/servicenow/package.json\n"
+    "copy to src/packages/splunk/package.json\n"
+    "@@ -1,3 +1,4 @@\n"
+    " {\n"
+    '-  "name": "@syf-mcp/servicenow"\n'
+    '+  "name": "@syf-mcp/splunk",\n'
+    '+  "version": "1.0.0"\n'
+    " }\n"
+    "diff --git src://src/packages/servicenow/package.json"
+    " dst://src/packages/servicenow/package.json\n"
+    "@@ -1,2 +1,3 @@\n"
+    '   "scripts": {\n'
+    '-    "check-types": "npx tsc --noEmit"\n'
+    '+    "check-types": "npx tsc --noEmit",\n'
+    '+    "test": "vitest run"\n'
+)
+
+
+def test_copy_header_parses_to_copied_status_with_source_old_path():
+    """Test A: `copy from`/`copy to` must yield status "copied", not "renamed".
+
+    The source file's own separate modified section must stay independently
+    "modified". old_path on the copy target is already correct today (the
+    `diff --git src://... dst://...` header alone supplies both operands) --
+    only the status label is wrong, because nothing recognizes a copy as
+    distinct from a rename.
+    """
+    files = parse_unified_diff(COPY_AND_MODIFY_DIFF)
+    by_path = {f.path: f for f in files}
+    assert set(by_path) == {
+        "src/packages/splunk/package.json",
+        "src/packages/servicenow/package.json",
+    }
+
+    splunk = by_path["src/packages/splunk/package.json"]
+    servicenow = by_path["src/packages/servicenow/package.json"]
+
+    assert splunk.old_path == "src/packages/servicenow/package.json"
+    assert splunk.status == "copied", (
+        f"expected status 'copied' for the copy target, got {splunk.status!r} "
+        "-- there is no 'copied' status yet, so parse_unified_diff falls "
+        "back to 'renamed' because old_path != new_path"
+    )
+    assert servicenow.status == "modified", (
+        f"expected the source file's own section to stay 'modified', "
+        f"got {servicenow.status!r}"
+    )
+
+
+FINDING_JSON = json.dumps({
+    "findings": [
+        {
+            "file": "src/packages/splunk/package.json",
+            "line": 2,
+            "severity": "warning",
+            "confidence": 0.8,
+            "title": "ServiceNow package.json removed by rename to splunk",
+            "body": (
+                "The copy from src/packages/servicenow/package.json to "
+                "src/packages/splunk/package.json removed the ServiceNow "
+                "package.json; it no longer exists after this PR."
+            ),
+        }
+    ],
+    "escalations": [],
+})
+
+
+def test_removal_claim_on_a_path_present_in_post_image_is_dropped():
+    """Test B: the issue's exact false-positive finding must be dropped.
+
+    A finding claiming src/packages/servicenow/package.json was "removed"
+    by the copy, while that path is present in the diff's post-image (its
+    own "modified" section, and it is the copy's still-present source),
+    must not post. FakeLLM returns this JSON verbatim for every LLM call
+    (both chunk workers and the systemic sweep), so no LLM call is made in
+    this test -- the string is a fixed fixture.
+    """
+    forge = FakeForge(pr=make_pr(), diff=COPY_AND_MODIFY_DIFF)
+    llm = FakeLLM(findings_by_path=FINDING_JSON)
+    res = orchestrate_review(forge, REF, llm, post=False)
+
+    active_titles = {f.title for f in res["findings_active"]}
+    assert "ServiceNow package.json removed by rename to splunk" not in active_titles, (
+        "a finding claiming removal of a path present in the post-image "
+        "must not survive to post"
+    )
+
+    matches = [
+        f for f in res["findings_dropped"]
+        if f.title == "ServiceNow package.json removed by rename to splunk"
+    ]
+    assert matches, "the finding must survive as a dropped record, not vanish"
+    assert any(
+        (f.drop_reason or "").startswith(
+            "claims removal of a path present in the post-image"
+        )
+        for f in matches
+    ), f"unexpected drop_reason(s): {[f.drop_reason for f in matches]!r}"
+
+
+# --- Controls: must PASS today and after the fix -----------------------
+
+DELETED_FILE_DIFF = (
+    "diff --git a/src/old.ts b/src/old.ts\n"
+    "deleted file mode 100644\n"
+    "--- a/src/old.ts\n"
+    "+++ /dev/null\n"
+    "@@ -1,3 +0,0 @@\n"
+    "-old content\n"
+    "-more old content\n"
+    "-final line\n"
+)
+
+OTHER_FILE_DIFF = (
+    "diff --git a/src/other.py b/src/other.py\n"
+    "new file mode 100644\n"
+    "--- /dev/null\n"
+    "+++ b/src/other.py\n"
+    "@@ -0,0 +1,3 @@\n"
+    "+import foo\n"
+    '+print("old.ts removed")\n'
+    "+bar()\n"
+)
+
+GENUINE_DELETE_DIFF = DELETED_FILE_DIFF + OTHER_FILE_DIFF
+
+CONTROL_FINDING_JSON = json.dumps({
+    "findings": [
+        {
+            "file": "src/other.py",
+            "line": 2,
+            "severity": "warning",
+            "confidence": 0.7,
+            "title": "Reference to a file removed elsewhere in this diff",
+            "body": "src/old.ts removed; src/other.py still references it by name.",
+        }
+    ],
+    "escalations": [],
+})
+
+
+def test_removal_claim_on_a_genuinely_deleted_path_stays_active():
+    """Control: a claim about a truly-deleted path must not be gated.
+
+    src/old.ts carries `deleted file mode` and has no other section in this
+    diff, so it really is absent from the post-image -- the new gate must
+    tell this apart from the issue's false positive and let it post.
+    """
+    files = parse_unified_diff(GENUINE_DELETE_DIFF)
+    by_path = {f.path: f for f in files}
+    assert by_path["src/old.ts"].status == "removed"
+
+    forge = FakeForge(pr=make_pr(), diff=GENUINE_DELETE_DIFF)
+    llm = FakeLLM(findings_by_path=CONTROL_FINDING_JSON)
+    res = orchestrate_review(forge, REF, llm, post=False)
+
+    active_titles = {f.title for f in res["findings_active"]}
+    assert "Reference to a file removed elsewhere in this diff" in active_titles, (
+        "a claim about a path that really is absent from the post-image "
+        "must not be caught by the removal-claim gate"
+    )
+
+
+PLAIN_RENAME_DIFF = (
+    "diff --git a/src/foo.ts b/src/bar.ts\n"
+    "similarity index 100%\n"
+    "rename from src/foo.ts\n"
+    "rename to src/bar.ts\n"
+)
+
+
+def test_plain_rename_still_yields_renamed_status():
+    """Control: an ordinary rename (no copy) keeps status "renamed"."""
+    files = parse_unified_diff(PLAIN_RENAME_DIFF)
+    assert len(files) == 1
+    assert files[0].status == "renamed"
+    assert files[0].old_path == "src/foo.ts"
+    assert files[0].new_path == "src/bar.ts"

--- a/tests/test_issue_04_determinism.py
+++ b/tests/test_issue_04_determinism.py
@@ -1,0 +1,198 @@
+"""Issue 04 — finding sets vary between identical runs.
+
+Temperature 0 and ``PRXREF_LLM_SEED`` already shipped (0.10.0), so what
+remains on the pipeline side is order-sensitivity in the passes that CAP or
+pick: a tie in the error cap, and a tie in the inline-comment cap, are broken
+by the arrival order of the list rather than by finding content. Tests A/A2
+pin the frozen order-invariance contract (identical result for any permutation
+of the same multiset, ordered by ``(file, line, title)``); Test B pins the new
+``sampling`` observability key. The controls pin what must keep working.
+"""
+from __future__ import annotations
+
+import itertools
+import threading
+
+from prxref.forges.base import PRRef
+from prxref.llm import InvokeResult
+from prxref.orchestrator import orchestrate_review
+from prxref.quality import apply_quality_gate
+from prxref.triage import Finding
+from tests.test_orchestrator import FakeForge, make_pr
+
+REF = PRRef(
+    forge="fake", host="fake.test", owner="acme", repo="widget",
+    number=7, url="https://fake.test/acme/widget/pull/7",
+)
+
+DIFF = (
+    "diff --git a/src/a.py b/src/a.py\n"
+    "new file mode 100644\n"
+    "--- /dev/null\n"
+    "+++ b/src/a.py\n"
+    "@@ -0,0 +1,3 @@\n"
+    "+data 1\n"
+    "+data 2\n"
+    "+data 3\n"
+)
+
+
+def _finding(file: str, line: int, title: str, conf: float = 0.9) -> Finding:
+    return Finding(
+        file=file, line=line, severity="error", confidence=conf,
+        title=title, body=f"data {line} is unsafe in {file}",
+    )
+
+
+def _key(f: Finding) -> tuple[str, int, str]:
+    return (f.file, f.line, f.title)
+
+
+class _StubLLM:
+    """No findings; optionally exposes sampling attributes."""
+
+    def __init__(self, **attrs) -> None:
+        for k, v in attrs.items():
+            setattr(self, k, v)
+        self._lock = threading.Lock()
+        self.calls = 0
+
+    def invoke(self, system, user, *, max_tokens=4096, json_mode=False, timeout_s=60.0):
+        with self._lock:
+            self.calls += 1
+        return InvokeResult(
+            text='{"findings":[],"escalations":[]}',
+            input_tokens=10, output_tokens=5,
+            model="test-model-1", backend="fake", elapsed_ms=1,
+        )
+
+
+# --------------------------------------------------------------------------
+# Test A — the error cap must not depend on arrival order (frozen contract)
+# --------------------------------------------------------------------------
+
+TIED = [
+    _finding("src/a.py", 1, "alpha leak"),
+    _finding("src/a.py", 2, "bravo leak"),
+    _finding("src/a.py", 3, "charlie leak"),
+]
+
+
+def test_a_error_cap_survivors_are_permutation_invariant():
+    """Three tied-confidence errors, cap 2: the same two must survive always."""
+    results = []
+    for perm in itertools.permutations(TIED):
+        staged = apply_quality_gate(list(perm), confidence_floor=0.6, max_errors=2)
+        survivors = frozenset(_key(f) for f in staged if f.drop_reason is None)
+        dropped = frozenset(
+            (_key(f), f.drop_reason) for f in staged if f.drop_reason is not None
+        )
+        results.append((survivors, dropped))
+    assert len({r[0] for r in results}) == 1, (
+        "error-cap survivors depend on arrival order: "
+        f"{sorted({tuple(sorted(r[0])) for r in results})}"
+    )
+    assert len({r[1] for r in results}) == 1
+
+
+def test_a_gate_output_is_sorted_by_file_line_title():
+    """The gate's output order must be content-derived, not arrival-derived."""
+    for perm in itertools.permutations(TIED):
+        staged = apply_quality_gate(list(perm), confidence_floor=0.6, max_errors=3)
+        assert [_key(f) for f in staged] == sorted(_key(f) for f in staged)
+
+
+def test_a2_inline_batch_is_permutation_invariant(monkeypatch):
+    """The posted inline batch is the same set for any worker-result order."""
+    from prxref import orchestrator
+
+    batches = []
+    for perm in itertools.permutations(TIED):
+        forge = FakeForge(pr=make_pr(), diff=DIFF)
+
+        def _fake_review_chunk(llm, files, _perm=perm, **kwargs):
+            return list(_perm), {
+                "escalations": [], "input_tokens": 0, "output_tokens": 0,
+                "model": "test-model-1", "elapsed_ms": 1, "error": "",
+            }
+
+        monkeypatch.setattr(orchestrator.reviewer, "review_chunk", _fake_review_chunk)
+        orchestrate_review(
+            forge, REF, _StubLLM(), post=True, post_mode="inline",
+            max_workers=1, max_errors=3, max_inline_comments=2,
+        )
+        batch = forge.inline_batches[-1] if forge.inline_batches else []
+        assert len(batch) == 2
+        batches.append(tuple((c.path, c.line) for c in batch))
+    assert len(set(batches)) == 1, f"inline batch varies by arrival order: {set(batches)}"
+
+
+# --------------------------------------------------------------------------
+# Test B — sampling observability (frozen contract)
+# --------------------------------------------------------------------------
+
+
+def test_b_result_reports_sampling_from_client():
+    forge = FakeForge(pr=make_pr(), diff=DIFF)
+    llm = _StubLLM(temperature=0.0, seed=7, models=["m1", "m2"])
+    result = orchestrate_review(forge, REF, llm, post=False)
+    assert result["sampling"] == {
+        "temperature": 0.0, "seed": 7, "models": ["m1", "m2"],
+    }
+
+
+def test_b_sampling_key_present_when_client_is_silent():
+    forge = FakeForge(pr=make_pr(), diff=DIFF)
+    result = orchestrate_review(forge, REF, _StubLLM(), post=False)
+    assert "sampling" in result
+    assert result["sampling"]["temperature"] is None
+    assert result["sampling"]["seed"] is None
+    assert result["sampling"]["models"] in ([], None)
+
+
+# --------------------------------------------------------------------------
+# Controls — must pass today (plus the error-exit half of Test B)
+# --------------------------------------------------------------------------
+
+
+def test_b_sampling_survives_the_error_exit():
+    """``_error_run`` is a SEPARATE exit reached from five call sites; the
+    sampling record must ride it too, or a failed run says nothing about what
+    sampling was in force."""
+    forge = FakeForge(pr=make_pr(), diff=DIFF)
+    forge.fail.add("get_pr")
+    llm = _StubLLM(temperature=0.0, seed=7, models=["m1", "m2"])
+    result = orchestrate_review(forge, REF, llm, post=False)
+    assert result["sampling"]["seed"] == 7
+
+
+def test_control_single_order_active_set(monkeypatch):
+    """One ordering still yields exactly the two highest-ranked errors."""
+    from prxref import orchestrator
+
+    forge = FakeForge(pr=make_pr(), diff=DIFF)
+
+    def _fake_review_chunk(llm, files, **kwargs):
+        return list(TIED), {
+            "escalations": [], "input_tokens": 0, "output_tokens": 0,
+            "model": "test-model-1", "elapsed_ms": 1, "error": "",
+        }
+
+    monkeypatch.setattr(orchestrator.reviewer, "review_chunk", _fake_review_chunk)
+    result = orchestrate_review(
+        forge, REF, _StubLLM(), post=False, max_workers=1, max_errors=2,
+    )
+    assert len(result["findings_active"]) == 2
+    assert result["verdict"] == "Request-Changes"
+    assert len(result["findings_dropped"]) == 1
+    assert "error cap exceeded" in result["findings_dropped"][0].drop_reason
+
+
+def test_control_temperature_reaches_the_wire():
+    """Temperature 0.0 in the wire payload is owned by
+    ``tests/test_llm_backends.py::TestTemperature``; not duplicated here, only
+    executed, so the payload contract keeps one owner."""
+    from tests.test_llm_backends import TestTemperature
+
+    TestTemperature().test_zero_is_a_real_value_not_an_omission()
+    TestTemperature().test_sent_when_configured()

--- a/tests/test_issue_05_hedged_findings.py
+++ b/tests/test_issue_05_hedged_findings.py
@@ -1,0 +1,243 @@
+"""Issue #05 / #11 — the quality gate admits self-hedged findings.
+
+A hedged finding states an unverified precondition about the code's own
+behaviour ("If figmaProxy.prepare still leases a client", "If they are
+members of the root workspaces globs, npm ci will fail"). Both shipped as
+`warning` under the user's name and both were false.
+
+Frozen contract: such a finding is dropped with
+``drop_reason`` starting ``hedged: `` followed by the matched phrase, and
+the gate entry point is ``prxref.quality.apply_hedge_gate(findings)`` —
+pure, order-preserving, sets ``drop_reason`` instead of discarding.
+
+Tests A and B FAIL today (no hedge gate exists). Test C is the control
+corpus and must PASS both today and after the fix; today it runs against a
+no-op shim (``getattr`` fallback) so a green result means "these bodies are
+legitimate", and after the fix the same assertions bind the real gate.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from prxref import quality
+from prxref.orchestrator import orchestrate_review
+from prxref.triage import Finding
+from tests.test_orchestrator import REF, FakeForge, FakeLLM  # noqa: F401
+
+MCP_PATH = "src/apps/mcp/src/services/mcp-server.ts"
+DOCKERFILE = "Dockerfile"
+
+
+def _diff_with_lines(path: str, lines: list[str]) -> str:
+    body = "\n".join("+" + ln for ln in lines)
+    return (
+        f"diff --git a/{path} b/{path}\n"
+        "new file mode 100644\n"
+        "--- /dev/null\n"
+        f"+++ b/{path}\n"
+        f"@@ -0,0 +1,{len(lines)} @@\n"
+        f"{body}\n"
+    )
+
+
+# mcp-server.ts: the createMcpHandler return lands on line 37, the line the
+# real finding cited. Dockerfile: the workspace-manifest COPY lands on 47.
+_MCP_LINES = [f"const filler{i} = {i};" for i in range(1, 37)]
+_MCP_LINES.append("  return createMcpHandler(serverFactory);")
+_MCP_LINES += [f"const tail{i} = {i};" for i in range(1, 4)]
+
+_DOCKER_LINES = [f"RUN echo layer{i}" for i in range(1, 47)]
+_DOCKER_LINES.append("COPY src/services/jira/package.json ./src/services/jira/")
+_DOCKER_LINES += [f"RUN echo tail{i}" for i in range(1, 4)]
+
+TWO_FILE_DIFF = _diff_with_lines(MCP_PATH, _MCP_LINES) + _diff_with_lines(
+    DOCKERFILE, _DOCKER_LINES
+)
+
+# Verbatim from docs/issues/inbox-2026-09-04/prxref-issues/
+# 05-quality-gate-admits-self-hedged-findings.md
+FIGMA_BODY = (
+    "The diff removes the close()/stream-wrapper lifecycle and returns "
+    "createMcpHandler(serverFactory) directly, so nothing calls figma cleanup "
+    "at end of request. If figmaProxy.prepare still leases a client, that "
+    "lease is only released when the enclosing scope (service layer) closes, "
+    "not per request."
+)
+# Verbatim from docs/issues/inbox-2026-09-04/prxref-issue-2026-09-03.md §1
+NPM_CI_BODY = (
+    "The deps stage copies only implementor, agentcore, github-copilot, "
+    "typescript-config, bitbucket and jira manifests, but this PR adds "
+    "workspaces src/services/confluence, src/services/sso and "
+    "src/agents/deep-agent. If they are members of the root workspaces globs, "
+    "`npm ci` in this stage will fail."
+)
+
+# FakeLLM in STRING mode returns this verbatim for every call, the systemic
+# sweep included; the sweep copies are dropped as duplicates, which is why the
+# assertions below look at every dropped finding sharing a title.
+HEDGED_RESPONSE = json.dumps(
+    {
+        "findings": [
+            {"file": MCP_PATH, "line": 37, "severity": "warning", "confidence": 0.7,
+             "title": "Per-request Figma resources no longer released after response",
+             "body": FIGMA_BODY},
+            {"file": DOCKERFILE, "line": 47, "severity": "warning", "confidence": 0.75,
+             "title": "deps stage misses new workspace manifests",
+             "body": NPM_CI_BODY},
+        ],
+        "escalations": [],
+    }
+)
+
+
+def _f(body: str, *, title: str = "Finding") -> Finding:
+    return Finding(
+        file=MCP_PATH, line=37, severity="warning", confidence=0.8,
+        title=title, body=body,
+    )
+
+
+class TestAEndToEnd:
+    """Both real-world hedged findings must be dropped by orchestrate_review."""
+
+    def test_hedged_findings_are_dropped(self):
+        forge = FakeForge(diff=TWO_FILE_DIFF)
+        llm = FakeLLM(HEDGED_RESPONSE)
+
+        res = orchestrate_review(forge, REF, llm, post=False)
+
+        active_titles = {f.title for f in res["findings_active"]}
+
+        for title in (
+            "Per-request Figma resources no longer released after response",
+            "deps stage misses new workspace manifests",
+        ):
+            assert title not in active_titles, f"{title!r} survived the gate"
+            reasons = [
+                f.drop_reason or ""
+                for f in res["findings_dropped"] if f.title == title
+            ]
+            assert reasons, f"{title!r} not in findings_dropped"
+            assert any(r.startswith("hedged:") for r in reasons), (
+                f"{title!r} dropped for {reasons!r}, expected a 'hedged:' reason"
+            )
+
+
+HEDGED_BODIES = [
+    # 1. the figmaProxy finding's own shape
+    ("if-still", FIGMA_BODY),
+    # 2. the npm ci finding's own shape
+    ("if-membership", NPM_CI_BODY),
+    ("if-is-still",
+     "The handler is registered twice. If the legacy router is still mounted "
+     "in server.ts, requests will be dispatched to both."),
+    ("assuming",
+     "Assuming the cache is keyed by tenant, this write will clobber another "
+     "tenant's entry on the next flush."),
+    ("unless-already",
+     "The migration adds a NOT NULL column. Unless the backfill job already "
+     "ran in production, this deploy will fail."),
+    ("may-still",
+     "The subscription is removed from the map, but the socket may still be "
+     "held open by the outer pool."),
+    ("cannot-verify",
+     "This drops the retry wrapper. I cannot verify whether the caller "
+     "retries, so the request may now fail permanently."),
+    ("not-visible-in-diff",
+     "The token refresh is not visible in the diff, so this change probably "
+     "leaves the credential stale."),
+    ("presumably",
+     "The flag is read once at import; presumably the config loader runs "
+     "before this module, otherwise the value is always false."),
+    ("only-caller",
+     "The signature changed from (a, b) to (a). If this is the only caller, "
+     "the change is safe; otherwise every other call site breaks."),
+    ("likely-still",
+     "The listener is detached on unmount, but the timer likely still holds a "
+     "reference to the component instance."),
+]
+
+
+class TestBGateUnit:
+    """Direct unit test of the frozen entry point ``apply_hedge_gate``."""
+
+    @pytest.mark.parametrize("label,body", HEDGED_BODIES, ids=[b[0] for b in HEDGED_BODIES])
+    def test_hedged_body_is_dropped(self, label, body):
+        out = quality.apply_hedge_gate([_f(body, title=label)])
+
+        assert len(out) == 1
+        assert out[0].drop_reason is not None, f"{label}: not dropped"
+        assert out[0].drop_reason.startswith("hedged:"), out[0].drop_reason
+        # the reason names the phrase that matched, not just the rule
+        assert len(out[0].drop_reason) > len("hedged: "), out[0].drop_reason
+
+    def test_order_and_purity(self):
+        findings = [_f(FIGMA_BODY, title="a"), _f("Plain bug.", title="b")]
+        out = quality.apply_hedge_gate(findings)
+
+        assert [f.title for f in out] == ["a", "b"]
+        assert findings[0].drop_reason is None  # input not mutated
+
+
+# Control corpus. Every body below contains if/unless/may/assuming/might but
+# describes what the code DOES under a runtime condition — a legitimate
+# finding. These must stay active. Two are lifted from the existing suite:
+# tests/test_integration.py:206,752 and tests/test_orchestrator.py:258.
+CONTROL_BODIES = [
+    ("divisor",
+     "size defaults to None and is used as a divisor on line 42; the diff "
+     "adds no guard."),
+    ("early-return",
+     "Returns early if the list is empty, so the counter is never "
+     "incremented."),
+    ("retry-spin",
+     "The retry loop may spin forever because the deadline is never "
+     "decremented."),
+    ("typeerror",
+     "Throws TypeError if `opts` is undefined: line 12 dereferences "
+     "opts.start without a guard."),
+    ("lodash-unless",
+     "unless() from lodash is called with a string, which it does not "
+     "accept."),
+    # tests/test_integration.py:206 and :752
+    ("jwterror", "decode(token) can raise JWTError if malformed."),
+    # tests/test_orchestrator.py:258
+    ("null-deref",
+     "x may be None when config is missing; data loss follows."),
+    # tests/test_quality.py-style concurrency body
+    ("concurrency", "Concurrent calls may corrupt state."),
+    ("assuming-noun",
+     "The parser is assuming-safe only for ASCII; line 20 indexes bytes "
+     "directly and raises on multibyte input."),
+    ("may-return",
+     "readFile may return a Buffer here, and the caller concatenates it with "
+     "a string, producing '[object Object]'."),
+    ("if-branch",
+     "If retries is 0 the loop body never runs, so the initial request is "
+     "skipped entirely."),
+    ("unless-flag",
+     "The endpoint is registered unless DEBUG is set, so production serves "
+     "the unauthenticated route."),
+]
+
+
+class TestCControls:
+    """Legitimate findings must survive. PASSES today via the no-op shim.
+
+    Until ``apply_hedge_gate`` exists the shim below is an identity function,
+    so this test is green today by construction; its value is that the SAME
+    assertions bind the real gate the moment the fix seat lands it.
+    """
+
+    @pytest.mark.parametrize("label,body", CONTROL_BODIES, ids=[b[0] for b in CONTROL_BODIES])
+    def test_control_stays_active(self, label, body):
+        gate = getattr(quality, "apply_hedge_gate", lambda fs: list(fs))
+
+        out = gate([_f(body, title=label)])
+
+        assert len(out) == 1
+        assert out[0].drop_reason is None, (
+            f"false positive on {label!r}: {out[0].drop_reason}"
+        )

--- a/tests/test_issue_06_sweep_deletions_threads.py
+++ b/tests/test_issue_06_sweep_deletions_threads.py
@@ -1,0 +1,246 @@
+"""Issue 06: the sweep is blind to pure deletions, and re-raises settled threads.
+
+Two halves, one issue. (1) ``build_digest`` only admits removed lines that hit
+one of the eight shipped pattern classes, none of which describe a deleted
+limit constant or a deleted validator — so guard removal, an advertised sweep
+class, is structurally invisible. (2) Nothing suppresses a finding that
+re-litigates a decision already argued out in a PR thread; the sweep prompt
+never sees the discussion at all.
+
+Frozen contracts under test: a ``guard-removal`` digest class applied to
+REMOVED lines and admitted ahead of fill classes; a ``settled in thread``
+drop_reason; and an ``### Existing discussion`` block in the sweep user prompt.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from test_orchestrator import (  # noqa: E402  (shared fixtures, read not guessed)
+    REF,
+    FakeForge,
+    FakeLLM,
+    _contract_review_chunk,
+    _contract_review_systemic,
+)
+
+from prxref import orchestrator  # noqa: E402
+from prxref.forges.base import Thread  # noqa: E402
+from prxref.llm import InvokeResult  # noqa: E402
+from prxref.orchestrator import orchestrate_review  # noqa: E402
+from prxref.quality import is_duplicate_of_existing  # noqa: E402
+from prxref.systemic import build_digest, match_class  # noqa: E402
+from prxref.triage import Finding, parse_unified_diff  # noqa: E402
+
+# The PR from the issue: three input-size guards and their enforcing filter
+# deleted outright, with two innocuous added lines. Nothing added here matches
+# any shipped pattern class, so the file's only systemic signal is deletions.
+REGISTRY_DIFF = (
+    "diff --git a/src/tools/registry.ts b/src/tools/registry.ts\n"
+    "--- a/src/tools/registry.ts\n"
+    "+++ b/src/tools/registry.ts\n"
+    "@@ -1,9 +1,5 @@\n"
+    ' import { z } from "zod";\n'
+    "-const MAX_TOOL_NAME_LENGTH = 128;\n"
+    "-const MAX_TOOL_DESCRIPTION_LENGTH = 4_000;\n"
+    "-const MAX_TOOL_SCHEMA_BYTES = 100_000;\n"
+    "-function isSupported(tool) {\n"
+    "-  return tool.name.length <= MAX_TOOL_NAME_LENGTH;\n"
+    "-}\n"
+    " export function listTools(raw) {\n"
+    "+  const list = raw.slice();\n"
+    "+  return list;\n"
+    " }\n"
+)
+
+SETTLED_THREAD = Thread(
+    path="src/tools/registry.ts",
+    line=None,
+    resolved=False,
+    author="bob",
+    body_snippet=(
+        "This still feels too defensive, I don't think we need it imo "
+        "— Removed the defensive tool metadata guard in commit 917d1f4"
+    ),
+)
+
+GUARD_FINDING = {
+    "file": "src/tools/registry.ts",
+    "line": 3,
+    "severity": "warning",
+    "confidence": 0.8,
+    "title": "Tool metadata guard removed: unbounded tool names from remote servers",
+    "body": (
+        "This change removes the tool metadata guard: MAX_TOOL_NAME_LENGTH and "
+        "isSupported no longer bound names or schemas supplied by a remote MCP "
+        "server."
+    ),
+}
+
+
+def _cls(text: str, kind: str = "-") -> str | None:
+    """``match_class`` for a line of a given diff kind.
+
+    ASSUMPTION recorded for the fix seat: today ``match_class(text)`` takes only
+    the text, so removal cannot be a matching condition. The recommended
+    signature is ``match_class(text, kind="+"|"-"|" ")`` with ``kind``
+    keyword-only and defaulted, keeping every existing call site valid. This
+    helper calls the new form and falls back to the old one so the controls
+    below pass under both.
+    """
+    try:
+        return match_class(text, kind=kind)
+    except TypeError:
+        return match_class(text)
+
+
+def _digest_of(diff: str, token_budget: int = 4000) -> str:
+    return build_digest(parse_unified_diff(diff), token_budget)
+
+
+@pytest.fixture
+def contract_stubs(monkeypatch):
+    """Chunk + sweep pinned to the orchestrator contract (no real reviewer)."""
+    monkeypatch.setattr(orchestrator.reviewer, "review_chunk", _contract_review_chunk)
+    monkeypatch.setattr(
+        orchestrator.reviewer, "review_systemic", _contract_review_systemic,
+    )
+
+
+class TestA_DigestSeesDeletedGuards:
+    def test_digest_carries_the_removed_limit_constants_and_validator(self):
+        digest = _digest_of(REGISTRY_DIFF)
+
+        assert "MAX_TOOL_NAME_LENGTH" in digest
+        assert "MAX_TOOL_DESCRIPTION_LENGTH" in digest
+        assert "MAX_TOOL_SCHEMA_BYTES" in digest
+        assert "isSupported" in digest
+        # Rendered as removals, so the model can tell deletion from addition.
+        assert "-2| const MAX_TOOL_NAME_LENGTH = 128;" in digest
+
+    def test_removed_limit_constant_is_classed_guard_removal(self):
+        assert _cls("const MAX_TOOL_NAME_LENGTH = 128;") == "guard-removal"
+        assert _cls("const MAX_TOOL_SCHEMA_BYTES = 100_000;") == "guard-removal"
+        assert _cls("static final int REQUEST_TIMEOUT = 30;") == "guard-removal"
+
+    def test_removed_validator_definition_is_classed_guard_removal(self):
+        assert _cls("function isSupported(tool) {") == "guard-removal"
+        assert _cls("function validateSchema(s) {") == "guard-removal"
+        assert _cls("def sanitize_name(name):") == "guard-removal"
+
+    def test_guard_removal_survives_the_per_file_cap_as_a_must_see_class(self):
+        from prxref.systemic import _MUST_SEE_CLASSES
+
+        assert "guard-removal" in _MUST_SEE_CLASSES
+
+
+class TestB_SettledThreadSuppression:
+    def test_finding_relitigating_a_settled_thread_is_dropped(self, contract_stubs):
+        forge = FakeForge(diff=REGISTRY_DIFF, threads=[SETTLED_THREAD])
+        llm = FakeLLM(json.dumps({"findings": [GUARD_FINDING]}))
+
+        res = orchestrate_review(forge, REF, llm, post=False)
+
+        titles = {f.title for f in res["findings_dropped"]}
+        assert GUARD_FINDING["title"] in titles, (
+            "guard-removal finding survived a settled thread on the same file; "
+            f"active={[f.title for f in res['findings_active']]}"
+        )
+        dropped = next(
+            f for f in res["findings_dropped"] if f.title == GUARD_FINDING["title"]
+        )
+        assert dropped.drop_reason.startswith("settled in thread")
+
+
+class TestC_SweepPromptCarriesTheDiscussion:
+    def test_sweep_user_prompt_lists_threads_for_digested_files(self, monkeypatch):
+        monkeypatch.setattr(
+            orchestrator.reviewer, "review_chunk", _contract_review_chunk,
+        )
+        calls: list[tuple[str, str]] = []
+
+        class CapturingLLM:
+            def invoke(self, system, user, **kwargs):
+                calls.append((system, user))
+                return InvokeResult(
+                    text='{"findings":[],"escalations":[]}',
+                    input_tokens=10, output_tokens=5,
+                    model="test-model-1", backend="fake", elapsed_ms=1,
+                )
+
+        forge = FakeForge(diff=REGISTRY_DIFF, threads=[SETTLED_THREAD])
+        orchestrate_review(forge, REF, CapturingLLM(), post=False)
+
+        sweep = [u for s, u in calls if "systemic sweep" in s.lower()]
+        assert sweep, f"no sweep call captured; systems={[s[:60] for s, _ in calls]}"
+        user = sweep[0]
+        assert "### Existing discussion" in user
+        assert "Removed the defensive tool metadata guard" in user
+
+
+class TestControls:
+    def test_removed_console_log_is_not_guard_removal(self):
+        assert _cls('console.log("x")') != "guard-removal"
+        assert _cls('console.log("x")') == "console-log"
+
+    def test_added_limit_constant_is_not_guard_removal(self):
+        assert _cls("const MAX_TOOL_NAME_LENGTH = 128;", kind="+") != "guard-removal"
+
+    def test_unrelated_thread_does_not_suppress(self, contract_stubs):
+        unrelated = Thread(
+            path="src/other/cache.ts", line=None, resolved=False, author="carol",
+            body_snippet="Bumping the cache eviction interval before release.",
+        )
+        forge = FakeForge(diff=REGISTRY_DIFF, threads=[unrelated])
+        llm = FakeLLM(json.dumps({"findings": [GUARD_FINDING]}))
+
+        res = orchestrate_review(forge, REF, llm, post=False)
+
+        assert GUARD_FINDING["title"] in {f.title for f in res["findings_active"]}
+
+    def test_resolved_thread_on_other_subject_does_not_suppress(self, contract_stubs):
+        other = Thread(
+            path="src/tools/registry.ts", line=None, resolved=True, author="dave",
+            body_snippet="Please rename listTools to enumerateTools for consistency.",
+        )
+        forge = FakeForge(diff=REGISTRY_DIFF, threads=[other])
+        llm = FakeLLM(json.dumps({"findings": [GUARD_FINDING]}))
+
+        res = orchestrate_review(forge, REF, llm, post=False)
+
+        assert GUARD_FINDING["title"] in {f.title for f in res["findings_active"]}
+
+
+class TestAlreadyCoveredBoundary:
+    """What today's thread dedup DOES catch, so the fix does not re-solve it."""
+
+    def test_line_pinned_thread_already_matches_at_the_unit_level(self):
+        """The one variant today's dedup catches — but only as a unit call.
+
+        Same line (distance 0) needs 1 shared token and 4 are shared
+        ({tool, metadata, guard, removed}). With ``line=None`` the distant
+        threshold is ``max(4, 17 // 2) == 8`` and the same thread is missed.
+        """
+        finding = Finding(
+            file=GUARD_FINDING["file"], line=3, severity="warning",
+            confidence=0.8, title=GUARD_FINDING["title"], body=GUARD_FINDING["body"],
+        )
+        pinned = replace(SETTLED_THREAD, line=3)
+        assert is_duplicate_of_existing(finding, [pinned]) is True
+
+    def test_end_to_end_even_the_pinned_thread_misses_today(self, contract_stubs):
+        """Measured: ``apply_line_align`` demotes the finding to line 0 before
+        dedup runs, so the distance-0 tier above never applies in the real
+        pipeline. The suppression must therefore be line-independent."""
+        forge = FakeForge(diff=REGISTRY_DIFF, threads=[replace(SETTLED_THREAD, line=3)])
+        llm = FakeLLM(json.dumps({"findings": [GUARD_FINDING]}))
+
+        res = orchestrate_review(forge, REF, llm, post=False)
+        landed = (res["findings_active"] + res["findings_dropped"])[0]
+        assert landed.line == 0

--- a/tests/test_issue_07_containment_boundary.py
+++ b/tests/test_issue_07_containment_boundary.py
@@ -1,0 +1,305 @@
+"""Issue #07 — 'throws' findings must name their containment boundary.
+
+Self-contained: does not import tests/test_orchestrator.py or
+tests/test_reviewer.py fixtures (that module patches
+``orchestrator.reviewer.review_chunk`` via an autouse fixture scoped to its
+own file only; importing it here would risk pulling in unrelated import-time
+side effects). All fixtures below are the minimal shapes needed for this
+issue, modeled on those two files.
+
+Three things must exist for this suite to pass, none of which exist yet:
+1. The rendered worker prompt states the containment-boundary rule.
+2. A deterministic post-pass, ``prxref.quality.apply_containment_note``,
+   suffixes an un-boundaried throw-class finding's body with
+   " [containment boundary not stated]".
+3. That post-pass is wired into ``orchestrate_review``'s pass order.
+
+Tests A, B, C fail today (2026-09-04, prxref 0.11.1) and should pass once
+the fix lands. The two "Controls" tests pass today and after — they pin
+the no-false-positive behaviour using the identity fallback so they are not
+themselves evidence the fix landed.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from prxref import quality
+from prxref.forges.base import PRData, PRRef
+from prxref.llm import InvokeResult
+from prxref.orchestrator import orchestrate_review
+from prxref.reviewer import review_chunk
+from prxref.triage import Finding, parse_unified_diff
+
+# ---------------------------------------------------------------------------
+# Test A: the rendered worker prompt states the rule.
+# ---------------------------------------------------------------------------
+
+MINI_DIFF = (
+    "diff --git a/src/app.py b/src/app.py\n"
+    "--- a/src/app.py\n"
+    "+++ b/src/app.py\n"
+    "@@ -1,2 +1,3 @@\n"
+    " import os\n"
+    "+import sys\n"
+    " def main():\n"
+)
+
+
+class _CapturingLLM:
+    """Records the exact system/user text handed to invoke(); always returns
+    a clean empty-findings response so review_chunk's parse never fails."""
+
+    def __init__(self, text: str):
+        self.text = text
+        self.calls: list[dict] = []
+
+    def invoke(self, system, user, *, max_tokens=4096, json_mode=False, timeout_s=60.0):
+        self.calls.append({"system": system, "user": user})
+        return InvokeResult(
+            text=self.text, input_tokens=10, output_tokens=5,
+            model="capture-model", backend="fake", elapsed_ms=1,
+        )
+
+
+def test_worker_prompt_states_the_containment_boundary_rule():
+    llm = _CapturingLLM('{"findings":[],"escalations":[]}')
+    chunk = parse_unified_diff(MINI_DIFF)
+
+    review_chunk(llm, chunk)
+
+    assert len(llm.calls) == 1
+    combined = llm.calls[0]["system"] + "\n" + llm.calls[0]["user"]
+    assert "containment boundary" in combined, (
+        "worker.md must state: a finding that asserts a throw, panic, crash, "
+        "or unhandled rejection must name its containment boundary — the "
+        "enclosing catch, or state that it is uncaught and name the caller "
+        "it propagates to."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test B: end to end through orchestrate_review — the fix must be WIRED IN,
+# not just available as a function nobody calls.
+# ---------------------------------------------------------------------------
+
+# Mirrors issue 07's real-world shape: a throw with no catch anywhere in the
+# diff, escaping into the caller. Old file: 5 lines: new file: 8 (3 added).
+FIGMA_DIFF = (
+    "diff --git a/src/mcp/figma.ts b/src/mcp/figma.ts\n"
+    "--- a/src/mcp/figma.ts\n"
+    "+++ b/src/mcp/figma.ts\n"
+    "@@ -1,5 +1,8 @@\n"
+    " export function register(server) {\n"
+    "   for (const tool of tools) {\n"
+    "+    if (typeof tool.inputSchema !== \"object\") {\n"
+    "+      throw decodeServerJsonSchema(tool);\n"
+    "+    }\n"
+    "     server.addTool(tool);\n"
+    "   }\n"
+    " }\n"
+)
+
+# The issue's finding, verbatim (title + body text drawn from the issue
+# file), file/line anchored on the added throw line. No boundary language
+# anywhere in title or body — this is exactly the finding the issue says
+# understates blast radius.
+FIGMA_FINDING_JSON = json.dumps({
+    "findings": [
+        {
+            "file": "src/mcp/figma.ts",
+            "line": 4,
+            "severity": "error",
+            "confidence": 0.85,
+            "title": (
+                "decodeServerJsonSchema throws during register for "
+                "non-object inputSchema"
+            ),
+            "body": (
+                "any tool whose inputSchema is not an object throws "
+                "synchronously, aborting registration of all remaining "
+                "Figma tools instead of skipping that one tool."
+            ),
+        }
+    ],
+    "escalations": [],
+})
+
+
+class _VerbatimLLM:
+    """Returns the SAME text for every invoke() call — worker chunk call
+    and systemic-sweep call alike — matching FakeLLM's string-mode contract
+    in tests/test_orchestrator.py."""
+
+    def __init__(self, text: str):
+        self.text = text
+        self.calls = 0
+
+    def invoke(self, system, user, *, max_tokens=4096, json_mode=False, timeout_s=60.0):
+        self.calls += 1
+        return InvokeResult(
+            text=self.text, input_tokens=10, output_tokens=5,
+            model="figma-test-model", backend="fake", elapsed_ms=1,
+        )
+
+
+class _FakeForge:
+    name = "fake"
+
+    def __init__(self, pr: PRData, diff: str):
+        self.pr = pr
+        self.diff = diff
+        self.summaries: list[str] = []
+        self.inline_batches: list[list] = []
+
+    @staticmethod
+    def parse_pr_url(url: str):
+        return None
+
+    def get_pr(self, ref):
+        return self.pr
+
+    def get_diff(self, ref):
+        return self.diff
+
+    def post_summary(self, ref, body):
+        self.summaries.append(body)
+
+    def post_inline_comments(self, ref, comments):
+        self.inline_batches.append(list(comments))
+        return len(comments)
+
+    def list_threads(self, ref):
+        return []
+
+
+def _make_pr() -> PRData:
+    return PRData(
+        title="Register Figma tools", description="adds tool registration",
+        author="alice", source_branch="feature/figma", target_branch="main",
+        source_sha="a" * 40, target_sha="b" * 40, raw={},
+    )
+
+
+REF = PRRef(
+    forge="fake", host="fake.test", owner="acme", repo="widget",
+    number=7, url="https://fake.test/acme/widget/pull/7",
+)
+
+
+def test_containment_note_applied_end_to_end_through_orchestrate_review():
+    forge = _FakeForge(pr=_make_pr(), diff=FIGMA_DIFF)
+    llm = _VerbatimLLM(FIGMA_FINDING_JSON)
+
+    result = orchestrate_review(forge, REF, llm, post=False)
+
+    findings = result["findings_active"]
+    matches = [f for f in findings if "decodeServerJsonSchema" in f.title]
+    assert matches, (
+        f"expected the figma throw finding to survive the quality gates; "
+        f"active findings were: {findings}"
+    )
+    finding = matches[0]
+    assert finding.severity == "error"
+    assert finding.body.endswith(" [containment boundary not stated]"), (
+        f"finding body was not suffixed with the containment-boundary "
+        f"warning; got: {finding.body!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test C: apply_containment_note directly, on 4 throw-class bodies with no
+# boundary named. Explicit failure reason when the function does not exist.
+# ---------------------------------------------------------------------------
+
+def _require_apply_containment_note():
+    fn = getattr(quality, "apply_containment_note", None)
+    if fn is None:
+        pytest.fail("apply_containment_note missing")
+    return fn
+
+
+def _finding(title: str, body: str) -> Finding:
+    return Finding(
+        file="src/mcp/figma.ts", line=4, severity="error", confidence=0.85,
+        title=title, body=body,
+    )
+
+
+# Four throw-class phrasings (throws / panics / crashes / unhandled
+# rejection), none naming a boundary.
+THROW_CLASS_NO_BOUNDARY = [
+    _finding(
+        "Registration aborts on bad schema",
+        "The handler throws when the payload is malformed, aborting the "
+        "request entirely.",
+    ),
+    _finding(
+        "Parser dies on empty input",
+        "Parser panics on empty input, taking down the whole ingestion "
+        "pipeline.",
+    ),
+    _finding(
+        "Scheduler fails under contention",
+        "The scheduler crashes when two jobs collide on the same worker "
+        "slot.",
+    ),
+    _finding(
+        "Async handler drops the promise",
+        "An unhandled rejection escapes the async handler and terminates "
+        "the process.",
+    ),
+]
+
+
+class TestApplyContainmentNoteDirect:
+    def test_four_throw_class_bodies_get_suffixed(self):
+        apply_containment_note = _require_apply_containment_note()
+
+        result = apply_containment_note(THROW_CLASS_NO_BOUNDARY)
+
+        assert len(result) == len(THROW_CLASS_NO_BOUNDARY)
+        assert [f.title for f in result] == [f.title for f in THROW_CLASS_NO_BOUNDARY], (
+            "apply_containment_note must keep order"
+        )
+        for before, after in zip(THROW_CLASS_NO_BOUNDARY, result, strict=True):
+            assert after.body == before.body + " [containment boundary not stated]", (
+                f"not suffixed: {after.body!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Controls: no false positives. Run against the real function when present,
+# else an identity no-op — these must pass BOTH today and after the fix.
+# ---------------------------------------------------------------------------
+
+def _apply_containment_note_or_identity():
+    return getattr(quality, "apply_containment_note", lambda fs: list(fs))
+
+
+def test_control_boundary_named_finding_is_not_suffixed():
+    apply_containment_note = _apply_containment_note_or_identity()
+    finding = _finding(
+        "decodeServerJsonSchema throws during register for non-object inputSchema",
+        "The exception is uncaught here, but propagates to serverFactory "
+        "and fails MCP handler construction, so all tool families go down "
+        "together.",
+    )
+
+    result = apply_containment_note([finding])
+
+    assert result[0].body == finding.body
+
+
+def test_control_non_throw_finding_is_untouched():
+    apply_containment_note = _apply_containment_note_or_identity()
+    finding = _finding(
+        "computeTotal returns the wrong total for empty carts",
+        "The reduce accumulator starts at undefined instead of 0, so an "
+        "empty cart returns NaN instead of 0 as the total.",
+    )
+
+    result = apply_containment_note([finding])
+
+    assert result[0].body == finding.body

--- a/tests/test_issue_08_cli_format.py
+++ b/tests/test_issue_08_cli_format.py
@@ -1,0 +1,186 @@
+"""Eval for issue 08: --no-post prints only the verdict, and there is no
+machine-readable output at all.
+
+Mirrors ``tests/test_cli.py``'s ``fake_runtime`` stubbing style (fake
+``prxref.orchestrator`` / ``prxref.llm_backends`` modules installed via
+monkeypatch) rather than importing that fixture, so this file is
+self-contained and the crafted result dict — real ``Finding`` objects with
+title/body/drop_reason — is local to the two tests that need it.
+
+Test A and Test B are expected to FAIL against today's ``src/prxref/cli.py``:
+  * Test A: ``review`` has no ``--format`` flag, so argparse raises
+    ``SystemExit(2)`` before any output happens.
+  * Test B: text mode with ``--no-post`` prints only ``verdict:`` — no
+    finding titles, bodies, or the dropped-findings section.
+Both pass once the FROZEN CLI CONTRACT (see the issue file) is implemented.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import types
+
+import pytest
+
+from prxref.cli import main
+from prxref.forges.base import PRRef
+from prxref.triage import Finding
+
+REF = PRRef(
+    forge="github",
+    host="github.com",
+    owner="org",
+    repo="repo",
+    number=7,
+    url="https://github.com/org/repo/pull/7",
+)
+URL = "https://github.com/org/repo/pull/7"
+
+ACTIVE = Finding(
+    file="src/foo.py",
+    line=42,
+    severity="error",
+    confidence=0.92,
+    title="Off-by-one in loop bound",
+    body="The loop uses `<=` where `<` was intended, causing an out-of-bounds read.",
+    drop_reason=None,
+)
+DROPPED = Finding(
+    file="src/bar.py",
+    line=10,
+    severity="warning",
+    confidence=0.40,
+    title="Possible unused import",
+    body="`os` appears unused after this change.",
+    drop_reason="confidence 0.40 below floor 0.60",
+)
+
+RESULT = {
+    "verdict": "Request-Changes",
+    "findings_active": [ACTIVE],
+    "findings_dropped": [DROPPED],
+    "chunk_count": 3,
+    "chunks_reviewed": 3,
+    "chunks_failed": 0,
+    "elapsed_ms": 1234,
+    "input_tokens": 500,
+    "output_tokens": 120,
+    "posted": False,
+}
+
+
+def _install_fake_module(monkeypatch, fullname: str, **attrs) -> types.ModuleType:
+    mod = types.ModuleType(fullname)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    monkeypatch.setitem(sys.modules, fullname, mod)
+    return mod
+
+
+@pytest.fixture
+def stub_review(monkeypatch):
+    """Installs a fake orchestrator returning RESULT (one active, one dropped
+    finding), and a fake llm_backends, exactly as fake_runtime does in
+    tests/test_cli.py."""
+    monkeypatch.setattr("prxref.cli.detect_forge", lambda url: REF)
+    _install_fake_module(
+        monkeypatch,
+        "prxref.llm_backends",
+        create_llm_client=lambda cfg: object(),
+    )
+    _install_fake_module(
+        monkeypatch,
+        "prxref.orchestrator",
+        orchestrate_review=lambda **kwargs: RESULT,
+    )
+
+
+def test_format_json_emits_one_object_with_active_and_dropped_findings(
+    stub_review, capsys
+):
+    """Test A (must FAIL now). Today ``--format`` does not exist: argparse
+    rejects it with a SystemExit(2) usage error before anything is printed.
+    That failure is asserted explicitly below and then turned into a clean
+    pytest.fail so the test reads as a FAIL rather than an uncaught
+    SystemExit; once ``--format`` lands the except branch is never reached
+    and the real assertions (the fixed behaviour) run instead.
+    """
+    try:
+        rc = main([
+            "review", "--pr-url", URL, "--no-post", "--format", "json",
+        ])
+    except SystemExit as exc:
+        assert exc.code == 2, f"expected today's usage-error exit 2, got {exc.code}"
+        pytest.fail(
+            "review --format json not implemented yet: argparse rejected "
+            "--format with SystemExit(2) (issue 08 / FROZEN CLI CONTRACT)"
+        )
+        return
+
+    assert rc == 0
+    out, err = capsys.readouterr()
+    # "exactly ONE JSON object to stdout and nothing else on stdout" — a
+    # stray print anywhere in stdout breaks this parse.
+    payload = json.loads(out.strip())
+
+    assert payload["verdict"] == "Request-Changes"
+    assert payload["chunk_count"] == 3
+
+    findings = payload["findings"]
+    assert len(findings) == 2
+    active_row, dropped_row = findings[0], findings[1]
+
+    assert active_row["file"] == "src/foo.py"
+    assert active_row["line"] == 42
+    assert active_row["severity"] == "error"
+    assert active_row["confidence"] == pytest.approx(0.92)
+    assert active_row["title"] == "Off-by-one in loop bound"
+    assert active_row["body"] == ACTIVE.body
+    assert active_row["drop_reason"] is None
+
+    assert dropped_row["file"] == "src/bar.py"
+    assert dropped_row["line"] == 10
+    assert dropped_row["title"] == "Possible unused import"
+    assert dropped_row["drop_reason"] == "confidence 0.40 below floor 0.60"
+
+
+def test_no_post_text_mode_prints_finding_bodies_and_dropped_reasons(
+    stub_review, capsys
+):
+    """Test B (must FAIL now). Today ``_print_summary`` never renders finding
+    titles, bodies, or the dropped section in any mode — with ``--no-post``
+    they are unreachable without importing ``prxref.cli._run_review``
+    directly, which is exactly the bug the issue reports."""
+    rc = main(["review", "--pr-url", URL, "--no-post"])
+    assert rc == 0
+    out, _ = capsys.readouterr()
+
+    assert "error src/foo.py:42 Off-by-one in loop bound (confidence 0.92)" in out
+    assert "  " + ACTIVE.body in out
+    assert "dropped:" in out
+    assert "  src/bar.py:10 Possible unused import -- confidence 0.40 below floor 0.60" in out
+
+
+def test_control_verdict_and_counts_lines_still_appear_in_text_mode(
+    stub_review, capsys
+):
+    """Control (must PASS now and after): the pre-existing verbose summary
+    lines are not regressed by the fix."""
+    rc = main(["review", "--pr-url", URL, "--no-post", "-v"])
+    assert rc == 0
+    out, _ = capsys.readouterr()
+    assert "verdict: Request-Changes" in out
+    assert "counts:" in out
+
+
+def test_control_no_bodies_without_no_post_or_verbose(stub_review, capsys):
+    """Control (must PASS now and after): the default (posting) invocation,
+    with neither --no-post nor -v, prints only the verdict line — no finding
+    titles or bodies leak into plain default-mode stdout."""
+    rc = main(["review", "--pr-url", URL])
+    assert rc == 0
+    out, _ = capsys.readouterr()
+    assert "verdict: Request-Changes" in out
+    assert ACTIVE.title not in out
+    assert ACTIVE.body not in out
+    assert DROPPED.title not in out

--- a/tests/test_issue_09_unavailable_model_cache.py
+++ b/tests/test_issue_09_unavailable_model_cache.py
@@ -1,0 +1,135 @@
+"""Eval for issue 09: a model whose 4xx body says it is permanently
+unavailable must be cached for the lifetime of the OpenAICompatClient and
+skipped on every later invoke() -- not retried on every chunk/sweep.
+
+Mirrors the fake-session style in tests/test_llm_backends.py (a fake
+``session.post`` returning objects with ``status_code``/``json()``/
+``iter_content``/``close``) rather than inventing a new mocking approach.
+These tests are expected to FAIL against today's llm_backends.py (no
+per-run memory of a failed model exists yet) and PASS once the fix lands.
+"""
+from __future__ import annotations
+
+import json as json_module
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from prxref.llm_backends import LLMError, OpenAICompatClient
+
+
+def _resp(status_code=200, model="resolved", text="ok", error_message=None):
+    """A fake ``requests.Response`` -- success body or an OpenAI-style error body."""
+    if error_message is not None:
+        payload = {"error": {"message": error_message}}
+    else:
+        payload = {
+            "choices": [{"message": {"role": "assistant", "content": text}}],
+            "model": model,
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+        }
+    body = json_module.dumps(payload).encode()
+    return SimpleNamespace(
+        status_code=status_code,
+        json=lambda: payload,
+        text=json_module.dumps(payload),
+        iter_content=lambda chunk_size=None: iter([body]),
+        close=lambda: None,
+    )
+
+
+class _ModelRoutedSession:
+    """Queues responses per model (by the posted ``json["model"]``); records every call."""
+
+    def __init__(self, responses: dict[str, list]):
+        self.responses = {k: list(v) for k, v in responses.items()}
+        self.calls: list[str] = []
+
+    def post(self, url, json=None, headers=None, timeout=None, stream=None):
+        model = json["model"]
+        self.calls.append(model)
+        queue = self.responses.get(model, [])
+        if not queue:
+            raise AssertionError(f"unexpected extra request for model {model!r}")
+        return queue.pop(0)
+
+    def count(self, model: str) -> int:
+        return self.calls.count(model)
+
+
+def _client(session, models):
+    return OpenAICompatClient(
+        base_url="https://llm.test/v1", api_key="k", models=list(models), session=session,
+    )
+
+
+_UNAVAILABLE_MSG = (
+    'The requested model is not available for integrator "opencode". '
+    'Available models: ["claude-sonnet-5"]'
+)
+
+
+class TestSkipsPermanentlyUnavailableModel:
+    def test_a_second_invoke_never_retries_the_unavailable_model(self, caplog):
+        session = _ModelRoutedSession({
+            "dead": [_resp(400, error_message=_UNAVAILABLE_MSG),
+                     _resp(400, error_message=_UNAVAILABLE_MSG)],
+            "alive": [_resp(text="ok"), _resp(text="ok")],
+        })
+        client = _client(session, ["dead", "alive"])
+        with caplog.at_level(logging.WARNING, logger="prxref.llm_backends"):
+            r1 = client.invoke("sys", "usr")
+            r2 = client.invoke("sys", "usr")
+        assert session.count("dead") == 1
+        assert r1.text == "ok"
+        assert r2.text == "ok"
+        skip_msgs = [
+            rec.getMessage() for rec in caplog.records
+            if "skipping for the rest of the run" in rec.getMessage()
+        ]
+        assert len(skip_msgs) == 1, skip_msgs
+        assert "dead" in skip_msgs[0]
+
+    def test_b_all_unavailable_second_invoke_raises_without_a_request(self):
+        session = _ModelRoutedSession({
+            "dead1": [_resp(400, error_message="model_not_found: dead1"),
+                      _resp(400, error_message="model_not_found: dead1")],
+            "dead2": [_resp(400, error_message="model_not_found: dead2"),
+                      _resp(400, error_message="model_not_found: dead2")],
+        })
+        client = _client(session, ["dead1", "dead2"])
+        with pytest.raises(LLMError):
+            client.invoke("sys", "usr")
+        calls_after_first = len(session.calls)
+        with pytest.raises(LLMError) as exc:
+            client.invoke("sys", "usr")
+        assert len(session.calls) == calls_after_first
+        assert "skipped (unavailable)" in str(exc.value)
+
+
+class TestControlsUnaffected:
+    """Transient failures and non-matching 4xx bodies must keep retrying every invoke."""
+
+    def test_transient_500_is_not_cached(self):
+        session = _ModelRoutedSession({
+            "dead": [_resp(500), _resp(500)],
+            "alive": [_resp(text="ok1"), _resp(text="ok2")],
+        })
+        client = _client(session, ["dead", "alive"])
+        r1 = client.invoke("sys", "usr")
+        r2 = client.invoke("sys", "usr")
+        assert session.count("dead") == 2
+        assert r1.text == "ok1"
+        assert r2.text == "ok2"
+
+    def test_400_without_an_unavailable_phrase_is_not_cached(self):
+        session = _ModelRoutedSession({
+            "dead": [_resp(400, error_message="invalid request: messages must not be empty"),
+                     _resp(400, error_message="invalid request: messages must not be empty")],
+            "alive": [_resp(text="ok1"), _resp(text="ok2")],
+        })
+        client = _client(session, ["dead", "alive"])
+        client.invoke("sys", "usr")
+        client.invoke("sys", "usr")
+        assert session.count("dead") == 2

--- a/tests/test_issue_10_release_shaped_pr.py
+++ b/tests/test_issue_10_release_shaped_pr.py
@@ -1,0 +1,196 @@
+"""Issue 10: flag a release-shaped PR that also touches source files.
+
+prxref returned zero findings on a release PR whose branch quietly carried
+the commits of a different, still-open PR — diff-visible without any repo
+archaeology: every changed file except two was release machinery (version
+bumps, CHANGELOG, lockfile, a consumed changeset), and the two remaining
+files were source.
+
+Frozen contract under test:
+
+- Release machinery basenames: package.json, pyproject.toml, Cargo.toml,
+  setup.py, setup.cfg, VERSION, version.py, __version__.py, *.gemspec,
+  CHANGELOG*/HISTORY*/RELEASE_NOTES* (any case), lockfiles (package-lock.json,
+  pnpm-lock.yaml, yarn.lock, bun.lockb, bun.lock, uv.lock, poetry.lock,
+  Pipfile.lock, Cargo.lock, Gemfile.lock, go.sum, composer.lock), anything
+  under a ``.changeset/`` directory, and ``.release-please-manifest.json``.
+- A PR is release-shaped when it changes >= 2 files and >= 80% of them are
+  release machinery.
+- When a release-shaped PR ALSO changes any non-machinery file, the pipeline
+  emits exactly ONE finding: severity "warning", confidence 1.0, file = the
+  first offending file (sorted), line 0 (file-level — no single diff hunk
+  owns a whole-PR-shape claim), title
+  "Release-shaped PR touches source: <N> non-release file(s)", body listing
+  every offending path on its own line and ending with
+  " (deterministic check, no model)". It must survive the normal quality
+  passes.
+- Pure release PRs and ordinary feature PRs emit no such finding.
+
+This is a deterministic (non-LLM) heuristic: today NOTHING in the pipeline
+produces a finding without an LLM call, so every test below that expects a
+finding fails until a ``heuristics`` module (or equivalent) is wired into
+``orchestrate_review``. The FakeLLM below always answers with an empty
+findings payload — including for the systemic sweep, which the shared
+``_contract_review_systemic`` stub short-circuits to ``[]`` regardless of
+what it is asked — so any finding that appears is not model output.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from test_orchestrator import (  # noqa: E402  (shared fixtures, read not guessed)
+    REF,
+    FakeForge,
+    FakeLLM,
+    _contract_review_chunk,
+    _contract_review_systemic,
+)
+
+from prxref import orchestrator  # noqa: E402
+from prxref.orchestrator import orchestrate_review  # noqa: E402
+
+# An empty-but-valid worker payload: the chunk contract parses this as zero
+# findings, and the sweep is stubbed below to ignore its input entirely — so
+# together the model contributes nothing to any test in this file.
+EMPTY_LLM = FakeLLM('{"findings":[],"escalations":[]}')
+
+
+@pytest.fixture
+def contract_stubs(monkeypatch):
+    """Chunk + sweep pinned to the orchestrator contract (no real reviewer)."""
+    monkeypatch.setattr(orchestrator.reviewer, "review_chunk", _contract_review_chunk)
+    monkeypatch.setattr(
+        orchestrator.reviewer, "review_systemic", _contract_review_systemic,
+    )
+
+
+def _modified_file_diff(path: str, old: str = "old value", new: str = "new value") -> str:
+    """One small modified-file diff section: one hunk, one changed line."""
+    return (
+        f"diff --git a/{path} b/{path}\n"
+        f"--- a/{path}\n"
+        f"+++ b/{path}\n"
+        "@@ -1,1 +1,1 @@\n"
+        f"-{old}\n"
+        f"+{new}\n"
+    )
+
+
+def _deleted_file_diff(path: str, line: str = "consumed changeset") -> str:
+    """One deleted-file diff section (e.g. a changeset consumed by a release)."""
+    return (
+        f"diff --git a/{path} b/{path}\n"
+        "deleted file mode 100644\n"
+        f"--- a/{path}\n"
+        "+++ /dev/null\n"
+        "@@ -1,1 +0,0 @@\n"
+        f"-{line}\n"
+    )
+
+
+# Nine distinct release-machinery basenames (one is a deleted changeset) so
+# the ratio clears the >=80% bar with margin even after two source files are
+# added: 9 / 11 = 81.8%. A literal 5-machinery/2-source split (the issue's
+# own worked example) sits at 5/7 = 71.4%, BELOW the frozen 80% threshold —
+# recomputed here rather than copied, see the verify report's Eval section.
+MACHINERY_PATHS = [
+    "package.json",
+    "CHANGELOG.md",
+    "pnpm-lock.yaml",
+    "packages/cli/package.json",
+    "VERSION",
+    "Cargo.toml",
+    "setup.py",
+    "RELEASE_NOTES.md",
+]
+DELETED_CHANGESET = ".changeset/brave-foxes.md"
+
+SOURCE_PATHS = [
+    "src/apps/cli/src/config/json-file.ts",
+    "src/apps/cli/src/config/json-file.test.ts",
+]
+# Sorted order matters: the contract anchors the finding on the first
+# offending file, sorted.
+SOURCE_PATHS_SORTED = sorted(SOURCE_PATHS)
+
+
+def _release_shaped_diff(*, include_source: bool) -> str:
+    parts = [_modified_file_diff(p) for p in MACHINERY_PATHS]
+    parts.append(_deleted_file_diff(DELETED_CHANGESET))
+    if include_source:
+        parts.extend(_modified_file_diff(p) for p in SOURCE_PATHS)
+    return "\n".join(parts)
+
+
+def _feature_diff_with_one_manifest() -> str:
+    """5 source files + 1 manifest bump: 1/6 = 16.7% machinery, not release-shaped."""
+    parts = [_modified_file_diff(f"src/mod{i}.py") for i in range(1, 6)]
+    parts.append(_modified_file_diff("package.json"))
+    return "\n".join(parts)
+
+
+def _single_manifest_diff() -> str:
+    """One file changed: fails the >= 2 files half of the contract outright."""
+    return _modified_file_diff("package.json")
+
+
+class TestReleaseShapedPRTouchesSource:
+    """Test A: must FAIL today (no deterministic finding exists yet)."""
+
+    def test_release_shaped_pr_with_two_source_files_raises_one_finding(
+        self, contract_stubs,
+    ):
+        forge = FakeForge(diff=_release_shaped_diff(include_source=True))
+        res = orchestrate_review(forge, REF, EMPTY_LLM, post=False)
+
+        active = res["findings_active"]
+        assert len(active) == 1, (
+            f"expected exactly one finding, got {len(active)}: {active}"
+        )
+        f = active[0]
+
+        assert f.title.startswith("Release-shaped PR touches source:")
+        assert "2 non-release file" in f.title
+        assert f.severity == "warning"
+        assert f.confidence == 1.0
+        assert f.line == 0
+        assert f.file == SOURCE_PATHS_SORTED[0]
+        assert f.drop_reason is None
+
+        # Both offending paths named in the body. Containment rather than
+        # exact-own-line matching: the contract says each path is on its own
+        # line AND the body ends with " (deterministic check, no model)" —
+        # if that suffix is appended to the last path's line rather than a
+        # line of its own, a strict per-line match would false-negative on
+        # an otherwise-compliant implementation.
+        for path in SOURCE_PATHS:
+            assert path in f.body, f"{path!r} missing from body:\n{f.body}"
+
+        assert f.body.endswith(" (deterministic check, no model)")
+
+
+class TestControls:
+    """Diffs that must never raise the release-shaped finding — now or after
+    the fix lands."""
+
+    def test_pure_release_pr_no_source_files_yields_no_finding(self, contract_stubs):
+        forge = FakeForge(diff=_release_shaped_diff(include_source=False))
+        res = orchestrate_review(forge, REF, EMPTY_LLM, post=False)
+        assert res["findings_active"] == []
+
+    def test_ordinary_feature_pr_with_incidental_manifest_bump_yields_no_finding(
+        self, contract_stubs,
+    ):
+        forge = FakeForge(diff=_feature_diff_with_one_manifest())
+        res = orchestrate_review(forge, REF, EMPTY_LLM, post=False)
+        assert res["findings_active"] == []
+
+    def test_single_manifest_file_diff_yields_no_finding(self, contract_stubs):
+        forge = FakeForge(diff=_single_manifest_diff())
+        res = orchestrate_review(forge, REF, EMPTY_LLM, post=False)
+        assert res["findings_active"] == []

--- a/tests/test_issue_12_package_json_section.py
+++ b/tests/test_issue_12_package_json_section.py
@@ -1,0 +1,264 @@
+"""Issue #12 — package.json section misattribution: a devDependency reported
+as a runtime dependency.
+
+docs/issues/inbox-2026-09-04/prxref-issue-2026-09-03.md §2: on ``syf-mcp``
+PR #45, prxref flagged ``vitest`` as a production dependency at
+``src/apps/mcp/package.json:20`` — line 20 is ``"@syf-mcp/jenkins": "*",``, a
+``dependencies`` entry, not the ``vitest`` line (which is line 37, inside
+``devDependencies``). Posted as an OUTOFSCOPE comment, then retracted.
+
+Frozen contract: ``prxref.quality.apply_manifest_claim_check(findings,
+files: list[FileDiff]) -> list[Finding]`` for findings on package.json files
+(basename match):
+- Extract the claimed dependency key (first backticked or bare npm package
+  name that also appears as a JSON key in the file's post-image hunk
+  lines). If the anchored line's key differs from the claimed key, drop with
+  ``drop_reason`` starting ``anchor mismatch:`` naming both keys.
+- Else, if the claim asserts a section ("runtime dependencies", "production
+  dependenc", "under `dependencies`", "in dependencies" vs
+  "devDependencies") and the section enclosing the anchor differs from the
+  claimed one, drop with ``drop_reason`` starting ``section mismatch:``
+  naming claimed vs actual.
+- Non-package.json findings, and findings with no extractable key, are
+  untouched.
+
+Mechanism finding (traced empirically with quality.apply_line_align against
+the fixture below, not guessed): the existing content-pass realign
+(quality._realign_member, called from apply_line_align via
+prxref/quality.py:397) shares the token "dependencies" between BOTH the
+``"dependencies": {`` and ``"devDependencies": {`` header lines (the latter
+via the compound split of "devDependencies"), so its best-content-match
+target is a HEADER line rather than the vitest content line. A finding
+anchored at 20 realigns to 20 (a no-op, since the nearest added line to the
+winning header is the anchor's own line). A finding anchored at 37 realigns
+DOWN to 20 (the header's nearest added line is the jenkins entry, not
+vitest, because 20 sits numerically closer to the devDependencies header at
+26 than 37 does). So if ``apply_manifest_claim_check`` ran AFTER
+``apply_line_align``, both a line-20 and a line-37 report would already be
+anchored at 20 by the time the new check saw them, and BOTH would report
+"anchor mismatch:" — Test B's "section mismatch:" case would be
+unreachable. The fix must run BEFORE ``apply_line_align`` (between
+prxref/orchestrator.py:453 ``apply_location_validation`` and :454
+``apply_line_align``), operating on each finding's raw, LLM-reported anchor.
+
+Tests A and B FAIL today (no such pass exists, so nothing drops either
+finding). Test C is a direct unit-level guard on both anchor variants. The
+controls are the no-op-shim pattern from test_issue_05_hedged_findings.py:
+green today by construction, and bind the real gate once it lands.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from prxref import quality
+from prxref.orchestrator import orchestrate_review
+from prxref.triage import Finding, parse_unified_diff
+from tests.test_orchestrator import REF, FakeForge, FakeLLM  # noqa: F401
+
+PKG_PATH = "src/apps/mcp/package.json"
+
+# Post-image line map, exact (traced with tests/../parse_unified_diff, not
+# guessed):
+#   12  "version": "0.1.0",                        context
+#   13  "dependencies": {                           context — dependencies header
+#   14..19  six existing runtime deps               context
+#   20  "@syf-mcp/jenkins": "*",                     ADDED (+) — the real finding's anchor
+#   21..24  four more existing runtime deps          context
+#   25  },                                           context — dependencies close
+#   26  "devDependencies": {                         context — devDependencies header
+#   27..36  ten existing dev deps                    context
+#   37  "vitest": "^4.0.18",                         ADDED (+) — vitest's real line
+#   38  }                                            context — devDependencies close
+#
+# old_count = 25 (25 context lines, 2 added lines added on top) and
+# new_count = 27 (12..38 inclusive); nothing before line 12 changed, so
+# old_start == new_start == 12. Hunk header: "@@ -12,25 +12,27 @@".
+_HUNK_LINES = [
+    '  "version": "0.1.0",',
+    '  "dependencies": {',
+    '    "@syf-mcp/core": "^1.0.0",',
+    '    "@syf-mcp/logging": "^1.0.0",',
+    '    "axios": "^1.6.0",',
+    '    "commander": "^11.0.0",',
+    '    "dotenv": "^16.3.0",',
+    '    "express": "^4.18.0",',
+    '+    "@syf-mcp/jenkins": "*",',
+    '    "lodash": "^4.17.21",',
+    '    "winston": "^3.11.0",',
+    '    "yargs": "^17.7.0",',
+    '    "zod": "^3.22.0",',
+    '  },',
+    '  "devDependencies": {',
+    '    "@syf-mcp/eslint-config": "^1.0.0",',
+    '    "@types/express": "^4.17.0",',
+    '    "@types/node": "^20.0.0",',
+    '    "eslint": "^8.50.0",',
+    '    "prettier": "^3.0.0",',
+    '    "ts-node": "^10.9.0",',
+    '    "typescript": "^5.2.0",',
+    '    "@types/jest": "^29.5.0",',
+    '    "esbuild": "^0.19.0",',
+    '    "nodemon": "^3.0.0",',
+    '+    "vitest": "^4.0.18",',
+    '  }',
+]
+assert sum(1 for ln in _HUNK_LINES if ln.startswith("+")) == 2
+assert len(_HUNK_LINES) == 27  # new_count
+
+PACKAGE_JSON_DIFF = (
+    f"diff --git a/{PKG_PATH} b/{PKG_PATH}\n"
+    f"--- a/{PKG_PATH}\n"
+    f"+++ b/{PKG_PATH}\n"
+    "@@ -12,25 +12,27 @@\n"
+    + "\n".join(_HUNK_LINES) + "\n"
+)
+
+# Verbatim from docs/issues/inbox-2026-09-04/prxref-issue-2026-09-03.md §2,
+# comment 1253956.
+TITLE = "vitest added to runtime dependencies"
+BODY = (
+    "vitest is a test-only tool but is added under `dependencies` in "
+    "src/apps/mcp/package.json, unlike src/packages/jenkins/package.json "
+    "where it is correctly a devDependency. This bloats production "
+    "installs/bundles."
+)
+
+
+def _finding(line: int) -> Finding:
+    return Finding(
+        file=PKG_PATH, line=line, severity="outofscope", confidence=0.8,
+        title=TITLE, body=BODY,
+    )
+
+
+def _reasons_for(res: dict, title: str) -> list[str]:
+    return [f.drop_reason or "" for f in res["findings_dropped"] if f.title == title]
+
+
+class TestAAnchorAtJenkinsLine:
+    """The real-world report: anchored at 20, the jenkins line — must be
+    dropped for an ANCHOR key mismatch (claimed key ``vitest`` != anchor
+    key ``@syf-mcp/jenkins``), which is the anchor-key check the frozen
+    contract runs BEFORE the section check. Traced above: apply_line_align
+    leaves a line-20 anchor at 20 (a no-op realign), so this holds whether
+    the new pass runs before or after apply_line_align — it is Test B where
+    the ordering bites.
+    """
+
+    def test_end_to_end(self):
+        response = json.dumps({"findings": [
+            {"file": PKG_PATH, "line": 20, "severity": "outofscope",
+             "confidence": 0.8, "title": TITLE, "body": BODY},
+        ]})
+        forge = FakeForge(diff=PACKAGE_JSON_DIFF)
+        res = orchestrate_review(forge, REF, FakeLLM(response), post=False)
+
+        active_titles = {f.title for f in res["findings_active"]}
+        assert TITLE not in active_titles, "false-positive vitest claim survived"
+        reasons = _reasons_for(res, TITLE)
+        assert reasons, f"{TITLE!r} not in findings_dropped"
+        assert any(r.startswith("anchor mismatch:") for r in reasons), (
+            f"expected 'anchor mismatch:', got {reasons!r}"
+        )
+
+
+class TestBAnchorAtVitestLine:
+    """Same finding, anchored at 37 — the vitest line itself. The anchor
+    key now matches the claim (``vitest`` == ``vitest``), so the drop must
+    come from the SECTION check: claim says dependencies/runtime, actual
+    section is devDependencies. This is the case that pins pass order: if
+    apply_manifest_claim_check ran after apply_line_align, the realign
+    traced above moves this anchor from 37 to 20 first, and the check would
+    see an anchor-key mismatch instead — the wrong reason.
+    """
+
+    def test_end_to_end(self):
+        response = json.dumps({"findings": [
+            {"file": PKG_PATH, "line": 37, "severity": "outofscope",
+             "confidence": 0.8, "title": TITLE, "body": BODY},
+        ]})
+        forge = FakeForge(diff=PACKAGE_JSON_DIFF)
+        res = orchestrate_review(forge, REF, FakeLLM(response), post=False)
+
+        active_titles = {f.title for f in res["findings_active"]}
+        assert TITLE not in active_titles, "false-positive vitest claim survived"
+        reasons = _reasons_for(res, TITLE)
+        assert reasons, f"{TITLE!r} not in findings_dropped"
+        assert any(r.startswith("section mismatch:") for r in reasons), (
+            f"expected 'section mismatch:', got {reasons!r}"
+        )
+
+
+class TestCDirectUnit:
+    """Direct unit call on both anchor variants, no orchestrator involved."""
+
+    def test_apply_manifest_claim_check_exists_and_classifies_both(self):
+        if not hasattr(quality, "apply_manifest_claim_check"):
+            pytest.fail(
+                "prxref.quality.apply_manifest_claim_check does not exist "
+                "yet — issue #12's fix is not implemented"
+            )
+        files = parse_unified_diff(PACKAGE_JSON_DIFF)
+
+        out_a = quality.apply_manifest_claim_check([_finding(20)], files)
+        assert len(out_a) == 1
+        assert out_a[0].drop_reason is not None, "line-20 finding not dropped"
+        assert out_a[0].drop_reason.startswith("anchor mismatch:"), out_a[0].drop_reason
+
+        out_b = quality.apply_manifest_claim_check([_finding(37)], files)
+        assert len(out_b) == 1
+        assert out_b[0].drop_reason is not None, "line-37 finding not dropped"
+        assert out_b[0].drop_reason.startswith("section mismatch:"), out_b[0].drop_reason
+
+
+def _claim_check(findings, files):
+    """The frozen entry point, or an identity shim before it exists.
+
+    Mirrors test_issue_05_hedged_findings.py's TestCControls pattern: green
+    today by construction (the shim never drops anything), and the same
+    assertions bind the real gate once ``apply_manifest_claim_check`` lands.
+    """
+    fn = getattr(quality, "apply_manifest_claim_check", lambda fs, fl: list(fs))
+    return fn(findings, files)
+
+
+class TestDControls:
+    """Legitimate / out-of-scope findings must stay untouched, now and after."""
+
+    def test_correct_runtime_claim_stays_active(self):
+        files = parse_unified_diff(PACKAGE_JSON_DIFF)
+        f = Finding(
+            file=PKG_PATH, line=20, severity="warning", confidence=0.7,
+            title="@syf-mcp/jenkins pinned to * in dependencies",
+            body=(
+                "The version is pinned to `*` instead of a specific range, "
+                "so installs are not reproducible."
+            ),
+        )
+        out = _claim_check([f], files)
+        assert len(out) == 1
+        assert out[0].drop_reason is None, out[0].drop_reason
+
+    def test_non_package_json_file_untouched(self):
+        files = parse_unified_diff(PACKAGE_JSON_DIFF)
+        f = Finding(
+            file="src/index.ts", line=5, severity="warning", confidence=0.7,
+            title="Unused import",
+            body="`lodash` is imported here but never used.",
+        )
+        out = _claim_check([f], files)
+        assert len(out) == 1
+        assert out[0].drop_reason is None, out[0].drop_reason
+
+    def test_correct_devdependency_claim_stays_active(self):
+        files = parse_unified_diff(PACKAGE_JSON_DIFF)
+        f = Finding(
+            file=PKG_PATH, line=37, severity="outofscope", confidence=0.8,
+            title="vitest ^4.0.18 added to devDependencies",
+            body="This adds `vitest` as a test runner dependency for the mcp app.",
+        )
+        out = _claim_check([f], files)
+        assert len(out) == 1
+        assert out[0].drop_reason is None, out[0].drop_reason

--- a/tests/test_llm_backends.py
+++ b/tests/test_llm_backends.py
@@ -634,6 +634,146 @@ class TestLiteLLMClient:
         assert captured[0]["seed"] == 11
 
 
+class _FakeBadRequestError(Exception):
+    """Mimics litellm's own exception shape: a ``.message`` and a ``.model``.
+
+    Real litellm ``BadRequestError``/``NotFoundError`` instances carry both,
+    which is how the fix identifies which model in the chain actually failed
+    without depending on a reliable ``.status_code``.
+    """
+
+    def __init__(self, message: str, model: str | None = None):
+        super().__init__(message)
+        self.message = message
+        self.model = model
+
+
+class _FakeHttpError(Exception):
+    """A litellm-shaped exception carrying only ``.status_code`` (no ``.model``,
+    and a class name that does not itself say BadRequest/NotFound)."""
+
+    def __init__(self, message: str, status_code: int):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class TestLiteLLMClientSkipsPermanentlyUnavailableModel:
+    """Mirrors OpenAICompatClient's run-lifetime unavailable-model cache
+    (issue 09), keyed on litellm's exception shape instead of a status code.
+    """
+
+    def test_second_invoke_filters_the_unavailable_primary(self, monkeypatch, caplog):
+        calls: list[dict] = []
+
+        def fake_completion(**kwargs):
+            calls.append(kwargs)
+            if kwargs["model"] == "primary":
+                raise _FakeBadRequestError(
+                    "The requested model is not available for this integrator",
+                    model="primary",
+                )
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content="lit-ok"))],
+                usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+                model="fb1-resolved",
+            )
+
+        monkeypatch.setitem(
+            sys.modules, "litellm", types.SimpleNamespace(completion=fake_completion)
+        )
+        client = LiteLLMClient(models=["primary", "fb1"])
+        with caplog.at_level(logging.WARNING, logger="prxref.llm_backends"):
+            with pytest.raises(_FakeBadRequestError):
+                client.invoke("sys", "usr")
+            r2 = client.invoke("sys", "usr")
+        assert r2.text == "lit-ok"
+        assert calls[0]["model"] == "primary"
+        assert calls[0]["fallbacks"] == ["fb1"]
+        assert calls[1]["model"] == "fb1"
+        assert calls[1]["fallbacks"] == []
+        skip_msgs = [
+            rec.getMessage() for rec in caplog.records
+            if "skipping for the rest of the run" in rec.getMessage()
+        ]
+        assert len(skip_msgs) == 1, skip_msgs
+        assert "primary" in skip_msgs[0]
+
+    def test_all_unavailable_raises_without_calling_litellm(self, monkeypatch):
+        calls: list[dict] = []
+
+        def fake_completion(**kwargs):
+            calls.append(kwargs)
+            raise _FakeBadRequestError("model_not_found: dead", model="dead")
+
+        monkeypatch.setitem(
+            sys.modules, "litellm", types.SimpleNamespace(completion=fake_completion)
+        )
+        client = LiteLLMClient(models=["dead"])
+        with pytest.raises(_FakeBadRequestError):
+            client.invoke("sys", "usr")
+        with pytest.raises(LLMError) as exc:
+            client.invoke("sys", "usr")
+        assert len(calls) == 1
+        assert "skipped (unavailable)" in str(exc.value)
+        assert "dead" in str(exc.value)
+
+    def test_status_code_alone_signals_unavailable(self, monkeypatch):
+        """No ``BadRequest``/``NotFound`` in the class name; a 4xx
+        ``.status_code`` plus a phrase match is sufficient on its own."""
+        def fake_completion(**kwargs):
+            raise _FakeHttpError("no such model: primary", status_code=404)
+
+        monkeypatch.setitem(
+            sys.modules, "litellm", types.SimpleNamespace(completion=fake_completion)
+        )
+        client = LiteLLMClient(models=["primary", "fb1"])
+        with pytest.raises(_FakeHttpError):
+            client.invoke("sys", "usr")
+        assert client._unavailable == {"primary"}
+
+
+class TestLiteLLMClientControlsUnaffected:
+    """Transient/ambiguous exceptions must keep retrying every invoke."""
+
+    def test_a_generic_exception_does_not_filter(self, monkeypatch):
+        calls: list[dict] = []
+
+        def fake_completion(**kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                raise RuntimeError("connection reset by peer")
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content="lit-ok"))],
+                usage=None,
+                model="m",
+            )
+
+        monkeypatch.setitem(
+            sys.modules, "litellm", types.SimpleNamespace(completion=fake_completion)
+        )
+        client = LiteLLMClient(models=["primary", "fb1"])
+        with pytest.raises(RuntimeError):
+            client.invoke("sys", "usr")
+        client.invoke("sys", "usr")
+        assert calls[1]["model"] == "primary"
+        assert calls[1]["fallbacks"] == ["fb1"]
+
+    def test_5xx_status_code_with_a_matching_phrase_is_not_cached(self, monkeypatch):
+        """Only a 4xx signal qualifies -- mirrors OpenAICompatClient's rule
+        that a 5xx is never cached even when its body happens to use one of
+        the unavailable-phrase words."""
+        def fake_completion(**kwargs):
+            raise _FakeHttpError("model deprecated, retry later", status_code=503)
+
+        monkeypatch.setitem(
+            sys.modules, "litellm", types.SimpleNamespace(completion=fake_completion)
+        )
+        client = LiteLLMClient(models=["primary"])
+        with pytest.raises(_FakeHttpError):
+            client.invoke("sys", "usr")
+        assert client._unavailable == set()
+
+
 _ABSENT = object()
 
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -2468,6 +2468,203 @@ class TestSystemicSweep:
         assert res["chunk_count"] == 0
 
 
+class TestReleaseShapeFoldIn:
+    """The release-shape finding is a CHUNK-side finding (issue #29
+    residual): ``apply_sweep_dedup`` only ever drops a SWEEP finding, so
+    folding the heuristic in AFTER the sweep's own findings would let a
+    chunk worker's restatement of the same (file, title) pair get the
+    deterministic finding dropped as a duplicate of ITSELF, keeping the
+    model's echo instead of the deterministic check.
+
+    The two offending files are the only non-binary files in this diff —
+    the eight machinery files are diffed as binary, which ``build_chunks``
+    skips (there is no reviewable text) — so the review is exactly one
+    chunk (the two offenders) plus the sweep, and both the chunk worker
+    and the sweep are scripted to restate the heuristic's own (file,
+    title) pair on every call, the worst case named by the concern this
+    fix closes.
+
+    Verified empirically against the pre-fix assembly order (heuristic
+    appended after the sweep's findings): that order drops the
+    deterministic finding as "duplicate of chunk finding" and leaves only
+    the chunk worker's non-deterministic echo active — i.e. this test
+    fails before the fix. ``apply_sweep_dedup`` never drops a chunk-side
+    finding by contract (see its own docstring), so once the heuristic is
+    chunk-side neither it nor the chunk worker's own echo can be that
+    pass's victim; only the sweep's echo — the actual duplicate — is
+    dropped. That is why exactly one model ECHO (not zero) survives
+    alongside the deterministic finding: this pass has never deduplicated
+    two chunk-side findings against each other, and this test does not
+    assert that it now does.
+    """
+
+    TITLE = "Release-shaped PR touches source: 2 non-release file(s)"
+    DETERMINISTIC_SUFFIX = " (deterministic check, no model)"
+    OFFENDER_A = "src/alpha.py"
+    OFFENDER_B = "src/beta.py"
+    ANCHOR = min(OFFENDER_A, OFFENDER_B)  # heuristic anchors on the first, sorted
+
+    MACHINERY_BASENAMES = (
+        "package.json", "pyproject.toml", "Cargo.toml", "setup.py",
+        "setup.cfg", "VERSION", "CHANGELOG.md", "poetry.lock",
+    )
+
+    @staticmethod
+    def _binary_file_diff(path: str) -> str:
+        return (
+            f"diff --git a/{path} b/{path}\n"
+            "index 111..222 100644\n"
+            f"Binary files a/{path} and b/{path} differ\n"
+        )
+
+    def _diff(self) -> str:
+        # 8 machinery (binary, so build_chunks skips them) + 2 source files:
+        # 8/10 = 80%, exactly the frozen release-shape ratio boundary.
+        machinery = "".join(self._binary_file_diff(p) for p in self.MACHINERY_BASENAMES)
+        offenders = (
+            _added_file_diff(self.OFFENDER_A, 5) + _added_file_diff(self.OFFENDER_B, 5)
+        )
+        return machinery + offenders
+
+    def _matching_finding(self, body: str) -> Finding:
+        return Finding(
+            file=self.ANCHOR, line=1, severity="warning", confidence=0.9,
+            title=self.TITLE, body=body,
+        )
+
+    def test_a_chunk_and_sweep_echo_never_drops_the_deterministic_finding(
+        self, monkeypatch,
+    ):
+        def _review_chunk(llm, files, *, pr_title="", pr_description="",
+                           repo_hint="", max_tokens=None, context_lines=None,
+                           context_blocks=""):
+            return [self._matching_finding("chunk worker restatement")], {
+                "input_tokens": 10, "output_tokens": 5, "model": "m",
+                "elapsed_ms": 1, "error": "",
+            }
+
+        def _review_systemic(llm, digest, *, pr_title="", pr_description="",
+                              repo_hint="", max_tokens=None, threads=()):
+            return [self._matching_finding("sweep restatement")], {
+                "input_tokens": 7, "output_tokens": 3, "model": "sweep-model",
+                "elapsed_ms": 1, "error": "",
+            }
+
+        monkeypatch.setattr(orchestrator.reviewer, "review_chunk", _review_chunk)
+        monkeypatch.setattr(orchestrator.reviewer, "review_systemic", _review_systemic)
+
+        forge = FakeForge(diff=self._diff())
+        res = orchestrate_review(forge, REF, FakeLLM(), post=False)
+
+        # One chunk (the two offenders) plus the sweep.
+        assert res["chunk_count"] == 2
+
+        matching = [f for f in res["findings_active"] if f.title == self.TITLE]
+        deterministic = [f for f in matching if f.body.endswith(self.DETERMINISTIC_SUFFIX)]
+        echoes = [f for f in matching if not f.body.endswith(self.DETERMINISTIC_SUFFIX)]
+
+        # The deterministic finding survives — the whole point of the fix.
+        assert len(deterministic) == 1
+        assert deterministic[0].file == self.ANCHOR
+
+        # Exactly one model ECHO survives active — the chunk worker's own,
+        # which apply_sweep_dedup has never dropped and still must not.
+        assert len(echoes) == 1
+        assert echoes[0].body == "chunk worker restatement"
+
+        dropped_dupes = [
+            f for f in res["findings_dropped"]
+            if f.drop_reason == "duplicate of chunk finding"
+        ]
+        assert len(dropped_dupes) == 1
+        assert dropped_dupes[0].body == "sweep restatement"
+
+
+class TestReleaseShapeOnTheNoChunkPath:
+    """Concern #2: a diff that yields zero chunks skipped the deterministic
+    check entirely, because ``orchestrate_review`` returned via
+    ``_summary_only_run`` before ``heuristics.release_shape_findings`` was
+    ever called.
+
+    ``build_chunks`` skips a file for exactly one reason — it is binary,
+    ``"there is no reviewable text"`` (its own docstring; ``candidates =
+    [f for f in files if not f.is_binary]`` is the only filter) — so the
+    only diff shape that empties ``chunks`` while still exercising the
+    release-shape ratio is one where EVERY file, release machinery
+    included, is diffed as binary. A pure-text release PR (the realistic
+    case) always chunks normally and takes the path
+    ``TestReleaseShapeFoldIn`` already covers.
+    """
+
+    @staticmethod
+    def _binary_file_diff(path: str) -> str:
+        return (
+            f"diff --git a/{path} b/{path}\n"
+            "index 111..222 100644\n"
+            f"Binary files a/{path} and b/{path} differ\n"
+        )
+
+    # 9 release-machinery basenames, all binary, plus one binary
+    # non-machinery file: 9/10 = 90% >= the 80% ratio.
+    MACHINERY_BASENAMES = (
+        "package.json", "pyproject.toml", "Cargo.toml", "setup.py",
+        "setup.cfg", "VERSION", "CHANGELOG.md", "poetry.lock", "Cargo.lock",
+    )
+    OFFENDER = "src/logo.png"
+
+    def _diff(self) -> str:
+        return "".join(
+            self._binary_file_diff(p)
+            for p in (*self.MACHINERY_BASENAMES, self.OFFENDER)
+        )
+
+    def test_a_release_shaped_diff_with_zero_chunks_still_gets_the_finding(self):
+        forge = FakeForge(diff=self._diff())
+        res = orchestrate_review(forge, REF, FakeLLM(), post=True)
+
+        # Every file was binary: build_chunks skipped all of them, exactly
+        # the pre-fix condition that used to skip the heuristic too.
+        assert res["chunk_count"] == 0
+        assert res["chunks_reviewed"] == 0
+        assert res["chunks_failed"] == 0
+
+        active = res["findings_active"]
+        assert len(active) == 1
+        f = active[0]
+        assert f.title == "Release-shaped PR touches source: 1 non-release file(s)"
+        assert f.file == self.OFFENDER
+        assert f.line == 0
+        assert f.body.endswith(" (deterministic check, no model)")
+        assert res["verdict"] == "Approved"  # a warning-severity finding approves
+
+        assert len(forge.summaries) == 1
+        assert self.OFFENDER in forge.summaries[0]
+        assert "Release-shaped PR touches source" in forge.summaries[0]
+
+    def test_confidence_floor_still_applies_on_the_no_chunk_path(self):
+        """The caller's quality-gate knobs reach the heuristic finding here
+        exactly like they reach a chunk finding on the normal path."""
+        forge = FakeForge(diff=self._diff())
+        # The heuristic always emits confidence 1.0; a floor above 1.0 is
+        # unreachable and drops it, proving the gate actually ran here.
+        res = orchestrate_review(
+            forge, REF, FakeLLM(), post=False, confidence_floor=1.1,
+        )
+        assert res["findings_active"] == []
+        assert len(res["findings_dropped"]) == 1
+        assert "below floor" in res["findings_dropped"][0].drop_reason
+
+    def test_a_pure_release_diff_with_zero_chunks_yields_no_finding(self):
+        """The control: no offending file, no finding, same as before the fix."""
+        forge = FakeForge(
+            diff="".join(self._binary_file_diff(p) for p in self.MACHINERY_BASENAMES)
+        )
+        res = orchestrate_review(forge, REF, FakeLLM(), post=False)
+        assert res["chunk_count"] == 0
+        assert res["findings_active"] == []
+        assert res["verdict"] == "Approved"
+
+
 class TestChunkTimeoutRetry:
     """A chunk that outruns the LLM deadline gets ONE smaller-prompt retry."""
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -2425,6 +2425,32 @@ class TestSystemicSweep:
         assert len(res["findings_active"]) == 1
         assert res["findings_active"][0].confidence == 0.9
 
+    def test_byte_identical_copies_drop_the_sweep_one_not_the_chunk_one(
+        self, monkeypatch,
+    ):
+        """Two copies identical but for confidence must partition correctly.
+
+        The chunk/sweep boundary is re-derived after the quality gate from
+        ``_origin_key``. When that key ignored confidence the two copies
+        collided, ``finding_sort_key`` tied them, and the walk handed the
+        FIRST survivor to the sweep side — so the 0.95 chunk copy was dropped
+        as a "duplicate of chunk finding" and the 0.61 sweep copy survived.
+        """
+        double, _calls = _sweep_double([("findings", [dict(
+            self.SWEEP_FINDING[0], confidence=0.61,
+        )])])
+        monkeypatch.setattr(orchestrator.reviewer, "review_systemic", double)
+        res = orchestrate_review(
+            FakeForge(diff=SWEEP_SIGNAL_DIFF), REF, FakeLLM(json.dumps({
+                "findings": [dict(self.SWEEP_FINDING[0], confidence=0.95)],
+            })),
+            post=False, confidence_floor=0.6,
+        )
+        assert [f.confidence for f in res["findings_active"]] == [0.95]
+        dupes = [f for f in res["findings_dropped"]
+                 if f.drop_reason == "duplicate of chunk finding"]
+        assert [f.confidence for f in dupes] == [0.61]
+
     def test_a_sweep_failure_counts_as_one_failed_chunk(self, monkeypatch):
         double, _calls = _sweep_double([("error", "LLMError: all models failed")])
         monkeypatch.setattr(orchestrator.reviewer, "review_systemic", double)

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -34,7 +34,7 @@ SUMMARY_TEMPLATE = (
 
 def _contract_review_chunk(
     llm, files, *, pr_title="", pr_description="", repo_hint="",
-    max_tokens=None, context_lines=None,
+    max_tokens=None, context_lines=None, context_blocks="",
 ):
     result = llm.invoke(
         system="review the chunk",
@@ -407,7 +407,7 @@ class TestParallelFanOut:
 
         def barrier_review_chunk(
             llm, files, *, pr_title="", pr_description="", repo_hint="",
-            max_tokens=None, context_lines=None,
+            max_tokens=None, context_lines=None, context_blocks="",
         ):
             barrier.wait()
             return [Finding(
@@ -2475,8 +2475,12 @@ class TestChunkTimeoutRetry:
         calls: list[dict] = []
 
         def _rc(llm, files, *, pr_title="", pr_description="", repo_hint="",
-                max_tokens=None, context_lines=None):
-            calls.append({"context_lines": context_lines, "path": files[0].path})
+                max_tokens=None, context_lines=None, context_blocks=""):
+            calls.append({
+                "context_lines": context_lines,
+                "context_blocks": context_blocks,
+                "path": files[0].path,
+            })
             outcome = outcomes.pop(0)
             return [Finding(
                 file=files[0].path, line=1, severity="outofscope",
@@ -2569,3 +2573,105 @@ class TestChunkTimeoutRetry:
         assert not orchestrator._is_timeout_error("LLMError: m1: HTTP 500")
         assert not orchestrator._is_timeout_error("JSONDecodeError: bad json")
         assert not orchestrator._is_timeout_error("")
+
+
+TS_CONTEXT_DIFF_A = (
+    "diff --git a/src/a.ts b/src/a.ts\n"
+    "new file mode 100644\n"
+    "--- /dev/null\n"
+    "+++ b/src/a.ts\n"
+    "@@ -0,0 +1,2 @@\n"
+    "+import { Effect } from 'effect';\n"
+    "+export const a = Effect;\n"
+)
+
+TS_CONTEXT_DIFF_B = TS_CONTEXT_DIFF_A.replace("src/a.ts", "src/b.ts")
+
+TS_PACKAGE_JSON = '{"dependencies": {"effect": "4.0.0"}}'
+
+
+class _ReaderForge(FakeForge):
+    """FakeForge with the optional ``get_file_content``, counting every call."""
+
+    def __init__(self, *args, raises: bool = False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.raises = raises
+        self.content_calls: list[tuple[str, str]] = []
+
+    def get_file_content(self, ref, path, *, sha):
+        self.content_calls.append((path, sha))
+        if self.raises:
+            raise RuntimeError("boom get_file_content")
+        return TS_PACKAGE_JSON if path == "package.json" else None
+
+
+class TestChunkContextInjection:
+    """Issues 01/02: dependency pins and definitions reach the worker prompt,
+    and every way that read can fail degrades to no block, never to a failure."""
+
+    def _recording_llm(self, prompts):
+        class RecordingLLM:
+            def invoke(self, system, user, *, max_tokens=4096, json_mode=False,
+                       timeout_s=60.0):
+                prompts.append(f"{system}\n{user}")
+                return InvokeResult(
+                    text='{"findings": [], "escalations": []}',
+                    input_tokens=1, output_tokens=1,
+                    model="m", backend="b", elapsed_ms=1,
+                )
+        return RecordingLLM()
+
+    def _real_reviewer(self, monkeypatch):
+        monkeypatch.setattr(orchestrator.reviewer, "review_chunk", REAL_REVIEW_CHUNK)
+        monkeypatch.setattr(orchestrator.reviewer, "load_prompt", REAL_LOAD_PROMPT)
+
+    def test_the_dependency_block_reaches_the_prompt(self, monkeypatch):
+        self._real_reviewer(monkeypatch)
+        prompts: list[str] = []
+        res = orchestrate_review(
+            _ReaderForge(diff=TS_CONTEXT_DIFF_A), REF,
+            self._recording_llm(prompts), post=False,
+        )
+        assert res["chunks_failed"] == 0
+        assert any("### Dependency versions" in p for p in prompts)
+        assert any("effect@4.0.0" in p for p in prompts)
+
+    def test_a_reader_that_raises_still_reviews_and_adds_no_block(self, monkeypatch):
+        self._real_reviewer(monkeypatch)
+        prompts: list[str] = []
+        forge = _ReaderForge(diff=TS_CONTEXT_DIFF_A, raises=True)
+        res = orchestrate_review(forge, REF, self._recording_llm(prompts), post=False)
+
+        assert res["verdict"] == "Approved"
+        assert res["chunks_failed"] == 0
+        assert forge.content_calls, "the reader was never consulted"
+        assert all("### Dependency versions" not in p for p in prompts)
+        assert all("### Definitions referenced by this chunk" not in p for p in prompts)
+
+    def test_one_manifest_is_read_once_across_two_chunks(self):
+        forge = _ReaderForge(diff=TS_CONTEXT_DIFF_A + TS_CONTEXT_DIFF_B)
+        res = orchestrate_review(
+            forge, REF, FakeLLM("{}"), post=False, max_files_per_chunk=1,
+        )
+        assert res["chunk_count"] == 3  # two chunks plus the sweep
+        manifest_reads = [c for c in forge.content_calls if c[0] == "package.json"]
+        assert len(manifest_reads) == 1, forge.content_calls
+
+    def test_an_empty_head_sha_skips_the_reader_entirely(self):
+        pr = make_pr()
+        pr.source_sha = ""
+        forge = _ReaderForge(pr=pr, diff=TS_CONTEXT_DIFF_A)
+        res = orchestrate_review(forge, REF, FakeLLM("{}"), post=False)
+
+        assert res["chunks_failed"] == 0
+        assert forge.content_calls == []
+
+    def test_every_read_uses_the_pr_head_sha(self):
+        forge = _ReaderForge(diff=TS_CONTEXT_DIFF_A)
+        orchestrate_review(forge, REF, FakeLLM("{}"), post=False)
+        assert forge.content_calls
+        assert all(sha == forge.pr.source_sha for _, sha in forge.content_calls)
+
+    def test_a_forge_without_the_method_builds_no_reader(self):
+        forge = FakeForge(diff=TS_CONTEXT_DIFF_A)
+        assert orchestrator._make_file_reader(forge, REF, forge.pr) is None

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -273,6 +273,7 @@ class TestHappyPath:
             "verdict", "findings_active", "findings_dropped", "chunk_count",
             "chunks_reviewed", "chunks_failed",
             "elapsed_ms", "input_tokens", "output_tokens", "posted",
+            "sampling",
         }
         assert res["verdict"] == "Request-Changes"
         assert len(res["findings_active"]) == 2
@@ -735,6 +736,7 @@ class TestMaxTokensThreading:
             "verdict", "findings_active", "findings_dropped", "chunk_count",
             "chunks_reviewed", "chunks_failed",
             "elapsed_ms", "input_tokens", "output_tokens", "posted",
+            "sampling",
         }
 
 
@@ -1046,13 +1048,14 @@ class TestQualityGateKnobsAreThreaded:
             "verdict", "findings_active", "findings_dropped", "chunk_count",
             "chunks_reviewed", "chunks_failed",
             "elapsed_ms", "input_tokens", "output_tokens", "posted",
+            "sampling",
         }
 
 
 RESULT_KEYS = {
     "verdict", "findings_active", "findings_dropped", "chunk_count",
     "chunks_reviewed", "chunks_failed",
-    "elapsed_ms", "input_tokens", "output_tokens", "posted",
+    "elapsed_ms", "input_tokens", "output_tokens", "posted", "sampling",
 }
 
 
@@ -2569,3 +2572,42 @@ class TestChunkTimeoutRetry:
         assert not orchestrator._is_timeout_error("LLMError: m1: HTTP 500")
         assert not orchestrator._is_timeout_error("JSONDecodeError: bad json")
         assert not orchestrator._is_timeout_error("")
+
+
+class TestSamplingRecord:
+    """``sampling`` rides EVERY exit of ``orchestrate_review``.
+
+    The three exits are the normal return, ``_summary_only_run`` (empty
+    diff), and ``_error_run`` (five call sites); each is driven below.
+    """
+
+    class _Sampled(FakeLLM):
+        temperature = 0.0
+        seed = 11
+        models = ["fast", "slow"]
+
+    def test_normal_return_carries_the_client_knobs(self):
+        forge = FakeForge(diff=TWO_FILE_DIFF)
+        res = orchestrate_review(forge, REF, self._Sampled(), post=False)
+        assert res["sampling"] == {
+            "temperature": 0.0, "seed": 11, "models": ["fast", "slow"],
+        }
+
+    def test_empty_diff_exit_carries_the_client_knobs(self):
+        forge = FakeForge(diff="")
+        res = orchestrate_review(forge, REF, self._Sampled(), post=False)
+        assert res["sampling"]["seed"] == 11
+
+    def test_error_exit_carries_the_client_knobs(self):
+        forge = FakeForge(diff=TWO_FILE_DIFF)
+        forge.fail.add("get_diff")
+        res = orchestrate_review(forge, REF, self._Sampled(), post=False)
+        assert res["verdict"] == "Error"
+        assert res["sampling"]["models"] == ["fast", "slow"]
+
+    def test_a_silent_client_still_gets_all_three_keys(self):
+        forge = FakeForge(diff=TWO_FILE_DIFF)
+        res = orchestrate_review(forge, REF, FakeLLM(), post=False)
+        assert res["sampling"] == {
+            "temperature": None, "seed": None, "models": [],
+        }

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -66,6 +66,7 @@ def _contract_review_chunk(
 
 def _contract_review_systemic(
     llm, digest, *, pr_title="", pr_description="", repo_hint="", max_tokens=None,
+    threads=(),
 ):
     return [], {
         "escalations": [], "input_tokens": 0, "output_tokens": 0,
@@ -2300,9 +2301,9 @@ def _sweep_double(results: list, **meta_overrides):
 
     def _review_systemic(
         llm, digest, *, pr_title="", pr_description="", repo_hint="",
-        max_tokens=None,
+        max_tokens=None, threads=(),
     ):
-        calls.append({"digest": digest, "max_tokens": max_tokens})
+        calls.append({"digest": digest, "max_tokens": max_tokens, "threads": list(threads)})
         kind, payload = results.pop(0)
         meta = {
             "escalations": [], "input_tokens": 7, "output_tokens": 3,
@@ -2569,3 +2570,61 @@ class TestChunkTimeoutRetry:
         assert not orchestrator._is_timeout_error("LLMError: m1: HTTP 500")
         assert not orchestrator._is_timeout_error("JSONDecodeError: bad json")
         assert not orchestrator._is_timeout_error("")
+
+
+class TestSweepSeesTheDiscussion:
+    """Existing threads reach the sweep prompt, fetched once (issue 06)."""
+
+    THREAD = Thread(
+        path="src/supabase.ts", line=None, resolved=False, author="bob",
+        body_snippet="We already argued this one out on the earlier PR.",
+    )
+
+    def test_threads_for_digested_files_reach_the_sweep(self, monkeypatch):
+        double, calls = _sweep_double([("findings", [])])
+        monkeypatch.setattr(orchestrator.reviewer, "review_systemic", double)
+        forge = FakeForge(diff=SWEEP_SIGNAL_DIFF, threads=[self.THREAD])
+
+        orchestrate_review(forge, REF, FakeLLM('{"findings": []}'), post=False)
+
+        assert [t.path for t in calls[0]["threads"]] == ["src/supabase.ts"]
+
+    def test_a_thread_on_an_undigested_file_is_filtered_out(self, monkeypatch):
+        double, calls = _sweep_double([("findings", [])])
+        monkeypatch.setattr(orchestrator.reviewer, "review_systemic", double)
+        elsewhere = Thread(
+            path="docs/notes.md", line=None, resolved=False, author="carol",
+            body_snippet="Unrelated.",
+        )
+        forge = FakeForge(diff=SWEEP_SIGNAL_DIFF, threads=[elsewhere])
+
+        orchestrate_review(forge, REF, FakeLLM('{"findings": []}'), post=False)
+
+        assert calls[0]["threads"] == []
+
+    def test_a_list_threads_failure_still_runs_the_sweep(self, monkeypatch):
+        double, calls = _sweep_double([("findings", [])])
+        monkeypatch.setattr(orchestrator.reviewer, "review_systemic", double)
+        forge = FakeForge(diff=SWEEP_SIGNAL_DIFF, threads=[self.THREAD])
+        forge.fail.add("list_threads")
+
+        res = orchestrate_review(forge, REF, FakeLLM('{"findings": []}'), post=False)
+
+        assert len(calls) == 1
+        assert calls[0]["threads"] == []
+        assert res["chunks_failed"] == 0
+
+    def test_threads_are_fetched_once_for_the_sweep_and_the_dedup(self):
+        class CountingForge(FakeForge):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.thread_calls = 0
+
+            def list_threads(self, ref):
+                self.thread_calls += 1
+                return super().list_threads(ref)
+
+        forge = CountingForge(diff=SWEEP_SIGNAL_DIFF, threads=[self.THREAD])
+        orchestrate_review(forge, REF, FakeLLM('{"findings": []}'), post=False)
+
+        assert forge.thread_calls == 1

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -28,7 +28,12 @@ from prxref.quality import (
     normalize_title,
     snap_line,
 )
-from prxref.triage import Finding, added_lines_by_file, parse_unified_diff
+from prxref.triage import (
+    FileDiff,
+    Finding,
+    added_lines_by_file,
+    parse_unified_diff,
+)
 
 
 def _f(**kwargs) -> Finding:
@@ -1658,3 +1663,141 @@ class TestApplyContainmentNote:
         f = _f(body="The handler throws when the payload is malformed.")
         result = apply_containment_note([f])
         assert result[0] is not f
+
+
+# --- RC precision corpora (release 0.12.0 pipeline review, risks R2/R3) ------
+#
+# Copied verbatim from the reviewer's probe corpus. Each gate must drop every
+# case in its "must drop" list and keep every case in its "must keep" list;
+# before the fix the removal check false-dropped 4 of 5 innocent bodies and
+# the hedge gate false-dropped 2 of 5 assertive bodies.
+
+RC_FILES = [
+    FileDiff(path="src/app/auth.py", old_path=None, new_path="src/app/auth.py"),
+    FileDiff(path="src/app/db.py", old_path=None, new_path="src/app/db.py"),
+    FileDiff(
+        path="web/package.json", old_path=None, new_path="web/package.json"
+    ),
+    FileDiff(
+        path="src/app/legacy.py",
+        old_path="src/app/legacy.py",
+        new_path=None,
+        status="removed",
+    ),
+]
+
+RC_REMOVAL_CLAIMS = [
+    ("broken-import",
+     "Broken import",
+     "This PR removed src/app/db.py, but auth.py still imports it."),
+    ("dangling-ref",
+     "Dangling ref",
+     "web/package.json was removed yet the build script references it."),
+    ("deleted-module",
+     "Deleted module",
+     "The deletion of src/app/db.py leaves callers unresolved."),
+    ("gone",
+     "Gone",
+     "src/app/auth.py no longer exists after this change."),
+    ("dropped",
+     "Dropped",
+     "app/db.py has been removed; the migration will fail."),
+]
+
+RC_REMOVAL_INNOCENT = [
+    ("missing-guard",
+     "Missing guard",
+     "The removed null check in src/app/auth.py let None reach the parser."),
+    ("stale-cache",
+     "Stale cache",
+     "Deleted rows are re-fetched by src/app/db.py because the cache is not "
+     "invalidated."),
+    ("guard-removal",
+     "Guard removal",
+     "This change removes the tool metadata guard in src/app/auth.py: "
+     "MAX_TOOL_NAME_LENGTH no longer bounds names."),
+    ("dep-bump",
+     "Dep bump",
+     "The `lodash` pin was removed from web/package.json without a "
+     "replacement range."),
+    ("cleanup-regression",
+     "Cleanup regression",
+     "src/app/db.py deleted the retry wrapper, so transient failures now "
+     "surface to callers."),
+]
+
+RC_HEDGED = [
+    ("leak",
+     "If figmaProxy.prepare still leases a client, the pool is never "
+     "drained."),
+    ("dup", "If the migration already ran, this insert will conflict."),
+    ("maybe", "This may still deadlock under concurrent writes."),
+    ("assume", "Assuming the caller holds the lock, this is safe."),
+    ("unverified", "I cannot verify whether the flag is set elsewhere."),
+]
+
+RC_ASSERTIVE = [
+    ("lock-leak",
+     "If the input is empty the function returns None, but the lock remains "
+     "held."),
+    ("retry",
+     "If the request fails, retry() is called; the counter still increments "
+     "past the cap."),
+    ("off-by-one",
+     "The loop still runs when n == 0 because the guard uses <= instead "
+     "of <."),
+    ("ordering",
+     "If save() raises, the transaction remains open and the connection is "
+     "leaked."),
+    ("dead-code",
+     "The legacy branch is already unreachable; if it were reached it would "
+     "divide by zero."),
+]
+
+
+class TestRemovalClaimCorpus:
+    """The verb must GOVERN the path before a removal claim is judged."""
+
+    @pytest.mark.parametrize(
+        "label,title,body",
+        RC_REMOVAL_CLAIMS,
+        ids=[c[0] for c in RC_REMOVAL_CLAIMS],
+    )
+    def test_genuine_removal_claim_is_dropped(self, label, title, body):
+        out = apply_removal_claim_check(
+            [_f(file="src/app/auth.py", title=title, body=body)], RC_FILES
+        )
+        assert (out[0].drop_reason or "").startswith(
+            "claims removal of a path present in the post-image"
+        ), f"{label}: {out[0].drop_reason!r}"
+
+    @pytest.mark.parametrize(
+        "label,title,body",
+        RC_REMOVAL_INNOCENT,
+        ids=[c[0] for c in RC_REMOVAL_INNOCENT],
+    )
+    def test_innocent_removal_prose_survives(self, label, title, body):
+        out = apply_removal_claim_check(
+            [_f(file="src/app/auth.py", title=title, body=body)], RC_FILES
+        )
+        assert out[0].drop_reason is None, f"{label}: {out[0].drop_reason!r}"
+
+
+class TestHedgeGateCorpus:
+    """The hedge word must sit inside the ``if`` clause it qualifies."""
+
+    @pytest.mark.parametrize(
+        "label,body", RC_HEDGED, ids=[c[0] for c in RC_HEDGED]
+    )
+    def test_hedged_body_is_dropped(self, label, body):
+        out = apply_hedge_gate([_f(title="Finding", body=body)])
+        assert (out[0].drop_reason or "").startswith(
+            'hedged: "'
+        ), f"{label}: {out[0].drop_reason!r}"
+
+    @pytest.mark.parametrize(
+        "label,body", RC_ASSERTIVE, ids=[c[0] for c in RC_ASSERTIVE]
+    )
+    def test_assertive_body_survives(self, label, body):
+        out = apply_hedge_gate([_f(title="Finding", body=body)])
+        assert out[0].drop_reason is None, f"{label}: {out[0].drop_reason!r}"

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -11,6 +11,7 @@ from prxref.quality import (
     apply_line_align,
     apply_location_validation,
     apply_quality_gate,
+    apply_settled_thread_suppression,
     apply_severity_consistency,
     apply_thread_dedup,
     is_duplicate_of_existing,
@@ -1075,3 +1076,83 @@ class TestBodyCitationGrammar:
             body="Also line 55 matters.",
         )
         assert _body_cited_lines(f) == [40, 55]
+
+
+class TestSettledThreadSuppression:
+    """Line-independent suppression of re-litigated subjects (issue 06)."""
+
+    SETTLED = Thread(
+        path="src/tools/registry.ts",
+        line=None,
+        resolved=False,
+        author="bob",
+        body_snippet=(
+            "This still feels too defensive, I don't think we need it imo — "
+            "Removed the defensive tool metadata guard in commit 917d1f4"
+        ),
+    )
+
+    def _finding(self, **kwargs):
+        fields = {
+            "file": "src/tools/registry.ts",
+            "line": 0,
+            "title": (
+                "Tool metadata guard removed: unbounded tool names from remote servers"
+            ),
+            "body": (
+                "This change removes the tool metadata guard: MAX_TOOL_NAME_LENGTH "
+                "and isSupported no longer bound names or schemas supplied by a "
+                "remote MCP server."
+            ),
+        }
+        fields.update(kwargs)
+        return _f(**fields)
+
+    def test_a_file_level_finding_is_dropped_against_a_file_level_thread(self):
+        out = apply_settled_thread_suppression([self._finding()], [self.SETTLED])
+        assert out[0].drop_reason == "settled in thread: bob"
+
+    def test_the_reason_names_the_author(self):
+        thread = Thread(**{**self.SETTLED.__dict__, "author": "carol"})
+        out = apply_settled_thread_suppression([self._finding()], [thread])
+        assert out[0].drop_reason.endswith("carol")
+
+    def test_a_leading_dot_slash_path_still_matches(self):
+        thread = Thread(**{**self.SETTLED.__dict__, "path": "./src/tools/registry.ts"})
+        out = apply_settled_thread_suppression([self._finding()], [thread])
+        assert out[0].drop_reason is not None
+
+    def test_a_thread_on_another_file_never_suppresses(self):
+        thread = Thread(**{**self.SETTLED.__dict__, "path": "src/other/cache.ts"})
+        out = apply_settled_thread_suppression([self._finding()], [thread])
+        assert out[0].drop_reason is None
+
+    def test_a_same_file_thread_on_another_subject_never_suppresses(self):
+        thread = Thread(
+            path="src/tools/registry.ts", line=None, resolved=True, author="dave",
+            body_snippet="Please rename listTools to enumerateTools for consistency.",
+        )
+        out = apply_settled_thread_suppression([self._finding()], [thread])
+        assert out[0].drop_reason is None
+
+    def test_a_resolved_thread_still_settles_its_own_subject(self):
+        thread = Thread(**{**self.SETTLED.__dict__, "resolved": True})
+        out = apply_settled_thread_suppression([self._finding()], [thread])
+        assert out[0].drop_reason == "settled in thread: bob"
+
+    def test_an_already_dropped_finding_keeps_its_first_reason(self):
+        dropped = self._finding(drop_reason="duplicate of existing thread")
+        out = apply_settled_thread_suppression([dropped], [self.SETTLED])
+        assert out[0].drop_reason == "duplicate of existing thread"
+
+    def test_no_threads_is_a_passthrough_preserving_order(self):
+        findings = [self._finding(), self._finding(line=7)]
+        out = apply_settled_thread_suppression(findings, [])
+        assert [f.line for f in out] == [0, 7]
+        assert all(f.drop_reason is None for f in out)
+
+    def test_an_empty_finding_body_cannot_match_anything(self):
+        out = apply_settled_thread_suppression(
+            [_f(file="src/tools/registry.ts", title="", body="")], [self.SETTLED],
+        )
+        assert out[0].drop_reason is None

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -10,6 +10,7 @@ from prxref.quality import (
     active,
     apply_line_align,
     apply_location_validation,
+    apply_manifest_claim_check,
     apply_quality_gate,
     apply_severity_consistency,
     apply_thread_dedup,
@@ -1075,3 +1076,168 @@ class TestBodyCitationGrammar:
             body="Also line 55 matters.",
         )
         assert _body_cited_lines(f) == [40, 55]
+
+
+_MANIFEST_PATH = "web/package.json"
+
+# Post-image lines: 1 "{", 2 dependencies header, 3 express,
+# 4 +@acme/jenkins, 5 lodash, 6 "},", 7 devDependencies header,
+# 8-14 seven dev deps, 15 +vitest, 16 typescript, 17 "}", 18 "}".
+# vitest deliberately sits FARTHER from its own section header (8 lines)
+# than the jenkins entry does (3), which is what lets a header-ranked
+# realign pull a correct vitest anchor onto the jenkins line.
+_MANIFEST_DIFF = (
+    f"diff --git a/{_MANIFEST_PATH} b/{_MANIFEST_PATH}\n"
+    f"--- a/{_MANIFEST_PATH}\n"
+    f"+++ b/{_MANIFEST_PATH}\n"
+    "@@ -1,16 +1,18 @@\n"
+    "{\n"
+    '  "dependencies": {\n'
+    '    "express": "^4.18.0",\n'
+    '+    "@acme/jenkins": "*",\n'
+    '    "lodash": "^4.17.21"\n'
+    "  },\n"
+    '  "devDependencies": {\n'
+    '    "eslint": "^8.50.0",\n'
+    '    "prettier": "^3.0.0",\n'
+    '    "nodemon": "^3.0.0",\n'
+    '    "esbuild": "^0.19.0",\n'
+    '    "ts-node": "^10.9.0",\n'
+    '    "@types/node": "^20.0.0",\n'
+    '    "@types/jest": "^29.5.0",\n'
+    '+    "vitest": "^4.0.18",\n'
+    '    "typescript": "^5.2.0"\n'
+    "  }\n"
+    "}\n"
+)
+
+_MANIFEST_FILES = parse_unified_diff(_MANIFEST_DIFF)
+
+
+class TestManifestClaimCheck:
+    """apply_manifest_claim_check: a package.json claim must anchor on the
+    key and the dependency section it actually names."""
+
+    def test_anchor_mismatch_is_dropped(self):
+        f = _f(
+            file=_MANIFEST_PATH, line=4,
+            title="vitest added to runtime dependencies",
+            body="`vitest` is test-only but appears under `dependencies`.",
+        )
+        out = apply_manifest_claim_check([f], _MANIFEST_FILES)
+        assert len(out) == 1
+        assert out[0].drop_reason is not None
+        assert out[0].drop_reason.startswith("anchor mismatch:")
+        assert "vitest" in out[0].drop_reason
+        assert "@acme/jenkins" in out[0].drop_reason
+
+    def test_section_mismatch_is_dropped(self):
+        f = _f(
+            file=_MANIFEST_PATH, line=15,
+            title="vitest added to runtime dependencies",
+            body="This bloats production installs.",
+        )
+        out = apply_manifest_claim_check([f], _MANIFEST_FILES)
+        assert out[0].drop_reason is not None
+        assert out[0].drop_reason.startswith("section mismatch:")
+        assert "devDependencies" in out[0].drop_reason
+
+    def test_correct_claim_untouched(self):
+        f = _f(
+            file=_MANIFEST_PATH, line=15,
+            title="vitest added to devDependencies",
+            body="A new test runner is pulled in.",
+        )
+        out = apply_manifest_claim_check([f], _MANIFEST_FILES)
+        assert out[0].drop_reason is None
+
+    def test_scoped_package_name_resolves(self):
+        f = _f(
+            file=_MANIFEST_PATH, line=4,
+            title="@acme/jenkins pinned to * in dependencies",
+            body="A wildcard version makes installs unreproducible.",
+        )
+        out = apply_manifest_claim_check([f], _MANIFEST_FILES)
+        assert out[0].drop_reason is None
+
+    def test_no_claimed_key_untouched(self):
+        f = _f(
+            file=_MANIFEST_PATH, line=4,
+            title="Manifest formatting is inconsistent",
+            body="Indentation mixes two and four spaces.",
+        )
+        out = apply_manifest_claim_check([f], _MANIFEST_FILES)
+        assert out[0].drop_reason is None
+
+    def test_claimed_key_absent_from_hunks_untouched(self):
+        f = _f(
+            file=_MANIFEST_PATH, line=4,
+            title="webpack should not be a runtime dependency",
+            body="`webpack` belongs in devDependencies.",
+        )
+        out = apply_manifest_claim_check([f], _MANIFEST_FILES)
+        assert out[0].drop_reason is None
+
+    def test_non_manifest_file_untouched(self):
+        f = _f(
+            file="src/index.ts", line=4,
+            title="vitest added to runtime dependencies",
+            body="`vitest` is test-only but appears under `dependencies`.",
+        )
+        out = apply_manifest_claim_check([f], _MANIFEST_FILES)
+        assert out[0].drop_reason is None
+
+    def test_anchor_on_brace_line_has_no_key_and_no_section(self):
+        f = _f(
+            file=_MANIFEST_PATH, line=1,
+            title="vitest added to runtime dependencies",
+            body="This bloats production installs.",
+        )
+        out = apply_manifest_claim_check([f], _MANIFEST_FILES)
+        assert out[0].drop_reason is None, out[0].drop_reason
+
+    def test_anchor_on_section_header_falls_through_to_section_check(self):
+        f = _f(
+            file=_MANIFEST_PATH, line=7,
+            title="vitest added to runtime dependencies",
+            body="This bloats production installs.",
+        )
+        out = apply_manifest_claim_check([f], _MANIFEST_FILES)
+        assert out[0].drop_reason is not None
+        assert out[0].drop_reason.startswith("section mismatch:")
+
+    def test_already_dropped_finding_passes_through(self):
+        f = _f(
+            file=_MANIFEST_PATH, line=4,
+            title="vitest added to runtime dependencies",
+            body="`vitest` is test-only but appears under `dependencies`.",
+            drop_reason="confidence 0.10 below floor 0.60",
+        )
+        out = apply_manifest_claim_check([f], _MANIFEST_FILES)
+        assert out[0].drop_reason == "confidence 0.10 below floor 0.60"
+
+    def test_order_preserved(self):
+        a = _f(file=_MANIFEST_PATH, line=4, title="a", body="b")
+        b = _f(file="src/index.ts", line=1, title="c", body="d")
+        out = apply_manifest_claim_check([a, b], _MANIFEST_FILES)
+        assert [x.title for x in out] == ["a", "c"]
+
+
+class TestManifestRealignRegression:
+    """The section words must not decide a package.json realign: a claim
+    correctly anchored on the vitest entry stays there instead of being
+    pulled onto the nearest added line below the dependencies header."""
+
+    def test_correct_vitest_anchor_survives_line_align(self):
+        f = _f(
+            file=_MANIFEST_PATH, line=15,
+            title="vitest added to runtime dependencies",
+            body=(
+                "vitest is a test-only tool but is added under `dependencies` "
+                "in web/package.json. This bloats production installs."
+            ),
+        )
+        out = apply_line_align(
+            [f], added_lines_by_file(_MANIFEST_FILES), files=_MANIFEST_FILES
+        )
+        assert out[0].line == 15

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -3,11 +3,15 @@ from __future__ import annotations
 
 import logging
 
+import pytest
+
 from prxref.forges.base import Thread
 from prxref.quality import (
+    CONTAINMENT_NOTE_SUFFIX,
     _body_cited_lines,
     _resolve_max_errors,
     active,
+    apply_containment_note,
     apply_line_align,
     apply_location_validation,
     apply_quality_gate,
@@ -1075,3 +1079,92 @@ class TestBodyCitationGrammar:
             body="Also line 55 matters.",
         )
         assert _body_cited_lines(f) == [40, 55]
+
+
+class TestApplyContainmentNote:
+    """Issue #07: a throw-class finding with no named boundary gets flagged."""
+
+    def test_throws_with_no_boundary_gets_suffixed(self):
+        f = _f(
+            title="Handler aborts on bad input",
+            body="The handler throws when the payload is malformed.",
+        )
+        result = apply_containment_note([f])
+        assert result[0].body == f.body + CONTAINMENT_NOTE_SUFFIX
+
+    def test_panics_with_no_boundary_gets_suffixed(self):
+        f = _f(body="Parser panics on empty input, killing the pipeline.")
+        result = apply_containment_note([f])
+        assert result[0].body.endswith(CONTAINMENT_NOTE_SUFFIX)
+
+    def test_crashes_with_no_boundary_gets_suffixed(self):
+        f = _f(body="The scheduler crashes when two jobs collide.")
+        result = apply_containment_note([f])
+        assert result[0].body.endswith(CONTAINMENT_NOTE_SUFFIX)
+
+    def test_unhandled_rejection_with_no_boundary_gets_suffixed(self):
+        f = _f(body="An unhandled rejection escapes the async handler.")
+        result = apply_containment_note([f])
+        assert result[0].body.endswith(CONTAINMENT_NOTE_SUFFIX)
+
+    @pytest.mark.parametrize(
+        "boundary_phrase",
+        [
+            "but the exception is caught by the outer handler.",
+            "it is uncaught and propagates to serverFactory.",
+            "the catch block above swallows it silently.",
+            "wrapped in a try/catch at the call site.",
+            "wrapped in a try-catch at the call site.",
+            "the error is handled by the retry wrapper.",
+            "the rejection bubbles up to the caller.",
+            "it rejects the promise returned to the caller.",
+        ],
+    )
+    def test_throw_with_boundary_named_is_not_suffixed(self, boundary_phrase):
+        f = _f(body=f"The handler throws when malformed, {boundary_phrase}")
+        result = apply_containment_note([f])
+        assert result[0].body == f.body
+
+    def test_non_throw_finding_is_untouched(self):
+        f = _f(
+            title="computeTotal returns the wrong total",
+            body="The accumulator starts at undefined instead of 0.",
+        )
+        result = apply_containment_note([f])
+        assert result[0].body == f.body
+
+    def test_order_preserving(self):
+        findings = [
+            _f(title="a", body="throws on bad input, no boundary named."),
+            _f(title="b", body="totally unrelated body text."),
+            _f(title="c", body="panics under load, no boundary named."),
+        ]
+        result = apply_containment_note(findings)
+        assert [r.title for r in result] == ["a", "b", "c"]
+
+    def test_idempotent_does_not_double_suffix(self):
+        f = _f(body="The handler throws when the payload is malformed.")
+        once = apply_containment_note([f])
+        twice = apply_containment_note(once)
+        assert twice[0].body == once[0].body
+        assert twice[0].body.count(CONTAINMENT_NOTE_SUFFIX) == 1
+
+    def test_dropped_finding_is_also_decorated(self):
+        f = _f(
+            body="The handler throws when the payload is malformed.",
+            drop_reason="confidence 0.10 below floor 0.60",
+        )
+        result = apply_containment_note([f])
+        assert result[0].body.endswith(CONTAINMENT_NOTE_SUFFIX)
+        assert result[0].drop_reason == "confidence 0.10 below floor 0.60"
+
+    def test_original_finding_instance_is_not_mutated(self):
+        f = _f(body="The handler throws when the payload is malformed.")
+        original_body = f.body
+        apply_containment_note([f])
+        assert f.body == original_body
+
+    def test_returns_new_instance_when_suffixed(self):
+        f = _f(body="The handler throws when the payload is malformed.")
+        result = apply_containment_note([f])
+        assert result[0] is not f

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1,6 +1,7 @@
 """Tests for prxref.quality: line alignment, thread dedup, and quality gate."""
 from __future__ import annotations
 
+import itertools
 import logging
 
 from prxref.forges.base import Thread
@@ -13,6 +14,8 @@ from prxref.quality import (
     apply_quality_gate,
     apply_severity_consistency,
     apply_thread_dedup,
+    finding_rank_key,
+    finding_sort_key,
     is_duplicate_of_existing,
     normalize_title,
     snap_line,
@@ -1075,3 +1078,34 @@ class TestBodyCitationGrammar:
             body="Also line 55 matters.",
         )
         assert _body_cited_lines(f) == [40, 55]
+
+
+class TestDeterministicCaps:
+    """The error cap and the gate's output order are content-derived."""
+
+    TIED = [
+        _f(file="src/a.py", line=1, severity="error", confidence=0.9, title="alpha"),
+        _f(file="src/a.py", line=2, severity="error", confidence=0.9, title="bravo"),
+        _f(file="src/a.py", line=3, severity="error", confidence=0.9, title="charlie"),
+    ]
+
+    def test_error_cap_survivors_do_not_depend_on_arrival_order(self):
+        seen = set()
+        for perm in itertools.permutations(self.TIED):
+            staged = apply_quality_gate(list(perm), confidence_floor=0.6, max_errors=2)
+            seen.add(frozenset(f.title for f in staged if f.drop_reason is None))
+        assert seen == {frozenset({"alpha", "bravo"})}
+
+    def test_gate_output_is_sorted_by_file_line_title(self):
+        staged = apply_quality_gate(
+            list(reversed(self.TIED)), confidence_floor=0.6, max_errors=3
+        )
+        assert [f.title for f in staged] == ["alpha", "bravo", "charlie"]
+
+    def test_confidence_outranks_content_in_the_rank_key(self):
+        low = _f(file="src/a.py", line=1, severity="error", confidence=0.7, title="aaa")
+        high = _f(file="src/z.py", line=9, severity="error", confidence=0.95, title="zzz")
+        assert finding_rank_key(high) < finding_rank_key(low)
+
+    def test_sort_key_tolerates_a_missing_line(self):
+        assert finding_sort_key(_f(line=None, title="t")) == ("src/app.py", -1, "t")

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 
 import logging
 
+import pytest
+
 from prxref.forges.base import Thread
 from prxref.quality import (
     _body_cited_lines,
     _resolve_max_errors,
     active,
+    apply_hedge_gate,
     apply_line_align,
     apply_location_validation,
     apply_quality_gate,
@@ -1075,3 +1078,123 @@ class TestBodyCitationGrammar:
             body="Also line 55 matters.",
         )
         assert _body_cited_lines(f) == [40, 55]
+
+
+HEDGED_CASES = [
+    ("if-still", "If figmaProxy.prepare still leases a client, the lease "
+                 "outlives the request."),
+    ("if-already", "If the migration already applied the default, this write "
+                   "is a no-op."),
+    ("modal-still", "The socket may still be held open by the outer pool."),
+    ("assuming", "Assuming the cache is keyed by tenant, this write clobbers "
+                 "another entry."),
+    ("unless-already", "Unless the backfill job already ran, this deploy "
+                       "fails."),
+    ("not-verified", "I cannot confirm whether the caller retries, so the "
+                     "request may fail permanently."),
+    ("not-in-diff", "The token refresh is not visible in the diff, so the "
+                    "credential goes stale."),
+    ("only-caller", "If this is the only call site the change is safe; "
+                    "otherwise every other caller breaks."),
+    ("membership", "If they are members of the root workspaces globs, "
+                   "`npm ci` will fail."),
+]
+
+LEGITIMATE_CASES = [
+    ("divisor", "size defaults to None and is used as a divisor on line 42."),
+    ("early-return", "Returns early if the list is empty, so the counter is "
+                     "never incremented."),
+    ("retry-spin", "The retry loop may spin forever because the deadline is "
+                   "never decremented."),
+    ("typeerror", "Throws TypeError if `opts` is undefined: line 12 "
+                  "dereferences opts.start."),
+    ("lodash-unless", "unless() from lodash is called with a string, which it "
+                      "does not accept."),
+    ("jwterror", "decode(token) can raise JWTError if malformed."),
+    ("null-deref", "x may be None when config is missing; data loss follows."),
+    ("concurrency", "Concurrent calls may corrupt state."),
+    ("assuming-noun", "The parser is assuming-safe only for ASCII; line 20 "
+                      "indexes bytes directly."),
+    ("may-return", "readFile may return a Buffer here and the caller "
+                   "concatenates it with a string."),
+    ("if-branch", "If retries is 0 the loop body never runs, so the initial "
+                  "request is skipped."),
+    ("unless-flag", "The endpoint is registered unless DEBUG is set, so "
+                    "production serves the unauthenticated route."),
+    ("already-plain", "The lock is already held here, so the second acquire "
+                      "deadlocks."),
+    ("may-plain", "The callback may be invoked twice, double-charging the "
+                  "customer."),
+    ("still-plain", "The temp file is still on disk after the handler "
+                    "returns."),
+    ("if-null", "If cfg is None line 30 raises AttributeError."),
+]
+
+
+class TestHedgeGate:
+    @pytest.mark.parametrize(
+        "label,body", HEDGED_CASES, ids=[c[0] for c in HEDGED_CASES]
+    )
+    def test_hedged_body_is_dropped(self, label, body):
+        out = apply_hedge_gate([_f(title="Finding", body=body)])
+        assert len(out) == 1
+        assert out[0].drop_reason is not None, label
+        assert out[0].drop_reason.startswith('hedged: "'), out[0].drop_reason
+        assert out[0].drop_reason.endswith('"')
+
+    @pytest.mark.parametrize(
+        "label,body", LEGITIMATE_CASES, ids=[c[0] for c in LEGITIMATE_CASES]
+    )
+    def test_legitimate_body_survives(self, label, body):
+        out = apply_hedge_gate([_f(title="Finding", body=body)])
+        assert out[0].drop_reason is None, f"{label}: {out[0].drop_reason}"
+
+    def test_hedge_in_title_is_dropped(self):
+        out = apply_hedge_gate(
+            [_f(title="Lease may still be held", body="Plain body.")]
+        )
+        assert out[0].drop_reason.startswith("hedged:")
+
+    def test_drop_reason_quotes_the_matched_span(self):
+        out = apply_hedge_gate(
+            [_f(body="The socket may still be held open by the pool.")]
+        )
+        assert out[0].drop_reason == 'hedged: "may still"'
+
+    def test_drop_reason_span_is_bounded(self):
+        body = "If " + "x" * 75 + " still leaks."
+        out = apply_hedge_gate([_f(body=body)])
+        assert out[0].drop_reason is not None
+        assert len(out[0].drop_reason) == len('hedged: ""') + 80
+
+    def test_span_beyond_the_window_is_not_a_hedge(self):
+        body = "If " + "x" * 200 + " still leaks."
+        assert apply_hedge_gate([_f(body=body)])[0].drop_reason is None
+
+    def test_already_dropped_passes_through(self):
+        pre = _f(body="If the router is still mounted, both fire.",
+                 drop_reason="invalid severity: 'nit'")
+        out = apply_hedge_gate([pre])
+        assert out[0].drop_reason == "invalid severity: 'nit'"
+
+    def test_order_preserved_and_input_not_mutated(self):
+        findings = [
+            _f(title="a", body="Plain bug."),
+            _f(title="b", body="If the flag is still set, the loop spins."),
+            _f(title="c", body="Another plain bug."),
+        ]
+        out = apply_hedge_gate(findings)
+        assert [f.title for f in out] == ["a", "b", "c"]
+        assert [f.drop_reason is None for f in out] == [True, False, True]
+        assert all(f.drop_reason is None for f in findings)
+
+    def test_empty_input(self):
+        assert apply_hedge_gate([]) == []
+
+    def test_hedged_finding_does_not_consume_error_cap(self):
+        hedged = apply_hedge_gate(
+            [_f(severity="error", confidence=0.9,
+                body="If the cache is still warm, this errors.")]
+        )
+        out = apply_quality_gate(hedged, max_errors=1)
+        assert out[0].drop_reason.startswith("hedged:")

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -11,6 +11,7 @@ from prxref.quality import (
     apply_line_align,
     apply_location_validation,
     apply_quality_gate,
+    apply_removal_claim_check,
     apply_severity_consistency,
     apply_thread_dedup,
     is_duplicate_of_existing,
@@ -1075,3 +1076,95 @@ class TestBodyCitationGrammar:
             body="Also line 55 matters.",
         )
         assert _body_cited_lines(f) == [40, 55]
+
+
+COPY_DIFF = (
+    "diff --git src://pkg/servicenow/package.json dst://pkg/splunk/package.json\n"
+    "similarity index 53%\n"
+    "copy from pkg/servicenow/package.json\n"
+    "copy to pkg/splunk/package.json\n"
+    "@@ -1,1 +1,1 @@\n"
+    "-old\n"
+    "+new\n"
+)
+
+DELETE_DIFF = (
+    "diff --git a/src/old.ts b/src/old.ts\n"
+    "deleted file mode 100644\n"
+    "--- a/src/old.ts\n"
+    "+++ /dev/null\n"
+    "@@ -1,1 +0,0 @@\n"
+    "-gone\n"
+)
+
+
+class TestRemovalClaimCheck:
+    """``apply_removal_claim_check`` drops removal claims the diff contradicts."""
+
+    def test_drops_claim_when_the_copy_source_is_still_present(self):
+        files = parse_unified_diff(COPY_DIFF)
+        f = _f(
+            file="pkg/splunk/package.json",
+            title="ServiceNow package.json removed by rename to splunk",
+            body="pkg/servicenow/package.json no longer exists after this PR.",
+        )
+        out = apply_removal_claim_check([f], files)
+        assert len(out) == 1
+        assert (out[0].drop_reason or "").startswith(
+            "claims removal of a path present in the post-image"
+        )
+        assert "pkg/servicenow/package.json" in out[0].drop_reason
+
+    def test_claim_named_only_in_prose_against_the_new_file_is_dropped(self):
+        files = parse_unified_diff(COPY_DIFF)
+        f = _f(
+            file="pkg/splunk/package.json",
+            title="Package moved",
+            body="The servicenow/package.json was removed in this change.",
+        )
+        out = apply_removal_claim_check([f], files)
+        assert (out[0].drop_reason or "").startswith(
+            "claims removal of a path present in the post-image"
+        )
+
+    def test_keeps_claim_about_a_genuinely_removed_path(self):
+        files = parse_unified_diff(DELETE_DIFF)
+        f = _f(
+            file="src/old.ts",
+            title="File removed",
+            body="src/old.ts was removed by this PR.",
+        )
+        out = apply_removal_claim_check([f], files)
+        assert out[0].drop_reason is None
+
+    def test_keeps_a_non_removal_finding(self):
+        files = parse_unified_diff(COPY_DIFF)
+        f = _f(
+            file="pkg/splunk/package.json",
+            title="Missing version field",
+            body="pkg/servicenow/package.json defines a version; the copy does not.",
+        )
+        out = apply_removal_claim_check([f], files)
+        assert out[0].drop_reason is None
+
+    def test_passes_through_already_dropped_findings(self):
+        files = parse_unified_diff(COPY_DIFF)
+        f = _f(
+            file="pkg/splunk/package.json",
+            title="ServiceNow package.json removed",
+            body="pkg/servicenow/package.json no longer exists.",
+            drop_reason="invalid severity: 'nope'",
+        )
+        out = apply_removal_claim_check([f], files)
+        assert out[0].drop_reason == "invalid severity: 'nope'"
+
+    def test_preserves_input_order(self):
+        files = parse_unified_diff(COPY_DIFF)
+        findings = [
+            _f(title="First", body="nothing to see"),
+            _f(title="Second", body="pkg/servicenow/package.json was removed."),
+            _f(title="Third", body="still nothing"),
+        ]
+        out = apply_removal_claim_check(findings, files)
+        assert [x.title for x in out] == ["First", "Second", "Third"]
+        assert [x.drop_reason is None for x in out] == [True, False, True]

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -6,9 +6,14 @@ import logging
 
 import pytest
 
+from prxref.forges.base import Thread
 from prxref.llm import InvokeResult
 from prxref.reviewer import (
+    DISCUSSION_MAX_CHARS,
+    DISCUSSION_MAX_SNIPPET_CHARS,
+    DISCUSSION_MAX_THREADS,
     MAX_TOKENS,
+    _render_systemic_prompt,
     load_prompt,
     render_chunk,
     review_chunk,
@@ -659,3 +664,67 @@ class _RaisingLLM:
     def invoke(self, system, user, *, max_tokens=4096, json_mode=False,
                timeout_s=60.0):
         raise RuntimeError("provider down")
+
+
+class TestSystemicDiscussionBlock:
+    """The sweep prompt carries the PR's existing discussion (issue 06)."""
+
+    @staticmethod
+    def _thread(snippet: str, path: str = "src/a.ts", author: str = "bob") -> Thread:
+        return Thread(path=path, line=None, resolved=False, author=author,
+                      body_snippet=snippet)
+
+    def test_absent_threads_print_no_header(self):
+        _, user = _render_systemic_prompt("## src/a.ts", "t", "d", "r")
+        assert "### Existing discussion" not in user
+
+    def test_each_thread_renders_path_author_and_snippet(self):
+        _, user = _render_systemic_prompt(
+            "## src/a.ts", "t", "d", "r",
+            [self._thread("we decided the guard was unnecessary")],
+        )
+        assert "### Existing discussion" in user
+        assert "- src/a.ts: bob: we decided the guard was unnecessary" in user
+
+    def test_a_thread_without_an_author_is_named_unknown(self):
+        _, user = _render_systemic_prompt(
+            "## src/a.ts", "t", "d", "r", [self._thread("settled", author="")],
+        )
+        assert "- src/a.ts: unknown: settled" in user
+
+    def test_an_empty_snippet_contributes_no_line(self):
+        _, user = _render_systemic_prompt(
+            "## src/a.ts", "t", "d", "r", [self._thread("   ")],
+        )
+        assert "### Existing discussion" not in user
+
+    def test_a_long_snippet_is_truncated(self):
+        long = "x" * (DISCUSSION_MAX_SNIPPET_CHARS + 200)
+        _, user = _render_systemic_prompt(
+            "## src/a.ts", "t", "d", "r", [self._thread(long)],
+        )
+        assert "x" * DISCUSSION_MAX_SNIPPET_CHARS in user
+        assert "x" * (DISCUSSION_MAX_SNIPPET_CHARS + 1) not in user
+        assert "…" in user
+
+    def test_the_thread_count_is_capped_and_the_omission_stated(self):
+        threads = [
+            self._thread(f"decision number {i}")
+            for i in range(DISCUSSION_MAX_THREADS + 4)
+        ]
+        _, user = _render_systemic_prompt("## src/a.ts", "t", "d", "r", threads)
+        assert "decision number 0" in user
+        assert f"decision number {DISCUSSION_MAX_THREADS}" not in user
+        assert "… 4 more threads omitted" in user
+
+    def test_the_block_is_capped_in_characters(self):
+        threads = [self._thread("y" * 190) for _ in range(DISCUSSION_MAX_THREADS)]
+        _, user = _render_systemic_prompt("## src/a.ts", "t", "d", "r", threads)
+        block = user.split("### Existing discussion", 1)[1]
+        assert len(block) < DISCUSSION_MAX_CHARS + 200
+        assert "more threads omitted" in block
+
+    def test_review_systemic_passes_threads_through_to_the_prompt(self):
+        llm = FakeLLM(CLEAN_RESPONSE)
+        review_systemic(llm, "## src/a.ts", threads=[self._thread("already settled")])
+        assert "already settled" in llm.calls[0]["user"]

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -659,3 +659,42 @@ class _RaisingLLM:
     def invoke(self, system, user, *, max_tokens=4096, json_mode=False,
                timeout_s=60.0):
         raise RuntimeError("provider down")
+
+
+class TestContextBlocks:
+    """Supplementary context lands in the ``user`` half or nowhere at all."""
+
+    def _chunk(self):
+        return parse_unified_diff(MINI_DIFF)
+
+    BLOCKS = "### Dependency versions\n\neffect@4.0.0"
+
+    def test_blocks_land_after_the_review_context_marker(self):
+        llm = FakeLLM(CLEAN_RESPONSE)
+        review_chunk(llm, self._chunk(), context_blocks=self.BLOCKS)
+        call = llm.calls[0]
+        assert self.BLOCKS in call["user"]
+        assert "effect@4.0.0" not in call["system"]
+
+    def test_blocks_follow_the_diff_fence(self):
+        llm = FakeLLM(CLEAN_RESPONSE)
+        review_chunk(llm, self._chunk(), context_blocks=self.BLOCKS)
+        user = llm.calls[0]["user"]
+        assert user.index("import sys") < user.index("### Dependency versions")
+        assert user.index("### Dependency versions") < user.index("## Output Format")
+
+    def test_the_empty_default_renders_no_placeholder_and_no_header(self):
+        llm = FakeLLM(CLEAN_RESPONSE)
+        review_chunk(llm, self._chunk())
+        user = llm.calls[0]["user"]
+        assert "{context_blocks}" not in user
+        assert "### Dependency versions" not in user
+        assert "### Definitions referenced by this chunk" not in user
+
+    def test_no_template_placeholder_is_left_unsubstituted(self):
+        llm = FakeLLM(CLEAN_RESPONSE)
+        review_chunk(llm, self._chunk(), context_blocks=self.BLOCKS)
+        rendered = llm.calls[0]["system"] + llm.calls[0]["user"]
+        for slot in ("{pr_title}", "{pr_description}", "{repo_hint}",
+                     "{diff}", "{context_blocks}"):
+            assert slot not in rendered

--- a/tests/test_systemic.py
+++ b/tests/test_systemic.py
@@ -423,3 +423,6 @@ class TestSweepPromptContract:
         from prxref.reviewer import _CONTEXT_MARKER
 
         assert _CONTEXT_MARKER in load_prompt("systemic.md")
+
+    def test_the_prompt_states_the_containment_boundary_rule(self):
+        assert "containment boundary" in load_prompt("systemic.md")

--- a/tests/test_systemic.py
+++ b/tests/test_systemic.py
@@ -423,3 +423,68 @@ class TestSweepPromptContract:
         from prxref.reviewer import _CONTEXT_MARKER
 
         assert _CONTEXT_MARKER in load_prompt("systemic.md")
+
+
+class TestGuardRemoval:
+    """A deleted limit constant or validator is a class of its own (issue 06).
+
+    Removal-only by construction: the same text ADDED is a guard being put in
+    place, which is not a finding.
+    """
+
+    @pytest.mark.parametrize("line", [
+        "const MAX_TOOL_NAME_LENGTH = 128;",
+        "const MAX_TOOL_SCHEMA_BYTES = 100_000;",
+        "static final int REQUEST_TIMEOUT = 30;",
+        "MAX_UPLOAD_BYTES: int = 5_000",
+        "MAX_RETRIES_CAP = 3",
+    ])
+    def test_removed_limit_constants(self, line):
+        assert match_class(line, kind="-") == "guard-removal"
+
+    @pytest.mark.parametrize("line", [
+        "function isSupported(tool) {",
+        "function validateSchema(s) {",
+        "def sanitize_name(name):",
+        "def check_bounds(n):",
+        "fn escape_html(s: &str) {",
+        "func assertOwner(u User) {",
+        "const guardInput = (x) => {",
+        "public boolean isValidName(String n) {",
+    ])
+    def test_removed_validator_definitions(self, line):
+        assert match_class(line, kind="-") == "guard-removal"
+
+    @pytest.mark.parametrize("line", [
+        "const MAX_TOOL_NAME_LENGTH = 128;",
+        "function isSupported(tool) {",
+    ])
+    def test_the_same_line_added_is_not_guard_removal(self, line):
+        assert match_class(line, kind="+") != "guard-removal"
+
+    def test_a_removed_log_line_keeps_its_own_class(self):
+        assert match_class('console.log("x")', kind="-") == "console-log"
+
+    def test_default_kind_is_an_addition(self):
+        assert match_class("const MAX_TOOL_NAME_LENGTH = 128;") is None
+
+    def test_the_digest_renders_removals_with_their_minus_marker(self):
+        digest = _digest(_modified_file(
+            "src/tools/registry.ts",
+            ['import { z } from "zod";'],
+            ["const MAX_TOOL_NAME_LENGTH = 128;", "function isSupported(tool) {"],
+            ["  return raw.slice();"],
+        ))
+        assert "-2| const MAX_TOOL_NAME_LENGTH = 128;" in digest
+        assert "-3| function isSupported(tool) {" in digest
+
+    def test_guard_removal_survives_a_tight_per_file_cap(self):
+        noise = [f"console.log('noise {i}');" for i in range(MAX_LINES_PER_FILE + 5)]
+        diff = _modified_file(
+            "src/big.ts",
+            ["const a = 1;"],
+            [*noise, "const MAX_BODY_BYTES = 1024;"],
+            [f"const filler{i} = {i};" for i in range(FULL_CONTENT_MAX_ADDED_LINES + 5)],
+        )
+        digest = _digest(diff)
+        assert "MAX_BODY_BYTES" in digest

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -452,3 +452,64 @@ def test_finding_dataclass_shape():
     )
     assert f.file == "a.py"
     assert f.drop_reason is None
+
+
+class TestCopyHeaders:
+    """``copy from``/``copy to`` extended headers mark a copy, not a rename."""
+
+    def test_parses_git_copy_headers(self):
+        diff = (
+            "diff --git a/pkg/a.json b/pkg/b.json\n"
+            "similarity index 53%\n"
+            "copy from a/pkg/a.json\n"
+            "copy to b/pkg/b.json\n"
+        )
+        files = parse_unified_diff(diff)
+        assert len(files) == 1
+        f = files[0]
+        assert f.status == "copied"
+        assert f.old_path == "pkg/a.json"
+        assert f.new_path == "pkg/b.json"
+        assert f.path == "pkg/b.json"
+
+    def test_parses_bitbucket_server_copy_headers(self):
+        diff = (
+            "diff --git src://pkg/a.json dst://pkg/b.json\n"
+            "dissimilarity index 12%\n"
+            "copy from src://pkg/a.json\n"
+            "copy to dst://pkg/b.json\n"
+        )
+        files = parse_unified_diff(diff)
+        assert len(files) == 1
+        f = files[0]
+        assert f.status == "copied"
+        assert f.old_path == "pkg/a.json"
+        assert f.new_path == "pkg/b.json"
+
+    def test_similarity_index_line_is_consumed(self):
+        diff = (
+            "diff --git a/pkg/a.json b/pkg/b.json\n"
+            "similarity index 53%\n"
+            "copy from a/pkg/a.json\n"
+            "copy to b/pkg/b.json\n"
+            "@@ -1,1 +1,1 @@\n"
+            "-old\n"
+            "+new\n"
+        )
+        files = parse_unified_diff(diff)
+        assert len(files) == 1
+        assert len(files[0].hunks) == 1
+        assert [ln.text for ln in files[0].hunks[0].lines] == ["old", "new"]
+
+    def test_copied_status_renders_copy_headers(self):
+        from prxref.reviewer import _render_file
+
+        diff = (
+            "diff --git a/pkg/a.json b/pkg/b.json\n"
+            "copy from a/pkg/a.json\n"
+            "copy to b/pkg/b.json\n"
+        )
+        rendered = _render_file(parse_unified_diff(diff)[0])
+        assert "copy from pkg/a.json" in rendered
+        assert "copy to pkg/b.json" in rendered
+        assert "rename from" not in rendered

--- a/uv.lock
+++ b/uv.lock
@@ -1153,7 +1153,7 @@ wheels = [
 
 [[package]]
 name = "prxref"
-version = "0.11.1"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
Version bump to 0.12.0 bundling the eleven fix branches for the 2026-09-03/04 real-PR audit (inbox issues 01–10 and 12, filed in `docs/issues/inbox-2026-09-04/`, not on GitHub). Each issue has an eval under `tests/test_issue_NN_*.py` that fails on 0.11.1 and passes here (42 failing on main → 80 passing). 1578 passed on 3.12 locally, ruff clean, `uv build` ok. Also backfills the 0.11.1 CHANGELOG section its release commit never cut, and the tag link references.

Headline changes: workers see library versions and same-file symbol definitions; new deterministic gates (hedge, manifest claim, removal claim, settled-thread, containment note, release-shaped PR); the systemic sweep sees deletions and the PR's own discussion; stable finding order with a `sampling` record; a run-lifetime cache for a model the provider has taken away; `--format json`.

Tag v0.12.0 on the merge commit after merge publishes sdist+wheel+PyPI.

🤖 Authored with Claude Code — Fable 5.1 via Claude Code (session 68f0a704)
