### PR TITLE
release: 0.12.1 — settled-thread gate crash on general comments (#54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- **The settled-thread gate no longer crashes on a general PR comment** (#54).
+  A thread without a path — any unanchored comment, near-universal on
+  Bitbucket Server — raised `AttributeError` inside
+  `apply_settled_thread_suppression` on 0.12.0, and because the pass chain is
+  not guarded the whole review was lost (`review failed: ...`, nothing
+  posted). Such a thread is now skipped by that gate; same-path suppression
+  is unchanged.
+
 ## [0.12.0] — 2026-09-04
 
 The context release. A real-PR audit of 0.11.0/0.11.1 — two review passes over

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.12.1] — 2026-09-04
+
 ### Fixed
 
 - **The settled-thread gate no longer crashes on a general PR comment** (#54).
@@ -755,7 +757,9 @@ Development baseline. Never published to PyPI and never tagged; superseded by
 - Diff content is sent to whichever OpenAI-compatible endpoint you configure.
 - Requires Python 3.12+. Tested on 3.12 and 3.13.
 
-[Unreleased]: https://github.com/sblattj/prxref/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/sblattj/prxref/compare/v0.12.1...HEAD
+[0.12.1]: https://github.com/sblattj/prxref/releases/tag/v0.12.1
+[0.12.0]: https://github.com/sblattj/prxref/releases/tag/v0.12.0
 [0.11.1]: https://github.com/sblattj/prxref/releases/tag/v0.11.1
 [0.11.0]: https://github.com/sblattj/prxref/releases/tag/v0.11.0
 [0.10.1]: https://github.com/sblattj/prxref/releases/tag/v0.10.1

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -41,7 +41,7 @@ it (noted in the table).
 | 2 | `apply_manifest_claim_check` | `package.json` only. Runs **before** line align, deliberately, so it reads the model's raw anchor. |
 | 3 | `apply_line_align` | Re-anchors a cited line to a real added line of that file, or demotes it to file-level. |
 | 4 | `apply_thread_dedup` | Drops a finding an existing PR thread already makes (path + line window + shared distinctive tokens). |
-| 5 | `apply_settled_thread_suppression` | Drops a finding that re-litigates a subject a thread already argued out. Line-independent by design. |
+| 5 | `apply_settled_thread_suppression` | Drops a finding that re-litigates a subject a thread already argued out. Line-independent by design. A thread with no path — a general, unanchored PR comment — is ignored by this pass, since it cannot be "same path" as any finding. |
 | 6 | `apply_severity_consistency` | Rewrites only: findings sharing a normalized title are all raised to the group's maximum severity. |
 | 7 | `apply_removal_claim_check` | Drops a claim that a **named** path was removed when the post-image still carries it. The removal verb must **govern** that path (`removed src/app.py`, `src/app.py was removed`); a bare "removed" elsewhere in the body is not a removal claim. |
 | 8 | `apply_hedge_gate` | Drops a finding whose own text conditions the defect on a precondition never established from the diff. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prxref"
-version = "0.12.0"
+version = "0.12.1"
 description = "Fast automated AI code review for Bitbucket, GitLab, and GitHub"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/prxref/__init__.py
+++ b/src/prxref/__init__.py
@@ -1,3 +1,3 @@
 """prxref — fast automated AI code review for Bitbucket, GitLab, and GitHub."""
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"

--- a/src/prxref/quality.py
+++ b/src/prxref/quality.py
@@ -876,9 +876,11 @@ def apply_settled_thread_suppression(
     the finding's title+body and the thread's snippet.
 
     ``resolved`` does not gate it: a resolved thread is still a decision the
-    reviewers made with more context than the review has. Order-preserving,
-    pure, and already-dropped findings pass through untouched so the reason
-    an earlier pass gave survives.
+    reviewers made with more context than the review has. A thread with no
+    path — a general, unanchored PR comment, near-universal on Bitbucket
+    Server — cannot be "same path" as any finding and is skipped rather than
+    compared. Order-preserving, pure, and already-dropped findings pass
+    through untouched so the reason an earlier pass gave survives.
     """
     if not threads:
         return list(findings)
@@ -892,6 +894,8 @@ def apply_settled_thread_suppression(
         author = ""
         if finding_tokens:
             for t in threads:
+                if t.path is None:
+                    continue
                 if _normalised_path(t.path) != _normalised_path(f.file):
                     continue
                 body_tokens = _tokens(t.body_snippet or "")

--- a/tests/test_issue_13_settled_thread_none_path.py
+++ b/tests/test_issue_13_settled_thread_none_path.py
@@ -1,0 +1,137 @@
+"""Issue 13: the settled-thread gate crashes on a path-less general PR comment.
+
+``apply_settled_thread_suppression`` calls ``_normalised_path(t.path)`` for
+every thread, and ``_normalised_path`` does ``path.startswith("./")`` — a
+plain ``str`` method. ``Thread.path`` is typed ``str | None`` and IS None for
+any general, unanchored PR comment (near-universal on Bitbucket Server), so
+the pass raises ``AttributeError: 'NoneType' object has no attribute
+'startswith'``. Because the quality-pass chain in ``orchestrate_review`` is
+not wrapped, that exception escapes the whole review: nothing gets posted.
+
+Frozen contract under test: a thread with ``path=None`` is skipped by this
+pass (the finding survives untouched), while same-path suppression with
+enough shared tokens is unaffected.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from test_orchestrator import (  # noqa: E402  (shared fixtures, read not guessed)
+    REF,
+    FakeForge,
+    FakeLLM,
+    _added_file_diff,
+    _contract_review_chunk,
+    _contract_review_systemic,
+)
+
+from prxref import orchestrator  # noqa: E402
+from prxref.forges.base import Thread  # noqa: E402
+from prxref.orchestrator import orchestrate_review  # noqa: E402
+from prxref.quality import apply_settled_thread_suppression  # noqa: E402
+from prxref.triage import Finding  # noqa: E402
+
+# Shared title/body across every case below, and a thread snippet chosen so
+# the shared-token count is exactly the SETTLED_MIN_SHARED_TOKENS floor (4:
+# retry, wrapper, transient, failures) when the path matches — so case (b)
+# is a genuine control on the SAME subject, not an easier one.
+FINDING_TITLE = "retry wrapper removed"
+FINDING_BODY = "transient failures now surface to callers"
+THREAD_SNIPPET = "please keep the retry wrapper for transient failures here"
+FINDING_FILE = "src/app/db.py"
+
+
+def _finding() -> Finding:
+    return Finding(
+        file=FINDING_FILE, line=3, severity="warning", confidence=0.9,
+        title=FINDING_TITLE, body=FINDING_BODY,
+    )
+
+
+@pytest.fixture
+def contract_stubs(monkeypatch):
+    """Chunk + sweep pinned to the orchestrator contract (no real reviewer)."""
+    monkeypatch.setattr(orchestrator.reviewer, "review_chunk", _contract_review_chunk)
+    monkeypatch.setattr(
+        orchestrator.reviewer, "review_systemic", _contract_review_systemic,
+    )
+
+
+class TestA_DirectReproduction:
+    def test_pathless_thread_leaves_the_finding_unchanged(self):
+        """A general PR comment (Thread.path is None) cannot be "same path"
+        as any finding, so it must not crash and must not suppress."""
+        t = Thread(
+            path=None, line=0, resolved=False, author="reviewer",
+            body_snippet=THREAD_SNIPPET,
+        )
+        f = _finding()
+
+        result = apply_settled_thread_suppression([f], [t])
+
+        assert result == [f]
+        assert result[0].drop_reason is None
+
+
+class TestB_ControlSamePathStillSettles:
+    def test_same_path_and_shared_tokens_still_drops(self):
+        t = Thread(
+            path=FINDING_FILE, line=0, resolved=False, author="reviewer",
+            body_snippet=THREAD_SNIPPET,
+        )
+        f = _finding()
+
+        result = apply_settled_thread_suppression([f], [t])
+
+        assert len(result) == 1
+        assert result[0].drop_reason == "settled in thread: reviewer"
+
+
+class TestC_EndToEndThroughOrchestrateReview:
+    def test_pathless_general_comment_does_not_lose_the_review(self, contract_stubs):
+        general_comment = Thread(
+            path=None, line=0, resolved=False, author="reviewer",
+            body_snippet=THREAD_SNIPPET,
+        )
+        forge = FakeForge(
+            diff=_added_file_diff(FINDING_FILE, 20),
+            threads=[general_comment],
+        )
+        finding_payload = {
+            "file": FINDING_FILE, "line": 3, "severity": "warning",
+            "confidence": 0.9, "title": FINDING_TITLE, "body": FINDING_BODY,
+        }
+        llm = FakeLLM(json.dumps({"findings": [finding_payload]}))
+
+        res = orchestrate_review(forge, REF, llm)
+
+        assert res["verdict"] != "Error", (
+            f"review failed instead of completing: {res}"
+        )
+        assert FINDING_TITLE in {f.title for f in res["findings_active"]}, (
+            f"finding missing from findings_active: {res['findings_active']}"
+        )
+        assert res["posted"] is True
+        assert len(forge.summaries) == 1
+
+
+class TestControlUnrelatedPathStillActive:
+    """A path-less thread on an unrelated subject must not accidentally
+    suppress either — same guard, different shared-token shape."""
+
+    def test_pathless_thread_with_no_shared_tokens_leaves_finding_active(self):
+        t = Thread(
+            path=None, line=0, resolved=False, author="reviewer",
+            body_snippet="Bumping the cache eviction interval before release.",
+        )
+        f = _finding()
+
+        result = apply_settled_thread_suppression([f], [t])
+
+        assert result[0].drop_reason is None

--- a/uv.lock
+++ b/uv.lock
@@ -1153,7 +1153,7 @@ wheels = [
 
 [[package]]
 name = "prxref"
-version = "0.12.0"
+version = "0.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
Patch release over 0.12.0 fixing #54: the new settled-thread gate called `startswith` on `Thread.path`, which is `None` for any general (unanchored) PR comment, near-universal on Bitbucket Server. The exception escaped the unguarded pass chain, so the CLI printed `review failed: ...`, exited 0, and posted nothing — the whole review was lost on any PR with a general comment and at least one finding. Reported by the 2026-09-04 audit client against its PR 48 after upgrading.

A path-less thread is now skipped by that gate (it cannot be "same path" as any finding); same-path suppression is unchanged. Eval `tests/test_issue_13_settled_thread_none_path.py` fails on 0.12.0 and passes here.

Tag v0.12.1 on the merge commit after merge publishes sdist+wheel+PyPI.

🤖 Authored with Claude Code — Fable 5.1 via Claude Code (session 68f0a704)
